### PR TITLE
TariffsScreen: fix to reduce flashing

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffsScreen.kt
@@ -209,7 +209,10 @@ fun TariffsScreen(
     }
 
     val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
-    if (bottomSheetState.isVisible && uiState.requestedLayout != TariffScreenLayout.ListDetailPane) {
+    if (bottomSheetState.isVisible &&
+        uiState.requestedLayout != TariffScreenLayout.ListDetailPane &&
+        uiState.requestedScreenType !is TariffsScreenType.Error
+    ) {
         TariffBottomSheet(
             modifier = Modifier.fillMaxSize(),
             productDetails = uiState.productDetails,
@@ -225,8 +228,8 @@ fun TariffsScreen(
     LaunchedEffect(uiState.productDetails, uiState.requestedLayout) {
         if (uiState.shouldUseBottomSheet()) {
             when {
-                uiState.productDetails != null && !bottomSheetState.isVisible -> bottomSheetState.show()
-                uiState.productDetails == null && bottomSheetState.isVisible -> bottomSheetState.hide()
+                uiState.productDetails != null && !bottomSheetState.isVisible && (uiState.requestedScreenType !is TariffsScreenType.Error) -> bottomSheetState.show()
+                (uiState.productDetails == null || uiState.requestedScreenType is TariffsScreenType.Error) && bottomSheetState.isVisible -> bottomSheetState.hide()
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/TariffsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/TariffsViewModel.kt
@@ -54,7 +54,9 @@ class TariffsViewModel(
                 onSuccess = { products ->
                     _uiState.update { currentUiState ->
                         currentUiState.copy(
+                            requestedScreenType = null, // force recalculation
                             productSummaries = products,
+                            productDetails = null,
                             isLoading = false,
                         ).updateScreenType()
                     }
@@ -120,7 +122,6 @@ class TariffsViewModel(
         _uiState.update { currentUiState ->
             currentUiState.copy(
                 isLoading = true,
-                requestedScreenType = null,
             )
         }
     }


### PR DESCRIPTION
quick fix to avoid setting null when start loading.
also fix to clear the error screen status when a successful list is retrieved.