### PR TITLE
(#101) Show MPAN on usage screen

### DIFF
--- a/composeApp/src/commonMain/composeResources/drawable/circle_check.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/circle_check.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="15"
+    android:viewportHeight="15">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M4,7.5L7,10l4,-5m-3.5,9.5a7,7 0,1 1,0 -14a7,7 0,0 1,0 14Z"
+        android:strokeWidth="1"
+        android:strokeColor="#000000" />
+</vector>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="retry">Retry</string>
     <string name="update">Update</string>
     <string name="kwh">kWh</string>
+    <string name="p_kwh">p/kWh</string>
     <string name="unit_kwh">%1$s kWh</string>
     <string name="unit_pound">£%1$s</string>
     <string name="standing_charge">Standing Charge</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -19,6 +19,11 @@
     <string name="kwh">kWh</string>
     <string name="unit_kwh">%1$s kWh</string>
     <string name="unit_pound">£%1$s</string>
+    <string name="standing_charge">Standing Charge</string>
+    <string name="standard_unit_rate">Standard Unit Rate</string>
+    <string name="unit_p_day">%1$d p/day</string>
+    <string name="unit_p_kwh">%1$d p/kWh</string>
+
     <string name="selected">Selected</string>
     <string name="loading">Loading...</string>
     <string name="provide_api_key">Provide API Key</string>
@@ -34,7 +39,7 @@
     <string name="grouping_label_month_weeks">Week Starting On</string>
     <string name="usage_chart_tooltip_spot_kwh">%1$s\n%2$s kWh</string>
     <string name="usage_chart_tooltip_range_kwh">%1$s - %2$s\n%3$s kWh</string>
-    <string name="usage_current_tariff">Your active tariff</string>
+    <string name="usage_current_tariff">Active tariff</string>
     <string name="usage_insights">Insights</string>
     <plurals name="usage_insights_consumption">
         <item quantity="one">Consumed %1$s kWh in one day</item>
@@ -49,7 +54,6 @@
     <string name="agile_about_tariff">About this tariff</string>
     <string name="agile_unit_rate_details">Published Unit Rates</string>
     <string name="agile_vat_unit_rate">VAT Unit Rate (p/kWh)</string>
-    <string name="agile_unit_rate">p/kWh</string>
     <string name="agile_expires_in">Expires in %1$s:%2$s</string>
     <string name="agile_different_tariff">You are on a different tariff</string>
     <string name="agile_product_code_retail_region">%1$s (Region %2$s)</string>

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TariffSummaryCardAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TariffSummaryCardAdaptive.kt
@@ -50,6 +50,7 @@ internal fun TariffSummaryCardAdaptive(
     modifier: Modifier = Modifier,
     layoutType: WindowWidthSizeClass = WindowWidthSizeClass.Compact,
     heading: String,
+    headingTextAlign: TextAlign = TextAlign.Start,
     tariff: Tariff,
 ) {
     val dimension = LocalDensity.current.getDimension()
@@ -66,6 +67,7 @@ internal fun TariffSummaryCardAdaptive(
             TariffSummaryCardLinear(
                 modifier = cardModifier,
                 heading = heading,
+                headingTextAlign = headingTextAlign,
                 tariff = tariff,
             )
         }
@@ -74,6 +76,7 @@ internal fun TariffSummaryCardAdaptive(
             TariffSummaryCardLinear(
                 modifier = cardModifier,
                 heading = heading,
+                headingTextAlign = headingTextAlign,
                 tariff = tariff,
             )
         }
@@ -82,6 +85,7 @@ internal fun TariffSummaryCardAdaptive(
             TariffSummaryCardThreeColumns(
                 modifier = cardModifier,
                 heading = heading,
+                headingTextAlign = headingTextAlign,
                 tariff = tariff,
             )
         }
@@ -92,6 +96,7 @@ internal fun TariffSummaryCardAdaptive(
 private fun TariffSummaryCardLinear(
     modifier: Modifier = Modifier,
     heading: String,
+    headingTextAlign: TextAlign,
     tariff: Tariff,
 ) {
     val dimension = LocalDensity.current.getDimension()
@@ -103,6 +108,7 @@ private fun TariffSummaryCardLinear(
             modifier = Modifier.fillMaxWidth(),
             style = MaterialTheme.typography.labelMedium,
             fontWeight = FontWeight.Bold,
+            textAlign = headingTextAlign,
             color = MaterialTheme.colorScheme.onSurface,
             text = heading,
         )
@@ -175,6 +181,7 @@ private fun TariffSummaryCardLinear(
 private fun TariffSummaryCardTwoColumns(
     modifier: Modifier = Modifier,
     heading: String,
+    headingTextAlign: TextAlign,
     tariff: Tariff,
 ) {
     val dimension = LocalDensity.current.getDimension()
@@ -186,6 +193,7 @@ private fun TariffSummaryCardTwoColumns(
             modifier = Modifier.fillMaxWidth(),
             style = MaterialTheme.typography.labelMedium,
             fontWeight = FontWeight.Bold,
+            textAlign = headingTextAlign,
             color = MaterialTheme.colorScheme.onSurface,
             text = heading,
         )
@@ -248,6 +256,7 @@ private fun TariffSummaryCardTwoColumns(
 private fun TariffSummaryCardThreeColumns(
     modifier: Modifier = Modifier,
     heading: String,
+    headingTextAlign: TextAlign,
     tariff: Tariff,
 ) {
     val dimension = LocalDensity.current.getDimension()
@@ -259,6 +268,7 @@ private fun TariffSummaryCardThreeColumns(
             modifier = Modifier.fillMaxWidth(),
             style = MaterialTheme.typography.labelMedium,
             fontWeight = FontWeight.Bold,
+            textAlign = headingTextAlign,
             color = MaterialTheme.colorScheme.onSurface,
             text = heading,
         )
@@ -330,6 +340,7 @@ private fun Preview() {
                 TariffSummaryCardAdaptive(
                     modifier = Modifier.fillMaxWidth(),
                     heading = stringResource(resource = Res.string.agile_different_tariff).uppercase(),
+                    headingTextAlign = TextAlign.Center,
                     tariff = TariffSamples.agileFlex221125,
                     layoutType = WindowWidthSizeClass.Compact,
                 )
@@ -337,6 +348,7 @@ private fun Preview() {
                 TariffSummaryCardAdaptive(
                     modifier = Modifier.fillMaxWidth(),
                     heading = stringResource(resource = Res.string.agile_different_tariff).uppercase(),
+                    headingTextAlign = TextAlign.Center,
                     tariff = TariffSamples.agileFlex221125,
                     layoutType = WindowWidthSizeClass.Medium,
                 )
@@ -344,6 +356,7 @@ private fun Preview() {
                 TariffSummaryCardAdaptive(
                     modifier = Modifier.fillMaxWidth(),
                     heading = stringResource(resource = Res.string.agile_different_tariff).uppercase(),
+                    headingTextAlign = TextAlign.Center,
                     tariff = TariffSamples.agileFlex221125,
                     layoutType = WindowWidthSizeClass.Expanded,
                 )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TariffSummaryCardAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TariffSummaryCardAdaptive.kt
@@ -35,23 +35,22 @@ import com.rwmobi.kunigami.ui.theme.AppTheme
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.agile_different_tariff
-import kunigami.composeapp.generated.resources.agile_product_code_retail_region
 import kunigami.composeapp.generated.resources.agile_tariff_standard_unit_rate_two_lines
 import kunigami.composeapp.generated.resources.agile_tariff_standing_charge_two_lines
 import kunigami.composeapp.generated.resources.standard_unit_rate
 import kunigami.composeapp.generated.resources.standing_charge
 import kunigami.composeapp.generated.resources.unit_p_day
 import kunigami.composeapp.generated.resources.unit_p_kwh
-import kunigami.composeapp.generated.resources.unknown
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun TariffSummaryCardAdaptive(
     modifier: Modifier = Modifier,
     layoutType: WindowWidthSizeClass = WindowWidthSizeClass.Compact,
+    tariff: Tariff,
     heading: String,
     headingTextAlign: TextAlign = TextAlign.Start,
-    tariff: Tariff,
+    subheading: String? = null,
 ) {
     val dimension = LocalDensity.current.getDimension()
     val cardModifier = modifier
@@ -68,6 +67,7 @@ internal fun TariffSummaryCardAdaptive(
                 modifier = cardModifier,
                 heading = heading,
                 headingTextAlign = headingTextAlign,
+                subheading = subheading,
                 tariff = tariff,
             )
         }
@@ -77,6 +77,7 @@ internal fun TariffSummaryCardAdaptive(
                 modifier = cardModifier,
                 heading = heading,
                 headingTextAlign = headingTextAlign,
+                subheading = subheading,
                 tariff = tariff,
             )
         }
@@ -86,6 +87,7 @@ internal fun TariffSummaryCardAdaptive(
                 modifier = cardModifier,
                 heading = heading,
                 headingTextAlign = headingTextAlign,
+                subheading = subheading,
                 tariff = tariff,
             )
         }
@@ -97,6 +99,7 @@ private fun TariffSummaryCardLinear(
     modifier: Modifier = Modifier,
     heading: String,
     headingTextAlign: TextAlign,
+    subheading: String?,
     tariff: Tariff,
 ) {
     val dimension = LocalDensity.current.getDimension()
@@ -123,15 +126,16 @@ private fun TariffSummaryCardLinear(
             text = tariff.displayName,
         )
 
-        val regionCode = tariff.getRetailRegion() ?: stringResource(resource = Res.string.unknown)
-        Text(
-            modifier = Modifier.fillMaxWidth(),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurface.copy(
-                alpha = 0.68f,
-            ),
-            text = stringResource(resource = Res.string.agile_product_code_retail_region, tariff.productCode, regionCode),
-        )
+        subheading?.let {
+            Text(
+                modifier = Modifier.wrapContentWidth(),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(
+                    alpha = 0.68f,
+                ),
+                text = subheading,
+            )
+        }
 
         Spacer(modifier = Modifier.size(size = dimension.grid_2))
 
@@ -182,6 +186,7 @@ private fun TariffSummaryCardTwoColumns(
     modifier: Modifier = Modifier,
     heading: String,
     headingTextAlign: TextAlign,
+    subheading: String?,
     tariff: Tariff,
 ) {
     val dimension = LocalDensity.current.getDimension()
@@ -216,15 +221,16 @@ private fun TariffSummaryCardTwoColumns(
                     text = tariff.displayName,
                 )
 
-                val regionCode = tariff.getRetailRegion() ?: stringResource(resource = Res.string.unknown)
-                Text(
-                    modifier = Modifier.wrapContentWidth(),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurface.copy(
-                        alpha = 0.68f,
-                    ),
-                    text = stringResource(resource = Res.string.agile_product_code_retail_region, tariff.productCode, regionCode),
-                )
+                subheading?.let {
+                    Text(
+                        modifier = Modifier.wrapContentWidth(),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurface.copy(
+                            alpha = 0.68f,
+                        ),
+                        text = subheading,
+                    )
+                }
             }
 
             Column(
@@ -257,6 +263,7 @@ private fun TariffSummaryCardThreeColumns(
     modifier: Modifier = Modifier,
     heading: String,
     headingTextAlign: TextAlign,
+    subheading: String?,
     tariff: Tariff,
 ) {
     val dimension = LocalDensity.current.getDimension()
@@ -291,15 +298,16 @@ private fun TariffSummaryCardThreeColumns(
                     text = tariff.displayName,
                 )
 
-                val regionCode = tariff.getRetailRegion() ?: stringResource(resource = Res.string.unknown)
-                Text(
-                    modifier = Modifier.wrapContentWidth(),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurface.copy(
-                        alpha = 0.68f,
-                    ),
-                    text = stringResource(resource = Res.string.agile_product_code_retail_region, tariff.productCode, regionCode),
-                )
+                subheading?.let {
+                    Text(
+                        modifier = Modifier.wrapContentWidth(),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurface.copy(
+                            alpha = 0.68f,
+                        ),
+                        text = subheading,
+                    )
+                }
             }
 
             Column(
@@ -341,6 +349,7 @@ private fun Preview() {
                     modifier = Modifier.fillMaxWidth(),
                     heading = stringResource(resource = Res.string.agile_different_tariff).uppercase(),
                     headingTextAlign = TextAlign.Center,
+                    subheading = "Sample subheading",
                     tariff = TariffSamples.agileFlex221125,
                     layoutType = WindowWidthSizeClass.Compact,
                 )
@@ -349,6 +358,7 @@ private fun Preview() {
                     modifier = Modifier.fillMaxWidth(),
                     heading = stringResource(resource = Res.string.agile_different_tariff).uppercase(),
                     headingTextAlign = TextAlign.Center,
+                    subheading = "Sample subheading",
                     tariff = TariffSamples.agileFlex221125,
                     layoutType = WindowWidthSizeClass.Medium,
                 )
@@ -357,6 +367,7 @@ private fun Preview() {
                     modifier = Modifier.fillMaxWidth(),
                     heading = stringResource(resource = Res.string.agile_different_tariff).uppercase(),
                     headingTextAlign = TextAlign.Center,
+                    subheading = "Sample subheading",
                     tariff = TariffSamples.agileFlex221125,
                     layoutType = WindowWidthSizeClass.Expanded,
                 )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TariffSummaryCardAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TariffSummaryCardAdaptive.kt
@@ -36,10 +36,12 @@ import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.agile_different_tariff
 import kunigami.composeapp.generated.resources.agile_product_code_retail_region
-import kunigami.composeapp.generated.resources.agile_tariff_standard_unit_rate
 import kunigami.composeapp.generated.resources.agile_tariff_standard_unit_rate_two_lines
-import kunigami.composeapp.generated.resources.agile_tariff_standing_charge
 import kunigami.composeapp.generated.resources.agile_tariff_standing_charge_two_lines
+import kunigami.composeapp.generated.resources.standard_unit_rate
+import kunigami.composeapp.generated.resources.standing_charge
+import kunigami.composeapp.generated.resources.unit_p_day
+import kunigami.composeapp.generated.resources.unit_p_kwh
 import kunigami.composeapp.generated.resources.unknown
 import org.jetbrains.compose.resources.stringResource
 
@@ -100,7 +102,8 @@ private fun TariffSummaryCardLinear(
         Text(
             modifier = Modifier.fillMaxWidth(),
             style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
             text = heading,
         )
 
@@ -126,21 +129,45 @@ private fun TariffSummaryCardLinear(
 
         Spacer(modifier = Modifier.size(size = dimension.grid_2))
 
-        Text(
+        Row(
             modifier = Modifier.fillMaxWidth(),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            text = stringResource(resource = Res.string.agile_tariff_standing_charge, tariff.vatInclusiveStandingCharge),
-        )
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_0_5),
+        ) {
+            Text(
+                modifier = Modifier.weight(weight = 1f),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                text = stringResource(resource = Res.string.standing_charge),
+            )
+            Text(
+                modifier = Modifier.wrapContentWidth(),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                text = stringResource(resource = Res.string.unit_p_day, tariff.vatInclusiveStandingCharge),
+            )
+        }
 
         Spacer(modifier = Modifier.size(size = dimension.grid_0_5))
 
-        Text(
+        Row(
             modifier = Modifier.fillMaxWidth(),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            text = stringResource(resource = Res.string.agile_tariff_standard_unit_rate, tariff.vatInclusiveUnitRate),
-        )
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_0_5),
+        ) {
+            Text(
+                modifier = Modifier.weight(weight = 1f),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                text = stringResource(resource = Res.string.standard_unit_rate),
+            )
+            Text(
+                modifier = Modifier.wrapContentWidth(),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                text = stringResource(resource = Res.string.unit_p_kwh, tariff.vatInclusiveUnitRate),
+            )
+        }
     }
 }
 
@@ -158,7 +185,8 @@ private fun TariffSummaryCardTwoColumns(
         Text(
             modifier = Modifier.fillMaxWidth(),
             style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
             text = heading,
         )
 
@@ -230,7 +258,8 @@ private fun TariffSummaryCardThreeColumns(
         Text(
             modifier = Modifier.fillMaxWidth(),
             style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
             text = heading,
         )
 

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/TariffLayoutAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/TariffLayoutAdaptive.kt
@@ -34,6 +34,8 @@ import kunigami.composeapp.generated.resources.account_tariff_end_date
 import kunigami.composeapp.generated.resources.account_tariff_standing_charge
 import kunigami.composeapp.generated.resources.account_tariff_start_date
 import kunigami.composeapp.generated.resources.account_tariff_unit_rate
+import kunigami.composeapp.generated.resources.agile_product_code_retail_region
+import kunigami.composeapp.generated.resources.unknown
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
 
@@ -80,9 +82,10 @@ private fun TariffLayoutCompact(
             text = tariff.fullName,
         )
 
+        val regionCode = tariff.getRetailRegion() ?: stringResource(resource = Res.string.unknown)
         Text(
             style = MaterialTheme.typography.bodySmall,
-            text = tariff.productCode,
+            text = stringResource(resource = Res.string.agile_product_code_retail_region, tariff.productCode, regionCode),
         )
 
         Spacer(modifier = Modifier.height(height = dimension.grid_2))
@@ -176,9 +179,10 @@ private fun TariffLayoutWide(
                 text = tariff.fullName,
             )
 
+            val regionCode = tariff.getRetailRegion() ?: stringResource(resource = Res.string.unknown)
             Text(
                 style = MaterialTheme.typography.bodySmall,
-                text = tariff.productCode,
+                text = stringResource(resource = Res.string.agile_product_code_retail_region, tariff.productCode, regionCode),
             )
 
             Spacer(modifier = Modifier.height(height = dimension.grid_2))

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import com.rwmobi.kunigami.domain.extensions.getNextHalfHourCountdownMillis
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.domain.extensions.toLocalHourMinuteString
@@ -200,6 +201,7 @@ fun AgileScreen(
                                         top = dimension.grid_2,
                                     ),
                                 heading = stringResource(resource = Res.string.agile_different_tariff).uppercase(),
+                                headingTextAlign = TextAlign.Start,
                                 tariff = uiState.userProfile.tariff,
                                 layoutType = uiState.requestedAdaptiveLayout,
                             )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/AgileTariffCardAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/AgileTariffCardAdaptive.kt
@@ -55,7 +55,7 @@ import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.agile_expires_in
 import kunigami.composeapp.generated.resources.agile_product_code_retail_region
 import kunigami.composeapp.generated.resources.agile_tariff_standing_charge
-import kunigami.composeapp.generated.resources.unit_p_kwh
+import kunigami.composeapp.generated.resources.p_kwh
 import kunigami.composeapp.generated.resources.unknown
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -233,7 +233,7 @@ private fun AgileTariffCardCompact(
                             overflow = TextOverflow.Clip,
                             style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.Bold,
-                            text = stringResource(resource = Res.string.unit_p_kwh),
+                            text = stringResource(resource = Res.string.p_kwh),
                         )
                     }
                 }
@@ -360,7 +360,7 @@ private fun AgileTariffCardExpanded(
                             overflow = TextOverflow.Clip,
                             style = MaterialTheme.typography.bodyLarge,
                             fontWeight = FontWeight.Bold,
-                            text = stringResource(resource = Res.string.unit_p_kwh),
+                            text = stringResource(resource = Res.string.p_kwh),
                         )
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/AgileTariffCardAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/AgileTariffCardAdaptive.kt
@@ -55,7 +55,7 @@ import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.agile_expires_in
 import kunigami.composeapp.generated.resources.agile_product_code_retail_region
 import kunigami.composeapp.generated.resources.agile_tariff_standing_charge
-import kunigami.composeapp.generated.resources.agile_unit_rate
+import kunigami.composeapp.generated.resources.unit_p_kwh
 import kunigami.composeapp.generated.resources.unknown
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -233,7 +233,7 @@ private fun AgileTariffCardCompact(
                             overflow = TextOverflow.Clip,
                             style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.Bold,
-                            text = stringResource(resource = Res.string.agile_unit_rate),
+                            text = stringResource(resource = Res.string.unit_p_kwh),
                         )
                     }
                 }
@@ -360,7 +360,7 @@ private fun AgileTariffCardExpanded(
                             overflow = TextOverflow.Clip,
                             style = MaterialTheme.typography.bodyLarge,
                             fontWeight = FontWeight.Bold,
-                            text = stringResource(resource = Res.string.agile_unit_rate),
+                            text = stringResource(resource = Res.string.unit_p_kwh),
                         )
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
@@ -168,6 +168,7 @@ fun UsageScreen(
                                 layoutType = uiState.requestedAdaptiveLayout,
                                 tariff = uiState.userProfile?.tariff,
                                 insights = uiState.insights,
+                                mpan = uiState.userProfile?.selectedMpan,
                             )
                         }
 

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/PresentationStyleDropdownMenu.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/PresentationStyleDropdownMenu.kt
@@ -28,7 +28,7 @@ import com.rwmobi.kunigami.ui.model.consumption.ConsumptionPresentationStyle
 import com.rwmobi.kunigami.ui.theme.AppTheme
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
-import kunigami.composeapp.generated.resources.bolt
+import kunigami.composeapp.generated.resources.circle_check
 import kunigami.composeapp.generated.resources.selected
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -62,7 +62,7 @@ internal fun PresentationStyleDropdownMenu(
                     if (currentPresentationStyle == presentationStyle) {
                         Icon(
                             modifier = Modifier.size(size = dimension.grid_3),
-                            painter = painterResource(resource = Res.drawable.bolt),
+                            painter = painterResource(resource = Res.drawable.circle_check),
                             contentDescription = stringResource(resource = Res.string.selected),
                         )
                     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TariffProjectionsCardAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TariffProjectionsCardAdaptive.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.domain.model.Tariff
 import com.rwmobi.kunigami.ui.components.TariffSummaryCardAdaptive
@@ -85,6 +86,7 @@ private fun TariffProjectionsCardLinear(
                 modifier = Modifier.fillMaxWidth(),
                 layoutType = WindowWidthSizeClass.Compact,
                 heading = stringResource(resource = Res.string.usage_current_tariff).uppercase(),
+                headingTextAlign = TextAlign.Center,
                 tariff = it,
             )
         }
@@ -140,6 +142,7 @@ private fun TariffProjectionsCardLTwoColumns(
                 modifier = Modifier.weight(weight = 0.4f).fillMaxHeight(),
                 layoutType = WindowWidthSizeClass.Compact,
                 heading = stringResource(resource = Res.string.usage_current_tariff).uppercase(),
+                headingTextAlign = TextAlign.Center,
                 tariff = it,
             )
         }
@@ -164,6 +167,7 @@ private fun TariffProjectionsCardThreeColumns(
                 modifier = Modifier.weight(weight = 1f).fillMaxHeight(),
                 layoutType = WindowWidthSizeClass.Compact,
                 heading = stringResource(resource = Res.string.usage_current_tariff).uppercase(),
+                headingTextAlign = TextAlign.Center,
                 tariff = it,
             )
         }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TariffProjectionsCardAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TariffProjectionsCardAdaptive.kt
@@ -32,12 +32,14 @@ import com.rwmobi.kunigami.ui.previewsampledata.TariffSamples
 import com.rwmobi.kunigami.ui.theme.AppTheme
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
+import kunigami.composeapp.generated.resources.account_mpan
 import kunigami.composeapp.generated.resources.usage_current_tariff
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun TariffProjectionsCardAdaptive(
     modifier: Modifier = Modifier,
+    mpan: String?,
     tariff: Tariff?,
     insights: Insights?,
     layoutType: WindowWidthSizeClass = WindowWidthSizeClass.Compact,
@@ -46,6 +48,7 @@ internal fun TariffProjectionsCardAdaptive(
         WindowWidthSizeClass.Compact -> {
             TariffProjectionsCardLinear(
                 modifier = modifier,
+                mpan = mpan,
                 tariff = tariff,
                 insights = insights,
             )
@@ -54,6 +57,7 @@ internal fun TariffProjectionsCardAdaptive(
         WindowWidthSizeClass.Medium -> {
             TariffProjectionsCardLTwoColumns(
                 modifier = modifier,
+                mpan = mpan,
                 tariff = tariff,
                 insights = insights,
             )
@@ -62,6 +66,7 @@ internal fun TariffProjectionsCardAdaptive(
         else -> {
             TariffProjectionsCardThreeColumns(
                 modifier = modifier,
+                mpan = mpan,
                 tariff = tariff,
                 insights = insights,
             )
@@ -72,6 +77,7 @@ internal fun TariffProjectionsCardAdaptive(
 @Composable
 private fun TariffProjectionsCardLinear(
     modifier: Modifier = Modifier,
+    mpan: String?,
     tariff: Tariff?,
     insights: Insights?,
 ) {
@@ -87,6 +93,7 @@ private fun TariffProjectionsCardLinear(
                 layoutType = WindowWidthSizeClass.Compact,
                 heading = stringResource(resource = Res.string.usage_current_tariff).uppercase(),
                 headingTextAlign = TextAlign.Center,
+                subheading = mpan?.let { stringResource(resource = Res.string.account_mpan, mpan) },
                 tariff = it,
             )
         }
@@ -109,6 +116,7 @@ private fun TariffProjectionsCardLinear(
 @Composable
 private fun TariffProjectionsCardLTwoColumns(
     modifier: Modifier = Modifier,
+    mpan: String?,
     tariff: Tariff?,
     insights: Insights?,
 ) {
@@ -143,6 +151,7 @@ private fun TariffProjectionsCardLTwoColumns(
                 layoutType = WindowWidthSizeClass.Compact,
                 heading = stringResource(resource = Res.string.usage_current_tariff).uppercase(),
                 headingTextAlign = TextAlign.Center,
+                subheading = mpan?.let { stringResource(resource = Res.string.account_mpan, mpan) },
                 tariff = it,
             )
         }
@@ -152,6 +161,7 @@ private fun TariffProjectionsCardLTwoColumns(
 @Composable
 private fun TariffProjectionsCardThreeColumns(
     modifier: Modifier = Modifier,
+    mpan: String?,
     tariff: Tariff?,
     insights: Insights?,
 ) {
@@ -168,6 +178,7 @@ private fun TariffProjectionsCardThreeColumns(
                 layoutType = WindowWidthSizeClass.Compact,
                 heading = stringResource(resource = Res.string.usage_current_tariff).uppercase(),
                 headingTextAlign = TextAlign.Center,
+                subheading = mpan?.let { stringResource(resource = Res.string.account_mpan, mpan) },
                 tariff = it,
             )
         }
@@ -213,6 +224,7 @@ private fun Preview() {
                     tariff = TariffSamples.agileFlex221125,
                     insights = insights,
                     layoutType = WindowWidthSizeClass.Expanded,
+                    mpan = "1200000123456",
                 )
 
                 TariffProjectionsCardAdaptive(
@@ -220,6 +232,7 @@ private fun Preview() {
                     tariff = TariffSamples.agileFlex221125,
                     insights = insights,
                     layoutType = WindowWidthSizeClass.Medium,
+                    mpan = "1200000123456",
                 )
 
                 TariffProjectionsCardAdaptive(
@@ -227,6 +240,7 @@ private fun Preview() {
                     tariff = TariffSamples.agileFlex221125,
                     insights = insights,
                     layoutType = WindowWidthSizeClass.Compact,
+                    mpan = "1200000123456",
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModel.kt
@@ -280,7 +280,7 @@ class UsageViewModel(
         } else {
             val consumptionAggregateRounded = consumptions.sumOf { it.consumption }.roundToNearestEvenHundredth()
             val consumptionTimeSpan = consumptions.getConsumptionTimeSpan()
-            val roughCost = (consumptionTimeSpan * tariff.vatInclusiveStandingCharge) + (consumptionAggregateRounded * tariff.vatInclusiveUnitRate) / 100.0
+            val roughCost = ((consumptionTimeSpan * tariff.vatInclusiveStandingCharge) + (consumptionAggregateRounded * tariff.vatInclusiveUnitRate)) / 100.0
             val consumptionDailyAverage = (consumptions.sumOf { it.consumption } / consumptions.getConsumptionTimeSpan()).roundToNearestEvenHundredth()
             val costDailyAverage = (tariff.vatInclusiveStandingCharge + consumptionDailyAverage * tariff.vatInclusiveUnitRate) / 100.0
             val consumptionAnnualProjection = (consumptions.sumOf { it.consumption } / consumptionTimeSpan * 365.25).roundToNearestEvenHundredth()


### PR DESCRIPTION
Made a minor change to utilise the product code space for MPAN.
Agile no longer showing product code to reduce repetition.
Account screen now instead to show tariff region.
Fixed to calculate the estimated cost, too.

The Usage Screen (happy flow) should now be done.