### PR TITLE
(#70) feed existing tariffs to account screen to test if it breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ This README will be updated with more technical details when the app is close to
 <br /><br />
 <hr/>
 <br /><br />
+
+#### Current limitations
+
+As explained above, these are the know issues to be sorted out in the future, since they are not affecting me:
+
+* Display tariff with dual rates (day unit rate and night unit rates)
+* 
+
 ## Some draft technical details
 
 * `/composeApp` is for code that will be shared across your Compose Multiplatform applications.

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -32,7 +32,7 @@
     <string name="account_version_api_disclaimer">OctoMeter Version %1$s (Build %2$d)\n%3$s\n\nThe APIs are provided by Octopus Energy Ltd. Usage subject to their terms of service.</string>
 
     <string name="account_error_load_account">Unable to retrieve your account details.</string>
-    <string name="account_error_load_tariff">Unable to retrieve the tariff details.</string>
+    <string name="account_error_load_tariff">Unable to retrieve your tariff.</string>
     <string name="account_error_account_empty">Unable to retrieve your account details. Try again?</string>
 
     <string name="account_number">Account %1$s</string>
@@ -42,7 +42,7 @@
     <string name="account_update_api_key">Update API Key</string>
 
     <string name="account_mpan">MPAN: %1$s</string>
-    <string name="account_error_no_tariff">Unable to retrieve your tariff.</string>
+    <string name="account_error_null_tariff">Unable to retrieve the details for your tariff %1$s.</string>
     <string name="account_tariff_period">From %1$s to %2$s</string>
     <string name="account_tariff_period_no_end_date">From %1$s</string>
     <string name="account_tariff_unit_rate">Unit Rate\n(p/kWh)</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -43,9 +43,9 @@
 
     <string name="account_mpan">MPAN: %1$s</string>
     <string name="account_error_null_tariff">Unable to retrieve the details for your tariff %1$s.</string>
-    <string name="account_tariff_period">From %1$s to %2$s</string>
-    <string name="account_tariff_period_no_end_date">From %1$s</string>
-    <string name="account_tariff_unit_rate">Unit Rate\n(p/kWh)</string>
+    <string name="account_tariff_start_date">Tariff starts on %1$s</string>
+    <string name="account_tariff_end_date">Tariff ends on %1$s</string>
+    <string name="account_tariff_unit_rate">Standard Unit Rate\n(p/kWh)</string>
     <string name="account_tariff_standing_charge">Standing Charge\n(p/day)</string>
     <string name="account_meter_serial">Serial: %1$s</string>
     <string name="account_meter_selected">SELECTED</string>

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/TariffMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/TariffMapper.kt
@@ -8,6 +8,7 @@
 package com.rwmobi.kunigami.data.repository.mapper
 
 import com.rwmobi.kunigami.data.source.network.dto.SingleProductApiResponse
+import com.rwmobi.kunigami.domain.exceptions.TariffNotFoundException
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.domain.model.Tariff
 
@@ -30,7 +31,7 @@ fun SingleProductApiResponse.toTariff(tariffCode: String): Tariff {
         throw IllegalArgumentException("$tariffCode not found in product $code")
     }
 
-    val rates = tariffDetails.varying ?: tariffDetails.directDebitMonthly ?: throw IllegalArgumentException("rate not found for tariff $tariffCode")
+    val rates = tariffDetails.varying ?: tariffDetails.directDebitMonthly ?: throw TariffNotFoundException(tariffCode)
 
     return Tariff(
         code = code,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/ElectricityTariffDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/ElectricityTariffDto.kt
@@ -24,5 +24,10 @@ data class ElectricityTariffDto(
     @SerialName("exit_fees_type") val exitFeesType: String,
     @SerialName("standard_unit_rate_exc_vat") val standardUnitRateExcVat: Double? = null,
     @SerialName("standard_unit_rate_inc_vat") val standardUnitRateIncVat: Double? = null,
+    // TODO: duel rates required different handling
+//    @SerialName("day_unit_rate_exc_vat") val dayUnitRateExcVat: Double? = null,
+//    @SerialName("day_unit_rate_inc_vat") val dayUnitRateIncVat: Double? = null,
+//    @SerialName("night_unit_rate_exc_vat") val nightUnitRateExcVat: Double? = null,
+//    @SerialName("night_unit_rate_inc_vat") val nightUnitRateIncVat: Double? = null,
     @SerialName("links") val links: List<LinkDto>,
 )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/exceptions/TariffNotFoundException.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/exceptions/TariffNotFoundException.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.kunigami.domain.exceptions
+
+class TariffNotFoundException(tariffCode: String, message: String = "rate not found for tariff $tariffCode") : Throwable(message)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/ElectricityMeterPointCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/ElectricityMeterPointCard.kt
@@ -29,7 +29,7 @@ import com.rwmobi.kunigami.ui.components.IconTextButton
 import com.rwmobi.kunigami.ui.destinations.account.AccountScreenLayout
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
-import kunigami.composeapp.generated.resources.account_error_no_tariff
+import kunigami.composeapp.generated.resources.account_error_null_tariff
 import kunigami.composeapp.generated.resources.account_mpan
 import kunigami.composeapp.generated.resources.reload
 import kunigami.composeapp.generated.resources.retry
@@ -77,7 +77,7 @@ internal fun ElectricityMeterPointCard(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.spacedBy(space = dimension.grid_2),
                 ) {
-                    Text(text = stringResource(resource = Res.string.account_error_no_tariff))
+                    Text(text = stringResource(resource = Res.string.account_error_null_tariff, meterPoint.currentAgreement.tariffCode))
 
                     IconTextButton(
                         modifier = Modifier.align(alignment = Alignment.CenterHorizontally),

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/TariffLayoutCompact.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/TariffLayoutCompact.kt
@@ -30,9 +30,9 @@ import com.rwmobi.kunigami.domain.model.Agreement
 import com.rwmobi.kunigami.domain.model.Tariff
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
-import kunigami.composeapp.generated.resources.account_tariff_period
-import kunigami.composeapp.generated.resources.account_tariff_period_no_end_date
+import kunigami.composeapp.generated.resources.account_tariff_end_date
 import kunigami.composeapp.generated.resources.account_tariff_standing_charge
+import kunigami.composeapp.generated.resources.account_tariff_start_date
 import kunigami.composeapp.generated.resources.account_tariff_unit_rate
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
@@ -67,12 +67,11 @@ internal fun TariffLayoutCompact(
 
         val tariffPeriod = agreement.validTo?.let {
             stringResource(
-                resource = Res.string.account_tariff_period,
-                agreement.validFrom.formatDate(),
+                resource = Res.string.account_tariff_end_date,
                 it.formatDate(),
             )
         } ?: stringResource(
-            resource = Res.string.account_tariff_period_no_end_date,
+            resource = Res.string.account_tariff_start_date,
             agreement.validFrom.formatDate(),
         )
 

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/TariffLayoutWide.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/TariffLayoutWide.kt
@@ -28,9 +28,9 @@ import com.rwmobi.kunigami.domain.model.Agreement
 import com.rwmobi.kunigami.domain.model.Tariff
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
-import kunigami.composeapp.generated.resources.account_tariff_period
-import kunigami.composeapp.generated.resources.account_tariff_period_no_end_date
+import kunigami.composeapp.generated.resources.account_tariff_end_date
 import kunigami.composeapp.generated.resources.account_tariff_standing_charge
+import kunigami.composeapp.generated.resources.account_tariff_start_date
 import kunigami.composeapp.generated.resources.account_tariff_unit_rate
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
@@ -70,17 +70,16 @@ internal fun TariffLayoutWide(
 
             val tariffPeriod = agreement.validTo?.let {
                 stringResource(
-                    resource = Res.string.account_tariff_period,
-                    agreement.validFrom.formatDate(),
+                    resource = Res.string.account_tariff_end_date,
                     it.formatDate(),
                 )
             } ?: stringResource(
-                resource = Res.string.account_tariff_period_no_end_date,
+                resource = Res.string.account_tariff_start_date,
                 agreement.validFrom.formatDate(),
             )
 
             Text(
-                style = MaterialTheme.typography.bodyMedium,
+                style = MaterialTheme.typography.bodySmall,
                 text = tariffPeriod,
             )
         }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AccountViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AccountViewModel.kt
@@ -13,7 +13,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import com.rwmobi.kunigami.domain.exceptions.IncompleteCredentialsException
-import com.rwmobi.kunigami.domain.exceptions.TariffNotFoundException
 import com.rwmobi.kunigami.domain.repository.UserPreferencesRepository
 import com.rwmobi.kunigami.domain.usecase.GetTariffRatesUseCase
 import com.rwmobi.kunigami.domain.usecase.GetUserAccountUseCase
@@ -112,7 +111,6 @@ class AccountViewModel(
 
             tariffRates.fold(
                 onSuccess = { tariff ->
-
                     _uiState.update { currentUiState ->
                         currentUiState.copy(
                             isDemoMode = false,
@@ -126,18 +124,14 @@ class AccountViewModel(
                 onFailure = { throwable ->
                     Logger.e(getString(resource = Res.string.account_error_load_tariff), throwable = throwable, tag = "AccountViewModel")
 
-                    if (throwable is TariffNotFoundException) {
-                        _uiState.update { currentUiState ->
-                            currentUiState.copy(
-                                isDemoMode = false,
-                                tariff = null,
-                                selectedMpan = selectedMpan,
-                                selectedMeterSerialNumber = selectedMeterSerialNumber,
-                                isLoading = false,
-                            )
-                        }
-                    } else {
-                        updateUIForError(message = throwable.message ?: getString(resource = Res.string.account_error_load_tariff))
+                    _uiState.update { currentUiState ->
+                        currentUiState.copy(
+                            isDemoMode = false,
+                            tariff = null,
+                            selectedMpan = selectedMpan,
+                            selectedMeterSerialNumber = selectedMeterSerialNumber,
+                            isLoading = false,
+                        )
                     }
                 },
             )


### PR DESCRIPTION
This is to improve the handing when there is a tariff rate we cannot parse, no matter it is because of dual rates, or simply unavailable.

We now should only show the error within the MPAN card rather than stopping the refresh which can made the account screen blank. 