### PR TITLE
Fix iOS orientation change bug

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/App.kt
@@ -47,7 +47,6 @@ import com.rwmobi.kunigami.ui.components.AppNavigationRail
 import com.rwmobi.kunigami.ui.navigation.AppNavigationHost
 import com.rwmobi.kunigami.ui.navigation.AppNavigationItem
 import com.rwmobi.kunigami.ui.theme.AppTheme
-import com.rwmobi.kunigami.ui.utils.getScreenSizeInfo
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.ok
 import org.jetbrains.compose.resources.stringResource
@@ -85,7 +84,6 @@ fun App(
     androidStatusBarModifier: @Composable ((isDarkTheme: Boolean) -> Unit)? = null,
 ) {
     val windowSizeClass = calculateWindowSizeClass()
-    val screenSizeInfo = getScreenSizeInfo()
     val lastDoubleTappedNavItem = remember { mutableStateOf<AppNavigationItem?>(null) }
     val navController = rememberNavController()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -163,7 +161,6 @@ fun App(
                         navController = navController,
                         lastDoubleTappedNavItem = lastDoubleTappedNavItem.value,
                         windowSizeClass = windowSizeClass,
-                        screenSizeInfo = screenSizeInfo,
                         onShowSnackbar = { errorMessageText ->
                             snackbarHostState.showSnackbar(
                                 message = errorMessageText,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/navigation/AppNavigationHost.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/navigation/AppNavigationHost.kt
@@ -24,8 +24,8 @@ import com.rwmobi.kunigami.ui.destinations.tariffs.TariffsScreen
 import com.rwmobi.kunigami.ui.destinations.tariffs.TariffsUIEvent
 import com.rwmobi.kunigami.ui.destinations.usage.UsageScreen
 import com.rwmobi.kunigami.ui.destinations.usage.UsageUIEvent
-import com.rwmobi.kunigami.ui.model.ScreenSizeInfo
 import com.rwmobi.kunigami.ui.utils.collectAsStateMultiplatform
+import com.rwmobi.kunigami.ui.utils.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.viewmodels.AccountViewModel
 import com.rwmobi.kunigami.ui.viewmodels.AgileViewModel
 import com.rwmobi.kunigami.ui.viewmodels.TariffsViewModel
@@ -37,7 +37,6 @@ fun AppNavigationHost(
     modifier: Modifier = Modifier,
     navController: NavHostController,
     windowSizeClass: WindowSizeClass,
-    screenSizeInfo: ScreenSizeInfo,
     lastDoubleTappedNavItem: AppNavigationItem?,
     onShowSnackbar: suspend (String) -> Unit,
     onScrolledToTop: (AppNavigationItem) -> Unit,
@@ -50,6 +49,9 @@ fun AppNavigationHost(
         composable(route = AppNavigationItem.USAGE.name) {
             val viewModel: UsageViewModel = viewModel { getKoin().get() }
             val uiState by viewModel.uiState.collectAsStateMultiplatform()
+
+            // workaround: Issue with iOS we have to do it here
+            val screenSizeInfo = getScreenSizeInfo()
             viewModel.notifyScreenSizeChanged(screenSizeInfo = screenSizeInfo)
 
             UsageScreen(
@@ -66,6 +68,9 @@ fun AppNavigationHost(
         composable(route = AppNavigationItem.AGILE.name) {
             val viewModel: AgileViewModel = viewModel { getKoin().get() }
             val uiState by viewModel.uiState.collectAsStateMultiplatform()
+
+            // workaround: Issue with iOS we have to do it here
+            val screenSizeInfo = getScreenSizeInfo()
             viewModel.notifyScreenSizeChanged(screenSizeInfo = screenSizeInfo)
 
             AgileScreen(


### PR DESCRIPTION
getScreenSizeInfo: move to calculate screen size from App to NavHost due to iOS recomposition differences

Only on iOS the updated screenSizeInfo object is not being passed to NavHost from AppNavigationHost. 

As a workaround we move to call getScreenSizeInfo within NavHost and it worled.