### PR TITLE
Map Ktor Darwin exceptions to domain model

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.android.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.kunigami.ui.extensions
+
+/***
+ * This is needed to handle Ktor Darwin Engine exceptions which does not exist in CommonMain
+ */
+actual fun Throwable.mapFromPlatform(): Throwable = this

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountUIState.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountUIState.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Immutable
 import com.rwmobi.kunigami.domain.exceptions.HttpException
 import com.rwmobi.kunigami.domain.model.account.UserProfile
 import com.rwmobi.kunigami.ui.extensions.generateRandomLong
+import com.rwmobi.kunigami.ui.extensions.mapFromPlatform
 import com.rwmobi.kunigami.ui.model.ErrorMessage
 import com.rwmobi.kunigami.ui.model.SpecialErrorScreen
 import io.ktor.util.network.UnresolvedAddressException
@@ -42,10 +43,10 @@ data class AccountUIState(
     }
 
     suspend fun filterErrorAndStopLoading(throwable: Throwable): AccountUIState {
-        return when (throwable) {
+        return when (val translatedThrowable = throwable.mapFromPlatform()) {
             is HttpException -> {
                 copy(
-                    requestedScreenType = AccountScreenType.ErrorScreen(SpecialErrorScreen.HttpError(statusCode = throwable.httpStatusCode)),
+                    requestedScreenType = AccountScreenType.ErrorScreen(SpecialErrorScreen.HttpError(statusCode = translatedThrowable.httpStatusCode)),
                     isLoading = false,
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileUIState.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileUIState.kt
@@ -16,6 +16,7 @@ import com.rwmobi.kunigami.domain.model.account.UserProfile
 import com.rwmobi.kunigami.domain.model.product.TariffSummary
 import com.rwmobi.kunigami.ui.extensions.generateRandomLong
 import com.rwmobi.kunigami.ui.extensions.getPlatformType
+import com.rwmobi.kunigami.ui.extensions.mapFromPlatform
 import com.rwmobi.kunigami.ui.model.ErrorMessage
 import com.rwmobi.kunigami.ui.model.PlatformType
 import com.rwmobi.kunigami.ui.model.ScreenSizeInfo
@@ -66,19 +67,17 @@ data class AgileUIState(
         )
     }
 
-    fun isOnDifferentTariff(): Boolean {
-        return (
-            false == isDemoMode &&
-                userProfile?.tariffSummary != null &&
-                userProfile.tariffSummary.tariffCode != agileTariffSummary?.tariffCode
-            )
-    }
+    fun isOnDifferentTariff() = (
+        false == isDemoMode &&
+            userProfile?.tariffSummary != null &&
+            userProfile.tariffSummary.tariffCode != agileTariffSummary?.tariffCode
+        )
 
     suspend fun filterErrorAndStopLoading(throwable: Throwable): AgileUIState {
-        return when (throwable) {
+        return when (val translatedThrowable = throwable.mapFromPlatform()) {
             is HttpException -> {
                 copy(
-                    requestedScreenType = AgileScreenType.Error(SpecialErrorScreen.HttpError(statusCode = throwable.httpStatusCode)),
+                    requestedScreenType = AgileScreenType.Error(SpecialErrorScreen.HttpError(statusCode = translatedThrowable.httpStatusCode)),
                     isLoading = false,
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffsUIState.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffsUIState.kt
@@ -17,6 +17,7 @@ import com.rwmobi.kunigami.domain.model.product.ProductDetails
 import com.rwmobi.kunigami.domain.model.product.ProductSummary
 import com.rwmobi.kunigami.ui.extensions.generateRandomLong
 import com.rwmobi.kunigami.ui.extensions.getPlatformType
+import com.rwmobi.kunigami.ui.extensions.mapFromPlatform
 import com.rwmobi.kunigami.ui.model.ErrorMessage
 import com.rwmobi.kunigami.ui.model.PlatformType
 import com.rwmobi.kunigami.ui.model.ScreenSizeInfo
@@ -82,10 +83,10 @@ data class TariffsUIState(
     }
 
     suspend fun filterErrorAndStopLoading(throwable: Throwable): TariffsUIState {
-        return when (throwable) {
+        return when (val translatedThrowable = throwable.mapFromPlatform()) {
             is HttpException -> {
                 copy(
-                    requestedScreenType = TariffsScreenType.Error(SpecialErrorScreen.HttpError(statusCode = throwable.httpStatusCode)),
+                    requestedScreenType = TariffsScreenType.Error(SpecialErrorScreen.HttpError(statusCode = translatedThrowable.httpStatusCode)),
                     isLoading = false,
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageUIState.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageUIState.kt
@@ -15,6 +15,7 @@ import com.rwmobi.kunigami.domain.exceptions.HttpException
 import com.rwmobi.kunigami.domain.model.account.UserProfile
 import com.rwmobi.kunigami.ui.extensions.generateRandomLong
 import com.rwmobi.kunigami.ui.extensions.getPlatformType
+import com.rwmobi.kunigami.ui.extensions.mapFromPlatform
 import com.rwmobi.kunigami.ui.model.ErrorMessage
 import com.rwmobi.kunigami.ui.model.PlatformType
 import com.rwmobi.kunigami.ui.model.ScreenSizeInfo
@@ -68,22 +69,20 @@ data class UsageUIState(
         )
     }
 
-    fun clearDataFieldsAndStopLoading(): UsageUIState {
-        return copy(
-            userProfile = null,
-            consumptionGroupedCells = listOf(),
-            consumptionRange = 0.0..0.0,
-            barChartData = null,
-            insights = null,
-            isLoading = false,
-        )
-    }
+    fun clearDataFieldsAndStopLoading() = copy(
+        userProfile = null,
+        consumptionGroupedCells = listOf(),
+        consumptionRange = 0.0..0.0,
+        barChartData = null,
+        insights = null,
+        isLoading = false,
+    )
 
     suspend fun filterErrorAndStopLoading(throwable: Throwable, defaultMessage: String? = null): UsageUIState {
-        return when (throwable) {
+        return when (val translatedThrowable = throwable.mapFromPlatform()) {
             is HttpException -> {
                 copy(
-                    requestedScreenType = UsageScreenType.Error(SpecialErrorScreen.HttpError(statusCode = throwable.httpStatusCode)),
+                    requestedScreenType = UsageScreenType.Error(SpecialErrorScreen.HttpError(statusCode = translatedThrowable.httpStatusCode)),
                     isLoading = false,
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.kunigami.ui.extensions
+
+/***
+ * This is needed to handle Ktor Darwin Engine exceptions which does not exist in CommonMain
+ */
+expect fun Throwable.mapFromPlatform(): Throwable

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.desktop.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.kunigami.ui.extensions
+
+/***
+ * This is needed to handle Ktor Darwin Engine exceptions which does not exist in CommonMain
+ */
+actual fun Throwable.mapFromPlatform(): Throwable = this

--- a/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.ios.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.kunigami.ui.extensions
+
+import com.rwmobi.kunigami.domain.exceptions.HttpException
+import io.ktor.client.engine.darwin.DarwinHttpRequestException
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.util.network.UnresolvedAddressException
+import platform.Foundation.NSError
+import platform.Foundation.NSURLErrorNotConnectedToInternet
+
+/***
+ * This is needed to handle Ktor Darwin Engine exceptions which does not exist in CommonMain
+ */
+actual fun Throwable.mapFromPlatform(): Throwable {
+    return when (this) {
+        is DarwinHttpRequestException -> {
+            // Check if the underlying error indicates no network
+            val nsError = (origin as? NSError)
+            if (nsError?.code == NSURLErrorNotConnectedToInternet) {
+                // No network connection available
+                UnresolvedAddressException()
+            } else {
+                this
+            }
+        }
+
+        is ClientRequestException -> {
+            HttpException(httpStatusCode = response.status.value)
+        }
+
+        else -> this
+    }
+}


### PR DESCRIPTION
A simple expect/actual to bring the iOS-specific Ktor exceptions to commonMain, so that we can map them to the existing throwable domain model we have.