### PR TITLE
(#112) Reduce Usage screen loading time

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.kt
@@ -41,7 +41,7 @@ fun Instant.roundDownToHour(): Instant {
 /***
  * Return the Instant with the time portion set to all 0
  */
-fun Instant.roundDownToDay(): Instant {
+fun Instant.roundToDayStart(): Instant {
     val currentZone = TimeZone.currentSystemDefault()
     val currentLocalDateTime = toLocalDateTime(timeZone = currentZone)
     return LocalDateTime(
@@ -55,7 +55,7 @@ fun Instant.roundDownToDay(): Instant {
     ).toInstant(timeZone = currentZone)
 }
 
-fun Instant.roundUpToDayEnd(): Instant {
+fun Instant.roundToDayEnd(): Instant {
     val currentZone = TimeZone.currentSystemDefault()
     val currentLocalDateTime = toLocalDateTime(timeZone = currentZone)
     return LocalDateTime(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.kt
@@ -102,6 +102,9 @@ fun Instant.toLocalWeekday(): String {
     return localDate.format(customFormat)
 }
 
+/***
+ * Returns DayOfWeekNames DayOfMonth
+ */
 fun Instant.toLocalWeekdayDay(): String {
     val localDate = this.toLocalDateTime(TimeZone.currentSystemDefault()).date
     val customFormat = LocalDate.Format {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -107,7 +107,7 @@ fun AgileScreen(
                     state = lazyListState,
                 ) {
                     if (uiState.isDemoMode == true) {
-                        item {
+                        item(key = "demoCta") {
                             DemoModeCtaAdaptive(
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -121,7 +121,7 @@ fun AgileScreen(
                     }
 
                     uiState.barChartData?.let { barChartData ->
-                        item {
+                        item(key = "chart") {
                             BoxWithConstraints(
                                 modifier = Modifier.padding(top = dimension.grid_1),
                             ) {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
@@ -119,12 +119,12 @@ fun UsageScreen(
                     }
 
                     if (uiState.consumptionGroupedCells.isEmpty()) {
-                        item {
+                        item(key = "noData") {
                             Text("no data")
                         }
                     } else {
                         uiState.barChartData?.let { barChartData ->
-                            item {
+                            item(key = "chart") {
                                 BoxWithConstraints {
                                     val constraintModifier = when (uiState.requestedChartLayout) {
                                         is RequestedChartLayout.Portrait -> {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
@@ -8,8 +8,8 @@
 package com.rwmobi.kunigami.ui.model.consumption
 
 import androidx.compose.runtime.Immutable
-import com.rwmobi.kunigami.domain.extensions.roundDownToDay
-import com.rwmobi.kunigami.domain.extensions.roundUpToDayEnd
+import com.rwmobi.kunigami.domain.extensions.roundToDayEnd
+import com.rwmobi.kunigami.domain.extensions.roundToDayStart
 import com.rwmobi.kunigami.domain.extensions.toLocalDateString
 import com.rwmobi.kunigami.domain.extensions.toLocalDay
 import com.rwmobi.kunigami.domain.extensions.toLocalDayMonth
@@ -47,8 +47,8 @@ import kotlin.time.Duration.Companion.nanoseconds
 data class ConsumptionQueryFilter(
     val presentationStyle: ConsumptionPresentationStyle = ConsumptionPresentationStyle.DAY_HALF_HOURLY,
     val pointOfReference: Instant = Clock.System.now(),
-    val requestedStart: Instant = Clock.System.now().roundDownToDay(),
-    val requestedEnd: Instant = Clock.System.now().roundUpToDayEnd(),
+    val requestedStart: Instant = Clock.System.now(),
+    val requestedEnd: Instant = Clock.System.now(),
 ) {
     companion object {
         fun calculateStartDate(pointOfReference: Instant, presentationStyle: ConsumptionPresentationStyle): Instant {
@@ -57,7 +57,7 @@ data class ConsumptionQueryFilter(
 
             return when (presentationStyle) {
                 ConsumptionPresentationStyle.DAY_HALF_HOURLY -> {
-                    pointOfReference.roundDownToDay()
+                    pointOfReference.roundToDayStart()
                 }
 
                 ConsumptionPresentationStyle.WEEK_SEVEN_DAYS -> {
@@ -100,7 +100,7 @@ data class ConsumptionQueryFilter(
 
             return when (presentationStyle) {
                 ConsumptionPresentationStyle.DAY_HALF_HOURLY -> {
-                    pointOfReference.roundUpToDayEnd()
+                    pointOfReference.roundToDayEnd()
                 }
 
                 ConsumptionPresentationStyle.WEEK_SEVEN_DAYS -> {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
@@ -143,7 +143,7 @@ data class ConsumptionQueryFilter(
      */
     fun getConsumptionPeriodString(): String {
         return when (presentationStyle) {
-            ConsumptionPresentationStyle.DAY_HALF_HOURLY -> pointOfReference.toLocalDateString()
+            ConsumptionPresentationStyle.DAY_HALF_HOURLY -> "${pointOfReference.toLocalWeekday()}, ${pointOfReference.toLocalDateString()}"
             ConsumptionPresentationStyle.WEEK_SEVEN_DAYS -> "${requestedStart.toLocalDateString().substringBefore(delimiter = ",")} - ${requestedEnd.toLocalDateString()}"
             ConsumptionPresentationStyle.MONTH_WEEKS -> pointOfReference.toLocalMonthYear()
             ConsumptionPresentationStyle.MONTH_THIRTY_DAYS -> pointOfReference.toLocalMonthYear()

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensionsKtTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensionsKtTest.kt
@@ -32,17 +32,17 @@ class InstantExtensionsKtTest {
     }
 
     @Test
-    fun `roundDownToDay should round down to start of day`() {
+    fun `roundToDayStart should round down to start of day`() {
         val instant = LocalDateTime(2023, 5, 1, 10, 45, 15).toInstant(timeZone)
         val expected = LocalDateTime(2023, 5, 1, 0, 0, 0).toInstant(timeZone)
-        instant.roundDownToDay() shouldBe expected
+        instant.roundToDayStart() shouldBe expected
     }
 
     @Test
-    fun `roundUpToDayEnd should round up to end of day`() {
+    fun `roundToDayEnd should round up to end of day`() {
         val instant = LocalDateTime(2023, 5, 1, 10, 45, 15).toInstant(timeZone)
         val expected = LocalDateTime(2023, 5, 1, 23, 59, 59, 999_999_999).toInstant(timeZone)
-        instant.roundUpToDayEnd() shouldBe expected
+        instant.roundToDayEnd() shouldBe expected
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilterTest.kt
@@ -10,6 +10,7 @@ import com.rwmobi.kunigami.domain.extensions.roundToDayEnd
 import com.rwmobi.kunigami.domain.extensions.roundToDayStart
 import com.rwmobi.kunigami.domain.extensions.toLocalDateString
 import com.rwmobi.kunigami.domain.extensions.toLocalMonthYear
+import com.rwmobi.kunigami.domain.extensions.toLocalWeekday
 import com.rwmobi.kunigami.domain.extensions.toLocalYear
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -115,7 +116,7 @@ class ConsumptionQueryFilterTest {
     @Test
     fun `getConsumptionPeriodString should return correct string for DAY_HALF_HOURLY`() {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.DAY_HALF_HOURLY, pointOfReference = now)
-        filter.getConsumptionPeriodString() shouldBe now.toLocalDateString()
+        filter.getConsumptionPeriodString() shouldBe "${now.toLocalWeekday()}, ${now.toLocalDateString()}"
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilterTest.kt
@@ -6,8 +6,8 @@
  */
 package com.rwmobi.kunigami.ui.model.consumption
 
-import com.rwmobi.kunigami.domain.extensions.roundDownToDay
-import com.rwmobi.kunigami.domain.extensions.roundUpToDayEnd
+import com.rwmobi.kunigami.domain.extensions.roundToDayEnd
+import com.rwmobi.kunigami.domain.extensions.roundToDayStart
 import com.rwmobi.kunigami.domain.extensions.toLocalDateString
 import com.rwmobi.kunigami.domain.extensions.toLocalMonthYear
 import com.rwmobi.kunigami.domain.extensions.toLocalYear
@@ -39,13 +39,13 @@ class ConsumptionQueryFilterTest {
     @Test
     fun `calculateStartDate should return correct start date for DAY_HALF_HOURLY`() {
         val startDate = ConsumptionQueryFilter.calculateStartDate(now, ConsumptionPresentationStyle.DAY_HALF_HOURLY)
-        startDate shouldBe now.roundDownToDay()
+        startDate shouldBe now.roundToDayStart()
     }
 
     @Test
     fun `calculateEndDate should return correct end date for DAY_HALF_HOURLY`() {
         val endDate = ConsumptionQueryFilter.calculateEndDate(now, ConsumptionPresentationStyle.DAY_HALF_HOURLY)
-        endDate shouldBe now.roundUpToDayEnd()
+        endDate shouldBe now.roundToDayEnd()
     }
 
     @Test
@@ -120,8 +120,8 @@ class ConsumptionQueryFilterTest {
 
     @Test
     fun `getConsumptionPeriodString should return correct string for WEEK_SEVEN_DAYS`() {
-        val start = now.roundDownToDay()
-        val end = now.roundUpToDayEnd()
+        val start = now.roundToDayStart()
+        val end = now.roundToDayEnd()
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.WEEK_SEVEN_DAYS, pointOfReference = now, requestedStart = start, requestedEnd = end)
         filter.getConsumptionPeriodString() shouldBe "${start.toLocalDateString().substringBefore(",")} - ${end.toLocalDateString()}"
     }


### PR DESCRIPTION
Turned out this is a bugfix as we have misused the return@forEach which means continue running the loop.

To speed up we look for yesterday's data instead of today straight away.