### PR TITLE
(#144) Provide DemoRestApiRepository thru DI

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/RepositoryModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/RepositoryModule.kt
@@ -7,6 +7,7 @@
 
 package com.rwmobi.kunigami.di
 
+import com.rwmobi.kunigami.data.repository.DemoRestApiRepository
 import com.rwmobi.kunigami.data.repository.OctopusRestApiRepository
 import com.rwmobi.kunigami.data.repository.OctopusUserPreferencesRepository
 import com.rwmobi.kunigami.domain.repository.RestApiRepository
@@ -15,7 +16,7 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val repositoryModule = module {
-    single<RestApiRepository> {
+    single<RestApiRepository>(named("production")) {
         OctopusRestApiRepository(
             productsEndpoint = get(),
             electricityMeterPointsEndpoint = get(),
@@ -23,6 +24,13 @@ val repositoryModule = module {
             dispatcher = get(named("DefaultDispatcher")),
         )
     }
+
+    single<RestApiRepository>(named("demo")) {
+        DemoRestApiRepository()
+    }
+
+    // Set the "production" instance as the default for RestApiRepository
+    single<RestApiRepository> { get(named("production")) }
 
     factory<UserPreferencesRepository> {
         OctopusUserPreferencesRepository(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/UseCaseModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/UseCaseModule.kt
@@ -36,6 +36,7 @@ val userCaseModule = module {
         GetConsumptionUseCase(
             userPreferencesRepository = get(),
             restApiRepository = get(),
+            demoRestApiRepository = get(named("demo")),
             dispatcher = get(named("DefaultDispatcher")),
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/GetConsumptionUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/GetConsumptionUseCase.kt
@@ -7,7 +7,6 @@
 
 package com.rwmobi.kunigami.domain.usecase
 
-import com.rwmobi.kunigami.data.repository.DemoRestApiRepository
 import com.rwmobi.kunigami.domain.exceptions.except
 import com.rwmobi.kunigami.domain.model.consumption.Consumption
 import com.rwmobi.kunigami.domain.model.consumption.ConsumptionDataGroup
@@ -23,6 +22,7 @@ import kotlin.coroutines.cancellation.CancellationException
 class GetConsumptionUseCase(
     private val userPreferencesRepository: UserPreferencesRepository,
     private val restApiRepository: RestApiRepository,
+    private val demoRestApiRepository: RestApiRepository,
     private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
     /***
@@ -65,7 +65,6 @@ class GetConsumptionUseCase(
                         },
                     )
                 } else {
-                    val demoRestApiRepository = DemoRestApiRepository()
                     demoRestApiRepository.getConsumption(
                         apiKey = "",
                         mpan = "",

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountInformationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountInformationScreen.kt
@@ -39,8 +39,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.domain.extensions.toLocalDateString
 import com.rwmobi.kunigami.domain.model.account.Account
-import com.rwmobi.kunigami.domain.model.account.Agreement
-import com.rwmobi.kunigami.domain.model.account.ElectricityMeterPoint
 import com.rwmobi.kunigami.domain.model.account.UserProfile
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.components.MessageActionScreen
@@ -50,10 +48,10 @@ import com.rwmobi.kunigami.ui.destinations.account.components.ElectricityMeterPo
 import com.rwmobi.kunigami.ui.destinations.account.components.UpdateAPIKeyCard
 import com.rwmobi.kunigami.ui.destinations.account.components.UpdateApiKeyDialog
 import com.rwmobi.kunigami.ui.model.SpecialErrorScreen
+import com.rwmobi.kunigami.ui.previewsampledata.AccountSamples
 import com.rwmobi.kunigami.ui.previewsampledata.TariffSamples
 import com.rwmobi.kunigami.ui.theme.AppTheme
 import com.rwmobi.kunigami.ui.theme.getDimension
-import kotlinx.datetime.Clock
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.account_clear_credential_title
 import kunigami.composeapp.generated.resources.account_error_account_empty
@@ -67,7 +65,6 @@ import kunigami.composeapp.generated.resources.unlink
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
-import kotlin.time.Duration
 
 @Composable
 internal fun AccountInformationScreen(
@@ -199,34 +196,7 @@ private fun Preview() {
                     userProfile = UserProfile(
                         selectedMpan = "1200000345678",
                         selectedMeterSerialNumber = "11A1234567",
-                        account = // null,
-                        Account(
-                            id = 8638,
-                            accountNumber = "A-1234A1B1",
-                            fullAddress = "Address line 1\nAddress line 2\nAddress line 3\nAddress line 4",
-                            movedInAt = Clock.System.now(),
-                            movedOutAt = null,
-                            electricityMeterPoints = listOf(
-                                ElectricityMeterPoint(
-                                    mpan = "1200000345678",
-                                    meterSerialNumbers = listOf("11A1234567", "11A12345A7"),
-                                    currentAgreement = Agreement(
-                                        tariffCode = "E-1R-AGILE-FLEX-22-11-25-A",
-                                        validFrom = Clock.System.now(),
-                                        validTo = Clock.System.now().plus(Duration.parse("365d")),
-                                    ),
-                                ),
-                                ElectricityMeterPoint(
-                                    mpan = "1200000345670",
-                                    meterSerialNumbers = listOf("11A1234560"),
-                                    currentAgreement = Agreement(
-                                        tariffCode = "E-1R-AGILE-FLEX-22-11-25-A",
-                                        validFrom = Clock.System.now(),
-                                        validTo = Clock.System.now().plus(Duration.parse("365d")),
-                                    ),
-                                ),
-                            ),
-                        ),
+                        account = AccountSamples.accountTwoElectricityMeterPoint,
                         tariffSummary = TariffSamples.agileFlex221125,
                     ),
                     errorMessages = listOf(),
@@ -260,7 +230,7 @@ private fun ErrorPreview() {
                     selectedMpan = "1200000345678",
                     selectedMeterSerialNumber = "11A1234567",
                     account = null,
-                    tariffSummary = TariffSamples.agileFlex221125,
+                    tariffSummary = null,
                 ),
                 errorMessages = listOf(),
             ),

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountScreen.kt
@@ -22,19 +22,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import com.rwmobi.kunigami.domain.model.account.Account
-import com.rwmobi.kunigami.domain.model.account.Agreement
-import com.rwmobi.kunigami.domain.model.account.ElectricityMeterPoint
-import com.rwmobi.kunigami.domain.model.account.UserProfile
 import com.rwmobi.kunigami.ui.components.ErrorScreenHandler
 import com.rwmobi.kunigami.ui.components.LoadingScreen
 import com.rwmobi.kunigami.ui.components.ScrollbarMultiplatform
 import com.rwmobi.kunigami.ui.composehelper.conditionalBlur
 import com.rwmobi.kunigami.ui.model.SpecialErrorScreen
-import com.rwmobi.kunigami.ui.previewsampledata.TariffSamples
+import com.rwmobi.kunigami.ui.previewsampledata.FakeDemoUserProfile
 import com.rwmobi.kunigami.ui.theme.AppTheme
 import com.rwmobi.kunigami.ui.theme.getDimension
-import kotlinx.datetime.Clock
-import kotlin.time.Duration
 
 @Composable
 fun AccountScreen(
@@ -171,27 +166,7 @@ private fun Preview() {
             uiState = AccountUIState(
                 isLoading = false,
                 requestedScreenType = AccountScreenType.Account,
-                userProfile = UserProfile(
-                    account = Account(
-                        id = 8638,
-                        accountNumber = "A-1234A1B1",
-                        fullAddress = "Address line 1\nAddress line 2\nAddress line 3\nAddress line 4",
-                        movedInAt = Clock.System.now(),
-                        movedOutAt = null,
-                        electricityMeterPoints = listOf(
-                            ElectricityMeterPoint(
-                                mpan = "1200000345678",
-                                meterSerialNumbers = listOf("11A1234567"),
-                                currentAgreement = Agreement(
-                                    tariffCode = "E-1R-AGILE-FLEX-22-11-25-A",
-                                    validFrom = Clock.System.now(),
-                                    validTo = Clock.System.now().plus(Duration.parse("365d")),
-                                ),
-                            ),
-                        ),
-                    ),
-                    tariffSummary = TariffSamples.agileFlex221125,
-                ),
+                userProfile = FakeDemoUserProfile.flexibleOctopusRegionADirectDebit,
                 errorMessages = listOf(),
             ),
             uiEvent = AccountUIEvent(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/OnboardingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/OnboardingScreen.kt
@@ -29,16 +29,10 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import com.rwmobi.kunigami.domain.model.account.Account
-import com.rwmobi.kunigami.domain.model.account.Agreement
-import com.rwmobi.kunigami.domain.model.account.ElectricityMeterPoint
-import com.rwmobi.kunigami.domain.model.account.UserProfile
 import com.rwmobi.kunigami.ui.destinations.account.components.AppInfoFooter
 import com.rwmobi.kunigami.ui.destinations.account.components.CredentialsInputForm
-import com.rwmobi.kunigami.ui.previewsampledata.TariffSamples
 import com.rwmobi.kunigami.ui.theme.AppTheme
 import com.rwmobi.kunigami.ui.theme.getDimension
-import kotlinx.datetime.Clock
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.bulb
 import kunigami.composeapp.generated.resources.onboarding_introduction_1
@@ -50,7 +44,6 @@ import kunigami.composeapp.generated.resources.onboarding_welcome_aboard
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
-import kotlin.time.Duration
 
 @Composable
 internal fun OnboardingScreen(
@@ -139,27 +132,7 @@ private fun Preview() {
                 uiState = AccountUIState(
                     isLoading = false,
                     requestedScreenType = AccountScreenType.Onboarding,
-                    userProfile = UserProfile(
-                        account = Account(
-                            id = 8638,
-                            accountNumber = "A-1234A1B1",
-                            fullAddress = "Address line 1\nAddress line 2\nAddress line 3\nAddress line 4",
-                            movedInAt = Clock.System.now(),
-                            movedOutAt = null,
-                            electricityMeterPoints = listOf(
-                                ElectricityMeterPoint(
-                                    mpan = "1200000345678",
-                                    meterSerialNumbers = listOf("11A1234567"),
-                                    currentAgreement = Agreement(
-                                        tariffCode = "E-1R-AGILE-FLEX-22-11-25-A",
-                                        validFrom = Clock.System.now(),
-                                        validTo = Clock.System.now().plus(Duration.parse("365d")),
-                                    ),
-                                ),
-                            ),
-                        ),
-                        tariffSummary = TariffSamples.agileFlex221125,
-                    ),
+                    userProfile = null,
                     errorMessages = listOf(),
                 ),
                 uiEvent = AccountUIEvent(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/previewsampledata/AccountSamples.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/previewsampledata/AccountSamples.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.kunigami.ui.previewsampledata
+
+import com.rwmobi.kunigami.domain.model.account.Account
+import com.rwmobi.kunigami.domain.model.account.Agreement
+import com.rwmobi.kunigami.domain.model.account.ElectricityMeterPoint
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.time.Duration
+
+internal object AccountSamples {
+    val account928 = Account(
+        id = 928,
+        accountNumber = "A-9009A9A9",
+        fullAddress = "RW MobiMedia UK Limited\n2 Frederick Street\nKing's Cross\nLondon\nWC1X 0ND",
+        movedInAt = Instant.parse("2023-03-28T00:00:00Z"),
+        movedOutAt = null,
+        electricityMeterPoints = listOf(
+            ElectricityMeterPoint(
+                mpan = "9900000999999",
+                meterSerialNumbers = listOf("99A9999999"),
+                currentAgreement = Agreement(
+                    tariffCode = "E-1R-VAR-22-11-01-A",
+                    validFrom = Instant.parse("2023-03-28T00:00:00Z"),
+                    validTo = null,
+                ),
+            ),
+        ),
+    )
+
+    val accountTwoElectricityMeterPoint = Account(
+        id = 8638,
+        accountNumber = "A-1234A1B1",
+        fullAddress = "Address line 1\nAddress line 2\nAddress line 3\nAddress line 4",
+        movedInAt = Clock.System.now(),
+        movedOutAt = null,
+        electricityMeterPoints = listOf(
+            ElectricityMeterPoint(
+                mpan = "1200000345678",
+                meterSerialNumbers = listOf("11A1234567", "11A12345A7"),
+                currentAgreement = Agreement(
+                    tariffCode = "E-1R-AGILE-FLEX-22-11-25-A",
+                    validFrom = Clock.System.now(),
+                    validTo = Clock.System.now().plus(Duration.parse("365d")),
+                ),
+            ),
+            ElectricityMeterPoint(
+                mpan = "1200000345670",
+                meterSerialNumbers = listOf("11A1234560"),
+                currentAgreement = Agreement(
+                    tariffCode = "E-1R-AGILE-FLEX-22-11-25-A",
+                    validFrom = Clock.System.now(),
+                    validTo = Clock.System.now().plus(Duration.parse("365d")),
+                ),
+            ),
+        ),
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/previewsampledata/FakeDemoUserProfile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/previewsampledata/FakeDemoUserProfile.kt
@@ -7,45 +7,13 @@
 
 package com.rwmobi.kunigami.ui.previewsampledata
 
-import com.rwmobi.kunigami.domain.model.account.Account
-import com.rwmobi.kunigami.domain.model.account.Agreement
-import com.rwmobi.kunigami.domain.model.account.ElectricityMeterPoint
 import com.rwmobi.kunigami.domain.model.account.UserProfile
-import com.rwmobi.kunigami.domain.model.product.TariffSummary
-import kotlinx.datetime.Instant
 
-object FakeDemoUserProfile {
+internal object FakeDemoUserProfile {
     val flexibleOctopusRegionADirectDebit = UserProfile(
         selectedMpan = "9900000999999",
         selectedMeterSerialNumber = "99A9999999",
-        account = Account(
-            id = 928,
-            accountNumber = "A-9009A9A9",
-            fullAddress = "RW MobiMedia UK Limited\n2 Frederick Street\nKing's Cross\nLondon\nWC1X 0ND",
-            movedInAt = Instant.parse("2023-03-28T00:00:00Z"),
-            movedOutAt = null,
-            electricityMeterPoints = listOf(
-                ElectricityMeterPoint(
-                    mpan = "9900000999999",
-                    meterSerialNumbers = listOf("99A9999999"),
-                    currentAgreement = Agreement(
-                        tariffCode = "E-1R-VAR-22-11-01-A",
-                        validFrom = Instant.parse("2023-03-28T00:00:00Z"),
-                        validTo = null,
-                    ),
-                ),
-            ),
-        ),
-        tariffSummary = TariffSummary(
-            productCode = "VAR-22-11-01",
-            fullName = "Flexible Octopus",
-            displayName = "Flexible Octopus",
-            description = "Flexible Octopus offers great value and 100% renewable electricity. As a variable tariff, your prices can rise and fall with wholesale prices - but we'll always give you notice of a change.",
-            tariffCode = "E-1R-VAR-22-11-01-A",
-            availableFrom = Instant.parse("2023-03-28T00:00:00Z"),
-            availableTo = null,
-            vatInclusiveUnitRate = 25.2546,
-            vatInclusiveStandingCharge = 47.8485,
-        ),
+        account = AccountSamples.account928,
+        tariffSummary = TariffSamples.var221101,
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/previewsampledata/TariffSamples.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/previewsampledata/TariffSamples.kt
@@ -7,19 +7,33 @@
 
 package com.rwmobi.kunigami.ui.previewsampledata
 
+import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.domain.model.product.TariffSummary
 import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 
-object TariffSamples {
+internal object TariffSamples {
     val agileFlex221125 = TariffSummary(
         productCode = "AGILE-FLEX-22-11-25",
         tariffCode = "E-1R-AGILE-FLEX-22-11-25-A",
         fullName = "Octopus 12M Fixed April 2024 v1",
         displayName = "Octopus 12M Fixed",
-        vatInclusiveUnitRate = 99.257,
-        vatInclusiveStandingCharge = 94.682,
+        vatInclusiveUnitRate = 99.257.roundToTwoDecimalPlaces(),
+        vatInclusiveStandingCharge = 94.682.roundToTwoDecimalPlaces(),
         description = "With Agile Octopus, you get access to half-hourly energy prices, tied to wholesale prices and updated daily.  The unit rate is capped at 100p/kWh (including VAT).",
         availableFrom = Clock.System.now(),
         availableTo = null,
+    )
+
+    val var221101 = TariffSummary(
+        productCode = "VAR-22-11-01",
+        fullName = "Flexible Octopus",
+        displayName = "Flexible Octopus",
+        description = "Flexible Octopus offers great value and 100% renewable electricity. As a variable tariff, your prices can rise and fall with wholesale prices - but we'll always give you notice of a change.",
+        tariffCode = "E-1R-VAR-22-11-01-A",
+        availableFrom = Instant.parse("2023-03-28T00:00:00Z"),
+        availableTo = null,
+        vatInclusiveUnitRate = 25.2546.roundToTwoDecimalPlaces(),
+        vatInclusiveStandingCharge = 47.8485.roundToTwoDecimalPlaces(),
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModel.kt
@@ -237,13 +237,14 @@ class UsageViewModel(
             },
             onFailure = { throwable ->
                 if (throwable is IncompleteCredentialsException) {
+                    val fakeDemoUserProfile = FakeDemoUserProfile.flexibleOctopusRegionADirectDebit
                     _uiState.update { currentUiState ->
                         currentUiState.copy(
                             isDemoMode = true,
-                            userProfile = FakeDemoUserProfile.flexibleOctopusRegionADirectDebit,
+                            userProfile = fakeDemoUserProfile,
                         )
                     }
-                    return FakeDemoUserProfile.flexibleOctopusRegionADirectDebit
+                    return fakeDemoUserProfile
                 } else {
                     Logger.e(getString(resource = Res.string.account_error_load_account), throwable = throwable, tag = "AccountViewModel")
                     _uiState.update { currentUiState ->

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/GetConsumptionUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/GetConsumptionUseCaseTest.kt
@@ -29,6 +29,7 @@ class GetConsumptionUseCaseTest {
     private lateinit var getConsumptionUseCase: GetConsumptionUseCase
     private lateinit var fakeUserPreferenceRepository: FakeUserPreferencesRepository
     private lateinit var fakeRestApiRepository: FakeRestApiRepository
+    private lateinit var fakeDemoRestApiRepository: FakeRestApiRepository
 
     @BeforeTest
     fun setupUseCase() {
@@ -36,9 +37,11 @@ class GetConsumptionUseCaseTest {
             demoMode = false // We do not test demo mode
         }
         fakeRestApiRepository = FakeRestApiRepository()
+        fakeDemoRestApiRepository = FakeRestApiRepository()
         getConsumptionUseCase = GetConsumptionUseCase(
             userPreferencesRepository = fakeUserPreferenceRepository,
             restApiRepository = fakeRestApiRepository,
+            demoRestApiRepository = fakeDemoRestApiRepository,
             dispatcher = UnconfinedTestDispatcher(),
         )
     }


### PR DESCRIPTION
Was accidentally hardcoded the fake repository when implementing the demo ticket.
Now moved to be provided by DI.
Usecase takes an additional parameter to accept the Demo repository so that in unit tests we can also inject another fake to test it.

Extracted certain preview fake objects to centralised class for reuse,