### PR TITLE
Gradle: merge kotlin toml versions - officially use 2.0 now

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,6 @@ junitVersion = "1.1.5"
 espressoCore = "3.5.1"
 uiautomator = "2.3.0"
 benchmarkMacroJunit4 = "1.2.4"
-kotlinVersion = "1.9.0"
 baselineprofile = "1.2.4"
 profileinstaller = "1.3.1"
 
@@ -104,5 +103,5 @@ serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref 
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 buildConfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
 android-test = { id = "com.android.test", version.ref = "agp" }
-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinVersion" }
+jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprofile" }


### PR DESCRIPTION
There was a mistake when upgrading Kotlin last time that we did not actually moved to Kotlni 2.0