### PR TITLE
(#49) show tooltip when pressing on the chart on mobile

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/VerticalBarChart.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/VerticalBarChart.kt
@@ -48,7 +48,6 @@ import io.github.koalaplot.core.xygraph.rememberAxisStyle
 @Composable
 fun VerticalBarChart(
     modifier: Modifier,
-    title: String? = null,
     xAxisTitle: String? = null,
     yAxisTitle: String? = null,
     entries: List<VerticalBarPlotEntry<Int, Double>>,
@@ -60,14 +59,7 @@ fun VerticalBarChart(
 ) {
     val dimension = LocalDensity.current.getDimension()
 
-    ChartLayout(
-        modifier = modifier,
-        title = {
-            title?.let {
-                ChartTitle(title = title)
-            }
-        },
-    ) {
+    ChartLayout(modifier = modifier) {
         XYGraph(
             panZoomEnabled = false,
             xAxisModel = CategoryAxisModel(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/VerticalBarChart.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/VerticalBarChart.kt
@@ -9,9 +9,12 @@
 
 package com.rwmobi.kunigami.ui.components.koalaplot
 
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.absolutePadding
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -19,11 +22,18 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RichTooltip
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -44,134 +54,170 @@ import io.github.koalaplot.core.xygraph.XYGraph
 import io.github.koalaplot.core.xygraph.XYGraphScope
 import io.github.koalaplot.core.xygraph.rememberAxisStyle
 
-@OptIn(ExperimentalKoalaPlotApi::class)
+@OptIn(ExperimentalKoalaPlotApi::class, ExperimentalComposeUiApi::class)
 @Composable
 fun VerticalBarChart(
     modifier: Modifier,
-    xAxisTitle: String? = null,
-    yAxisTitle: String? = null,
+    showToolTipOnClick: Boolean,
+    colorPalette: List<Color>,
     entries: List<VerticalBarPlotEntry<Int, Double>>,
     yAxisRange: ClosedFloatingPointRange<Double>,
     labelGenerator: (index: Int) -> String?,
     tooltipGenerator: (index: Int) -> String,
-    colorPalette: List<Color>,
+    xAxisTitle: String? = null,
+    yAxisTitle: String? = null,
     backgroundPlot: @Composable ((scope: XYGraphScope<Int, Double>) -> Unit)? = null,
 ) {
     val dimension = LocalDensity.current.getDimension()
 
-    ChartLayout(modifier = modifier) {
-        XYGraph(
-            panZoomEnabled = false,
-            xAxisModel = CategoryAxisModel(
-                categories = entries.indices.toList(),
-                firstCategoryIsZero = false, // true means first column cut into half
-            ),
-            xAxisLabels = { index ->
-                labelGenerator(index)?.let { label ->
-                    AxisLabel(
-                        modifier = Modifier.padding(horizontal = dimension.grid_1),
-                        label = label,
-                    )
-                }
-            },
-            xAxisStyle = AxisStyle(
-                color = MaterialTheme.colorScheme.onBackground.copy(
-                    alpha = 0.25f,
+    Box {
+        var showTooltipIndex: Int? by remember { mutableStateOf(null) }
+        ChartLayout(modifier = modifier) {
+            XYGraph(
+                panZoomEnabled = false,
+                xAxisModel = CategoryAxisModel(
+                    categories = entries.indices.toList(),
+                    firstCategoryIsZero = false, // true means first column cut into half
                 ),
-                majorTickSize = 4.dp,
-                tickPosition = TickPosition.Outside,
-                labelRotation = 90,
-            ),
-            xAxisTitle = {
-                xAxisTitle?.let {
-                    XAxisTitle(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = dimension.grid_1),
-                        title = it,
-                    )
-                }
-            },
-            verticalMajorGridLineStyle = null,
-            verticalMinorGridLineStyle = null,
+                xAxisLabels = { index ->
+                    labelGenerator(index)?.let { label ->
+                        AxisLabel(
+                            modifier = Modifier.padding(horizontal = dimension.grid_1),
+                            label = label,
+                        )
+                    }
+                },
+                xAxisStyle = AxisStyle(
+                    color = MaterialTheme.colorScheme.onBackground.copy(
+                        alpha = 0.25f,
+                    ),
+                    majorTickSize = 4.dp,
+                    tickPosition = TickPosition.Outside,
+                    labelRotation = 90,
+                ),
+                xAxisTitle = {
+                    xAxisTitle?.let {
+                        XAxisTitle(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = dimension.grid_1),
+                            title = it,
+                        )
+                    }
+                },
+                verticalMajorGridLineStyle = null,
+                verticalMinorGridLineStyle = null,
 
-            yAxisModel = DoubleLinearAxisModel(
-                range = yAxisRange,
-                minimumMajorTickIncrement = 0.1,
-                minorTickCount = 4,
-                allowZooming = false,
-                allowPanning = false,
-            ),
-            yAxisStyle = rememberAxisStyle(
-                tickPosition = TickPosition.Outside,
-            ),
-            yAxisLabels = {
-                AxisLabel(
-                    modifier = Modifier.absolutePadding(right = dimension.grid_0_25),
-                    label = it.toString(precision = 1),
-                )
-            },
-            yAxisTitle = {
-                yAxisTitle?.let {
-                    YAxisTitle(
-                        modifier = Modifier
-                            .fillMaxHeight()
-                            .padding(end = dimension.grid_1),
-                        title = it,
-                    )
-                }
-            },
-            horizontalMajorGridLineStyle = LineStyle(
-                brush = SolidColor(MaterialTheme.colorScheme.onBackground),
-                strokeWidth = 1.dp,
-                pathEffect = null,
-                alpha = 0.5f,
-                colorFilter = null,
-                blendMode = DrawScope.DefaultBlendMode,
-            ),
-            horizontalMinorGridLineStyle = LineStyle(
-                brush = SolidColor(MaterialTheme.colorScheme.onBackground),
-                strokeWidth = 1.dp,
-                pathEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 4f), 0f), // Configure dashed pattern
-                alpha = 0.25f,
-                colorFilter = null,
-                blendMode = DrawScope.DefaultBlendMode,
-            ),
-        ) {
-            backgroundPlot?.let { it(this) }
-
-            VerticalBarPlot(
-                data = entries,
-                barWidth = 0.8f,
-                bar = { index ->
-                    DefaultVerticalBar(
-                        modifier = Modifier.fillMaxWidth(),
-                        brush = SolidColor(
-                            colorPalette[
-                                entries[index].y.yMax.getPercentageColorIndex(
-                                    maxValue = yAxisRange.endInclusive,
-                                ),
-                            ],
-                        ),
-                        shape = RoundedCornerShape(
-                            topStart = 8.dp,
-                            topEnd = 8.dp,
-                            bottomEnd = 0.dp,
-                            bottomStart = 0.dp,
-                        ),
-                        hoverElement = {
-                            RichTooltip {
-                                Text(
-                                    modifier = Modifier.padding(all = dimension.grid_0_25),
-                                    style = MaterialTheme.typography.labelMedium,
-                                    textAlign = TextAlign.Center,
-                                    text = tooltipGenerator(index),
-                                )
-                            }
-                        },
+                yAxisModel = DoubleLinearAxisModel(
+                    range = yAxisRange,
+                    minimumMajorTickIncrement = 0.1,
+                    minorTickCount = 4,
+                    allowZooming = false,
+                    allowPanning = false,
+                ),
+                yAxisStyle = rememberAxisStyle(
+                    tickPosition = TickPosition.Outside,
+                ),
+                yAxisLabels = {
+                    AxisLabel(
+                        modifier = Modifier.absolutePadding(right = dimension.grid_0_25),
+                        label = it.toString(precision = 1),
                     )
                 },
-            )
+                yAxisTitle = {
+                    yAxisTitle?.let {
+                        YAxisTitle(
+                            modifier = Modifier
+                                .fillMaxHeight()
+                                .padding(end = dimension.grid_1),
+                            title = it,
+                        )
+                    }
+                },
+                horizontalMajorGridLineStyle = LineStyle(
+                    brush = SolidColor(MaterialTheme.colorScheme.onBackground),
+                    strokeWidth = 1.dp,
+                    pathEffect = null,
+                    alpha = 0.5f,
+                    colorFilter = null,
+                    blendMode = DrawScope.DefaultBlendMode,
+                ),
+                horizontalMinorGridLineStyle = LineStyle(
+                    brush = SolidColor(MaterialTheme.colorScheme.onBackground),
+                    strokeWidth = 1.dp,
+                    pathEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 4f), 0f), // Configure dashed pattern
+                    alpha = 0.25f,
+                    colorFilter = null,
+                    blendMode = DrawScope.DefaultBlendMode,
+                ),
+            ) {
+                backgroundPlot?.let { it(this) }
+
+                VerticalBarPlot(
+                    data = entries,
+                    barWidth = 0.8f,
+                    bar = { index ->
+                        DefaultVerticalBar(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .pointerInput(Unit) {
+                                    if (showToolTipOnClick) {
+                                        detectTapGestures(
+                                            onPress = { _ ->
+                                                showTooltipIndex = index
+                                                try {
+                                                    awaitRelease()
+                                                } finally {
+                                                    if (showTooltipIndex == index) {
+                                                        showTooltipIndex = null
+                                                    }
+                                                }
+                                            },
+                                        )
+                                    }
+                                },
+                            brush = SolidColor(
+                                colorPalette[
+                                    entries[index].y.yMax.getPercentageColorIndex(
+                                        maxValue = yAxisRange.endInclusive,
+                                    ),
+                                ],
+                            ),
+                            shape = RoundedCornerShape(
+                                topStart = 8.dp,
+                                topEnd = 8.dp,
+                                bottomEnd = 0.dp,
+                                bottomStart = 0.dp,
+                            ),
+                            hoverElement = {
+                                RichTooltip {
+                                    Text(
+                                        modifier = Modifier.padding(all = dimension.grid_0_25),
+                                        style = MaterialTheme.typography.labelMedium,
+                                        textAlign = TextAlign.Center,
+                                        text = tooltipGenerator(index),
+                                    )
+                                }
+                            },
+                        )
+                    },
+                )
+            }
+        }
+
+        showTooltipIndex?.let { index ->
+            RichTooltip(
+                modifier = Modifier
+                    .align(alignment = Alignment.TopCenter)
+                    .offset(y = dimension.grid_2),
+            ) {
+                Text(
+                    modifier = Modifier.padding(all = 4.dp),
+                    style = MaterialTheme.typography.labelMedium,
+                    textAlign = TextAlign.Center,
+                    text = tooltipGenerator(index),
+                )
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -160,6 +160,7 @@ fun AgileScreen(
 
                                 VerticalBarChart(
                                     modifier = constraintModifier.padding(all = dimension.grid_2),
+                                    showToolTipOnClick = uiState.showToolTipOnClick,
                                     entries = barChartData.verticalBarPlotEntries,
                                     yAxisRange = uiState.rateRange,
                                     yAxisTitle = stringResource(resource = Res.string.agile_vat_unit_rate),

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileUIState.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileUIState.kt
@@ -20,6 +20,7 @@ import com.rwmobi.kunigami.ui.model.rate.RateGroupedCells
 data class AgileUIState(
     val isLoading: Boolean = true,
     val isDemoMode: Boolean? = null,
+    val showToolTipOnClick: Boolean = false,
     val requestedChartLayout: RequestedChartLayout = RequestedChartLayout.Portrait,
     val requestedRateColumns: Int = 1,
     val requestedAdaptiveLayout: WindowWidthSizeClass = WindowWidthSizeClass.Compact,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
@@ -145,6 +145,7 @@ fun UsageScreen(
 
                                     VerticalBarChart(
                                         modifier = constraintModifier.padding(all = dimension.grid_2),
+                                        showToolTipOnClick = uiState.showToolTipOnClick,
                                         entries = barChartData.verticalBarPlotEntries,
                                         yAxisRange = uiState.consumptionRange,
                                         yAxisTitle = stringResource(resource = Res.string.kwh),

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageUIState.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageUIState.kt
@@ -22,6 +22,7 @@ data class UsageUIState(
     val isLoading: Boolean = true,
     val isDemoMode: Boolean? = null,
     val userProfile: UserProfile? = null,
+    val showToolTipOnClick: Boolean = false,
     val requestedChartLayout: RequestedChartLayout = RequestedChartLayout.Portrait,
     val requestedAdaptiveLayout: WindowWidthSizeClass = WindowWidthSizeClass.Compact,
     val requestedUsageColumns: Int = 1,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
@@ -23,7 +23,9 @@ import com.rwmobi.kunigami.domain.usecase.GetTariffRatesUseCase
 import com.rwmobi.kunigami.domain.usecase.SyncUserProfileUseCase
 import com.rwmobi.kunigami.ui.destinations.agile.AgileUIState
 import com.rwmobi.kunigami.ui.extensions.generateRandomLong
+import com.rwmobi.kunigami.ui.extensions.getPlatformType
 import com.rwmobi.kunigami.ui.model.ErrorMessage
+import com.rwmobi.kunigami.ui.model.PlatformType
 import com.rwmobi.kunigami.ui.model.ScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.chart.BarChartData
 import com.rwmobi.kunigami.ui.model.chart.RequestedChartLayout
@@ -92,6 +94,8 @@ class AgileViewModel(
     fun notifyScreenSizeChanged(screenSizeInfo: ScreenSizeInfo, windowSizeClass: WindowSizeClass) {
         _uiState.update { currentUiState ->
             Logger.v("AgileViewModel: ${screenSizeInfo.heightDp}h x ${screenSizeInfo.widthDp}w, isPortrait = ${screenSizeInfo.isPortrait()}")
+            val showToolTipOnClick = windowSizeClass.getPlatformType() != PlatformType.DESKTOP
+            val usageColumns = (screenSizeInfo.widthDp / rateColumnWidth).toInt()
             val requestedLayout = if (screenSizeInfo.isPortrait()) {
                 RequestedChartLayout.Portrait
             } else {
@@ -100,9 +104,8 @@ class AgileViewModel(
                 )
             }
 
-            val usageColumns = (screenSizeInfo.widthDp / rateColumnWidth).toInt()
-
             currentUiState.copy(
+                showToolTipOnClick = showToolTipOnClick,
                 requestedChartLayout = requestedLayout,
                 requestedRateColumns = usageColumns,
                 requestedAdaptiveLayout = windowSizeClass.widthSizeClass,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModel.kt
@@ -25,7 +25,9 @@ import com.rwmobi.kunigami.domain.usecase.GetConsumptionUseCase
 import com.rwmobi.kunigami.domain.usecase.SyncUserProfileUseCase
 import com.rwmobi.kunigami.ui.destinations.usage.UsageUIState
 import com.rwmobi.kunigami.ui.extensions.generateRandomLong
+import com.rwmobi.kunigami.ui.extensions.getPlatformType
 import com.rwmobi.kunigami.ui.model.ErrorMessage
+import com.rwmobi.kunigami.ui.model.PlatformType
 import com.rwmobi.kunigami.ui.model.ScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.chart.BarChartData
 import com.rwmobi.kunigami.ui.model.chart.RequestedChartLayout
@@ -175,6 +177,8 @@ class UsageViewModel(
     fun notifyScreenSizeChanged(screenSizeInfo: ScreenSizeInfo, windowSizeClass: WindowSizeClass) {
         _uiState.update { currentUiState ->
             Logger.v("UsageViewModel: $windowSizeClass, ${screenSizeInfo.heightDp}h x ${screenSizeInfo.widthDp}w, isPortrait = ${screenSizeInfo.isPortrait()}")
+            val showToolTipOnClick = windowSizeClass.getPlatformType() != PlatformType.DESKTOP
+            val usageColumns = (screenSizeInfo.widthDp / usageColumnWidth).toInt()
             val requestedLayout = if (screenSizeInfo.isPortrait()) {
                 RequestedChartLayout.Portrait
             } else {
@@ -183,9 +187,8 @@ class UsageViewModel(
                 )
             }
 
-            val usageColumns = (screenSizeInfo.widthDp / usageColumnWidth).toInt()
-
             currentUiState.copy(
+                showToolTipOnClick = showToolTipOnClick,
                 requestedAdaptiveLayout = windowSizeClass.widthSizeClass,
                 requestedChartLayout = requestedLayout,
                 requestedUsageColumns = usageColumns,


### PR DESCRIPTION
Until the charting library provides this, this is the workaround on mobile at least to trigger the tooltip when pressing on the bars on the chart. It's better than nothing, given that the main focus is the desktop app.