### PR TITLE
(#151) Change sticky header to static header

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -110,7 +110,6 @@ kotlin {
         desktopMain.dependencies {
             implementation("org.jetbrains.skiko:skiko-awt-runtime-$skikoTarget:$skikoVersion")
             implementation(compose.desktop.currentOs)
-            implementation(compose.material3)
             implementation(libs.kotlinx.coroutines.swing)
             implementation(libs.koin.jvm)
             implementation(libs.themedetector)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
-import com.rwmobi.kunigami.domain.model.account.Account
 import com.rwmobi.kunigami.ui.components.ErrorScreenHandler
 import com.rwmobi.kunigami.ui.components.LoadingScreen
 import com.rwmobi.kunigami.ui.components.ScrollbarMultiplatform
@@ -117,7 +116,7 @@ fun AccountScreen(
                             }
                         }
 
-                        else -> {
+                        !uiState.isLoading -> {
                             item(key = "noData") {
                                 ErrorScreenHandler(
                                     modifier = Modifier.fillMaxSize(),

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -107,158 +108,159 @@ fun AgileScreen(
                     enabled = uiState.rateGroupedCells.isNotEmpty(),
                     lazyListState = lazyListState,
                 ) { contentModifier ->
-                    LazyColumn(
+                    Column(
                         modifier = contentModifier
                             .fillMaxSize()
                             .conditionalBlur(enabled = uiState.isLoading && uiState.barChartData == null),
-                        contentPadding = PaddingValues(bottom = dimension.grid_4),
-                        state = lazyListState,
                     ) {
-                        stickyHeader(key = "header") {
-                            val subtitle = uiState.agileTariffSummary?.let {
-                                val regionCode = it.getRetailRegion() ?: stringResource(resource = Res.string.unknown)
-                                stringResource(resource = Res.string.agile_product_code_retail_region, it.productCode, regionCode)
-                            }
-                            DualTitleBar(
-                                modifier = Modifier
-                                    .background(color = MaterialTheme.colorScheme.secondary)
-                                    .fillMaxWidth()
-                                    .height(height = dimension.minListItemHeight),
-                                title = uiState.agileTariffSummary?.displayName ?: "",
-                                subtitle = subtitle,
-                            )
+                        val subtitle = uiState.agileTariffSummary?.let {
+                            val regionCode = it.getRetailRegion() ?: stringResource(resource = Res.string.unknown)
+                            stringResource(resource = Res.string.agile_product_code_retail_region, it.productCode, regionCode)
                         }
+                        DualTitleBar(
+                            modifier = Modifier
+                                .background(color = MaterialTheme.colorScheme.secondary)
+                                .fillMaxWidth()
+                                .height(height = dimension.minListItemHeight),
+                            title = uiState.agileTariffSummary?.displayName ?: "",
+                            subtitle = subtitle,
+                        )
 
-                        if (uiState.isDemoMode == true) {
-                            item(key = "demoCta") {
-                                DemoModeCtaAdaptive(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(all = dimension.grid_2),
-                                    description = stringResource(resource = Res.string.agile_demo_introduction),
-                                    ctaButtonLabel = stringResource(resource = Res.string.provide_api_key),
-                                    onCtaButtonClicked = uiEvent.onNavigateToAccountTab,
-                                    useWideLayout = uiState.requestedAdaptiveLayout != WindowWidthSizeClass.Compact,
-                                )
-                            }
-                        }
-
-                        uiState.barChartData?.let { barChartData ->
-                            item(key = "chart") {
-                                BoxWithConstraints(
-                                    modifier = Modifier.padding(top = dimension.grid_1),
-                                ) {
-                                    val constraintModifier = when (uiState.requestedChartLayout) {
-                                        is RequestedChartLayout.Portrait -> {
-                                            Modifier
-                                                .fillMaxWidth()
-                                                .aspectRatio(4 / 3f)
-                                        }
-
-                                        is RequestedChartLayout.LandScape -> {
-                                            Modifier
-                                                .fillMaxWidth()
-                                                .height(uiState.requestedChartLayout.requestedMaxHeight)
-                                        }
-                                    }
-
-                                    VerticalBarChart(
-                                        modifier = constraintModifier.padding(all = dimension.grid_2),
-                                        showToolTipOnClick = uiState.showToolTipOnClick,
-                                        entries = barChartData.verticalBarPlotEntries,
-                                        yAxisRange = uiState.rateRange,
-                                        yAxisTitle = stringResource(resource = Res.string.agile_vat_unit_rate),
-                                        labelGenerator = { index ->
-                                            barChartData.labels[index]
-                                        },
-                                        tooltipGenerator = { index ->
-                                            barChartData.tooltips[index]
-                                        },
-                                        colorPalette = colorPalette,
-                                        backgroundPlot = { graphScope ->
-                                            if (uiState.isOnDifferentTariff() &&
-                                                uiState.userProfile?.tariffSummary != null
-                                            ) {
-                                                graphScope.HorizontalLineAnnotation(
-                                                    location = uiState.userProfile.tariffSummary.vatInclusiveUnitRate,
-                                                    lineStyle = LineStyle(
-                                                        brush = SolidColor(MaterialTheme.colorScheme.error),
-                                                        strokeWidth = dimension.grid_0_5,
-                                                        pathEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 4f), 0f),
-                                                        alpha = 0.5f,
-                                                        colorFilter = null, // No color filter
-                                                        blendMode = DrawScope.DefaultBlendMode,
-                                                    ),
-                                                )
-                                            }
-                                        },
+                        LazyColumn(
+                            contentPadding = PaddingValues(bottom = dimension.grid_4),
+                            state = lazyListState,
+                        ) {
+                            if (uiState.isDemoMode == true) {
+                                item(key = "demoCta") {
+                                    DemoModeCtaAdaptive(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(all = dimension.grid_2),
+                                        description = stringResource(resource = Res.string.agile_demo_introduction),
+                                        ctaButtonLabel = stringResource(resource = Res.string.provide_api_key),
+                                        onCtaButtonClicked = uiEvent.onNavigateToAccountTab,
+                                        useWideLayout = uiState.requestedAdaptiveLayout != WindowWidthSizeClass.Compact,
                                     )
                                 }
                             }
-                        }
 
-                        item(key = "tariffDetails") {
-                            AgileTariffCardAdaptive(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(
-                                        start = dimension.grid_3,
-                                        end = dimension.grid_3,
-                                        top = dimension.grid_1,
-                                    ),
-                                agileTariffSummary = uiState.agileTariffSummary,
-                                differentTariffSummary = uiState.userProfile?.tariffSummary,
-                                colorPalette = colorPalette,
-                                rateRange = uiState.rateRange,
-                                rateGroupedCells = uiState.rateGroupedCells,
-                                requestedAdaptiveLayout = uiState.requestedAdaptiveLayout,
-                            )
-                        }
+                            uiState.barChartData?.let { barChartData ->
+                                item(key = "chart") {
+                                    BoxWithConstraints(
+                                        modifier = Modifier.padding(top = dimension.grid_1),
+                                    ) {
+                                        val constraintModifier = when (uiState.requestedChartLayout) {
+                                            is RequestedChartLayout.Portrait -> {
+                                                Modifier
+                                                    .fillMaxWidth()
+                                                    .aspectRatio(4 / 3f)
+                                            }
 
-                        if (uiState.rateGroupedCells.isNotEmpty()) {
-                            item(key = "headingUnitRateDetails") {
-                                Spacer(modifier = Modifier.height(height = dimension.grid_1))
+                                            is RequestedChartLayout.LandScape -> {
+                                                Modifier
+                                                    .fillMaxWidth()
+                                                    .height(uiState.requestedChartLayout.requestedMaxHeight)
+                                            }
+                                        }
 
-                                LargeTitleWithIcon(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(all = dimension.grid_2),
-                                    icon = painterResource(resource = Res.drawable.revenue),
-                                    label = stringResource(resource = Res.string.agile_unit_rate_details),
-                                )
+                                        VerticalBarChart(
+                                            modifier = constraintModifier.padding(all = dimension.grid_2),
+                                            showToolTipOnClick = uiState.showToolTipOnClick,
+                                            entries = barChartData.verticalBarPlotEntries,
+                                            yAxisRange = uiState.rateRange,
+                                            yAxisTitle = stringResource(resource = Res.string.agile_vat_unit_rate),
+                                            labelGenerator = { index ->
+                                                barChartData.labels[index]
+                                            },
+                                            tooltipGenerator = { index ->
+                                                barChartData.tooltips[index]
+                                            },
+                                            colorPalette = colorPalette,
+                                            backgroundPlot = { graphScope ->
+                                                if (uiState.isOnDifferentTariff() &&
+                                                    uiState.userProfile?.tariffSummary != null
+                                                ) {
+                                                    graphScope.HorizontalLineAnnotation(
+                                                        location = uiState.userProfile.tariffSummary.vatInclusiveUnitRate,
+                                                        lineStyle = LineStyle(
+                                                            brush = SolidColor(MaterialTheme.colorScheme.error),
+                                                            strokeWidth = dimension.grid_0_5,
+                                                            pathEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 4f), 0f),
+                                                            alpha = 0.5f,
+                                                            colorFilter = null, // No color filter
+                                                            blendMode = DrawScope.DefaultBlendMode,
+                                                        ),
+                                                    )
+                                                }
+                                            },
+                                        )
+                                    }
+                                }
                             }
-                        }
 
-                        uiState.rateGroupedCells.forEach { rateGroup ->
-                            item(key = "${rateGroup.title}Title") {
-                                RateGroupTitle(
+                            item(key = "tariffDetails") {
+                                AgileTariffCardAdaptive(
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .padding(
-                                            vertical = dimension.grid_2,
-                                            horizontal = dimension.grid_4,
+                                            start = dimension.grid_3,
+                                            end = dimension.grid_3,
+                                            top = dimension.grid_1,
                                         ),
-                                    title = rateGroup.title,
-                                )
-                            }
-
-                            // We can do fancier grouping, but for now evenly-distributed is ok
-                            val partitionedItems = rateGroup.rates.partitionList(columns = uiState.requestedRateColumns)
-                            val maxRows = partitionedItems.maxOf { it.size }
-
-                            items(maxRows) { rowIndex ->
-                                RateGroupCells(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(
-                                            horizontal = dimension.grid_4,
-                                            vertical = dimension.grid_0_25,
-                                        ),
-                                    partitionedItems = partitionedItems,
-                                    maxInRange = uiState.rateRange.endInclusive,
-                                    rowIndex = rowIndex,
+                                    agileTariffSummary = uiState.agileTariffSummary,
+                                    differentTariffSummary = uiState.userProfile?.tariffSummary,
                                     colorPalette = colorPalette,
+                                    rateRange = uiState.rateRange,
+                                    rateGroupedCells = uiState.rateGroupedCells,
+                                    requestedAdaptiveLayout = uiState.requestedAdaptiveLayout,
                                 )
+                            }
+
+                            if (uiState.rateGroupedCells.isNotEmpty()) {
+                                item(key = "headingUnitRateDetails") {
+                                    Spacer(modifier = Modifier.height(height = dimension.grid_1))
+
+                                    LargeTitleWithIcon(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(all = dimension.grid_2),
+                                        icon = painterResource(resource = Res.drawable.revenue),
+                                        label = stringResource(resource = Res.string.agile_unit_rate_details),
+                                    )
+                                }
+                            }
+
+                            uiState.rateGroupedCells.forEach { rateGroup ->
+                                item(key = "${rateGroup.title}Title") {
+                                    RateGroupTitle(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(
+                                                vertical = dimension.grid_2,
+                                                horizontal = dimension.grid_4,
+                                            ),
+                                        title = rateGroup.title,
+                                    )
+                                }
+
+                                // We can do fancier grouping, but for now evenly-distributed is ok
+                                val partitionedItems = rateGroup.rates.partitionList(columns = uiState.requestedRateColumns)
+                                val maxRows = partitionedItems.maxOf { it.size }
+
+                                items(maxRows) { rowIndex ->
+                                    RateGroupCells(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(
+                                                horizontal = dimension.grid_4,
+                                                vertical = dimension.grid_0_25,
+                                            ),
+                                        partitionedItems = partitionedItems,
+                                        maxInRange = uiState.rateRange.endInclusive,
+                                        rowIndex = rowIndex,
+                                        colorPalette = colorPalette,
+                                    )
+                                }
                             }
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -7,7 +7,6 @@
 
 package com.rwmobi.kunigami.ui.destinations.agile
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -64,7 +63,6 @@ import kunigami.composeapp.generated.resources.unknown
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun AgileScreen(
     modifier: Modifier = Modifier,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffsScreen.kt
@@ -7,10 +7,10 @@
 
 package com.rwmobi.kunigami.ui.destinations.tariffs
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -52,7 +52,7 @@ import kunigami.composeapp.generated.resources.navigation_tariffs
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
-@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TariffsScreen(
     modifier: Modifier = Modifier,
@@ -92,38 +92,39 @@ fun TariffsScreen(
                         modifier = Modifier.weight(weight = 1f),
                         lazyListState = mainLazyListState,
                     ) { contentModifier ->
-                        LazyColumn(
+                        Column(
                             modifier = contentModifier.fillMaxSize(),
-                            state = mainLazyListState,
                         ) {
-                            stickyHeader {
-                                DualTitleBar(
-                                    modifier = Modifier
-                                        .background(color = MaterialTheme.colorScheme.secondary)
-                                        .fillMaxWidth()
-                                        .height(height = dimension.minListItemHeight),
-                                    title = stringResource(resource = Res.string.navigation_tariffs),
-                                )
-                            }
+                            DualTitleBar(
+                                modifier = Modifier
+                                    .background(color = MaterialTheme.colorScheme.secondary)
+                                    .fillMaxWidth()
+                                    .height(height = dimension.minListItemHeight),
+                                title = stringResource(resource = Res.string.navigation_tariffs),
+                            )
 
-                            itemsIndexed(
-                                items = uiState.productSummaries,
-                                key = { _, product -> product.code },
-                            ) { index, product ->
-                                ProductItemAdaptive(
-                                    modifier = Modifier
-                                        .clickable(onClick = { uiEvent.onProductItemClick(product.code) })
-                                        .fillMaxWidth()
-                                        .padding(vertical = dimension.grid_1),
-                                    productSummary = product,
-                                    useWideLayout = uiState.requestedWideListLayout,
-                                )
-
-                                if (index < uiState.productSummaries.lastIndex) {
-                                    HorizontalDivider(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                            LazyColumn(
+                                state = mainLazyListState,
+                            ) {
+                                itemsIndexed(
+                                    items = uiState.productSummaries,
+                                    key = { _, product -> product.code },
+                                ) { index, product ->
+                                    ProductItemAdaptive(
+                                        modifier = Modifier
+                                            .clickable(onClick = { uiEvent.onProductItemClick(product.code) })
+                                            .fillMaxWidth()
+                                            .padding(vertical = dimension.grid_1),
+                                        productSummary = product,
+                                        useWideLayout = uiState.requestedWideListLayout,
                                     )
+
+                                    if (index < uiState.productSummaries.lastIndex) {
+                                        HorizontalDivider(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                                        )
+                                    }
                                 }
                             }
                         }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/DetailsScreenWrapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/DetailsScreenWrapper.kt
@@ -7,7 +7,7 @@
 
 package com.rwmobi.kunigami.ui.destinations.tariffs.components
 
-import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -20,7 +20,6 @@ import com.rwmobi.kunigami.domain.model.product.ProductDetails
 import com.rwmobi.kunigami.ui.components.ScrollbarMultiplatform
 import com.rwmobi.kunigami.ui.theme.getDimension
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun DetailsScreenWrapper(
     modifier: Modifier,
@@ -34,21 +33,22 @@ internal fun DetailsScreenWrapper(
         modifier = modifier,
         lazyListState = detailLazyListState,
     ) { contentModifier ->
-        LazyColumn(
+        Column(
             modifier = contentModifier.fillMaxSize(),
-            state = detailLazyListState,
         ) {
-            productDetails?.let { product ->
-                stickyHeader {
-                    header()
-                }
+            header()
 
-                productDetailsLayout(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = dimension.grid_1),
-                    productDetails = product,
-                )
+            LazyColumn(
+                state = detailLazyListState,
+            ) {
+                productDetails?.let { product ->
+                    productDetailsLayout(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = dimension.grid_1),
+                        productDetails = product,
+                    )
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
@@ -7,7 +7,6 @@
 
 package com.rwmobi.kunigami.ui.destinations.usage
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -140,13 +139,15 @@ fun UsageScreen(
                             }
 
                             if (uiState.consumptionGroupedCells.isEmpty()) {
-                                item(key = "noData") {
-                                    MessageActionScreen(
-                                        modifier = Modifier.fillMaxSize(),
-                                        icon = painterResource(resource = Res.drawable.file_dotted),
-                                        text = stringResource(resource = Res.string.error_screen_no_data_title),
-                                        description = stringResource(resource = Res.string.error_screen_no_data_description_no_auth),
-                                    )
+                                if (!uiState.isLoading) {
+                                    item(key = "noData") {
+                                        MessageActionScreen(
+                                            modifier = Modifier.fillMaxSize(),
+                                            icon = painterResource(resource = Res.drawable.file_dotted),
+                                            text = stringResource(resource = Res.string.error_screen_no_data_title),
+                                            description = stringResource(resource = Res.string.error_screen_no_data_description_no_auth),
+                                        )
+                                    }
                                 }
                             } else {
                                 uiState.barChartData?.let { barChartData ->

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -55,7 +56,6 @@ import kunigami.composeapp.generated.resources.usage_energy_consumption_breakdow
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun UsageScreen(
     modifier: Modifier = Modifier,
@@ -100,146 +100,147 @@ fun UsageScreen(
                     enabled = uiState.consumptionGroupedCells.isNotEmpty(),
                     lazyListState = lazyListState,
                 ) { contentModifier ->
-                    LazyColumn(
+                    Column(
                         modifier = contentModifier
                             .fillMaxSize()
                             .conditionalBlur(enabled = uiState.isLoading),
-                        contentPadding = PaddingValues(bottom = dimension.grid_4),
-                        state = lazyListState,
                     ) {
-                        stickyHeader {
-                            with(uiState.consumptionQueryFilter) {
-                                TitleNavigationBar(
-                                    modifier = Modifier
-                                        .background(color = MaterialTheme.colorScheme.secondary)
-                                        .fillMaxWidth()
-                                        .height(height = dimension.minListItemHeight),
-                                    currentPresentationStyle = uiState.consumptionQueryFilter.presentationStyle,
-                                    title = getConsumptionPeriodString(),
-                                    canNavigateBack = uiState.consumptionQueryFilter.canNavigateBackward(accountMoveInDate = uiState.userProfile?.account?.movedInAt ?: Instant.DISTANT_PAST),
-                                    canNavigateForward = uiState.consumptionQueryFilter.canNavigateForward(),
-                                    onNavigateBack = uiEvent.onPreviousTimeFrame,
-                                    onNavigateForward = uiEvent.onNextTimeFrame,
-                                    onSwitchPresentationStyle = { uiEvent.onSwitchPresentationStyle(it) },
-                                )
-                            }
+                        with(uiState.consumptionQueryFilter) {
+                            TitleNavigationBar(
+                                modifier = Modifier
+                                    .background(color = MaterialTheme.colorScheme.secondary)
+                                    .fillMaxWidth()
+                                    .height(height = dimension.minListItemHeight),
+                                currentPresentationStyle = presentationStyle,
+                                title = getConsumptionPeriodString(),
+                                canNavigateBack = canNavigateBackward(accountMoveInDate = uiState.userProfile?.account?.movedInAt ?: Instant.DISTANT_PAST),
+                                canNavigateForward = canNavigateForward(),
+                                onNavigateBack = uiEvent.onPreviousTimeFrame,
+                                onNavigateForward = uiEvent.onNextTimeFrame,
+                                onSwitchPresentationStyle = { uiEvent.onSwitchPresentationStyle(it) },
+                            )
                         }
 
-                        if (uiState.isDemoMode == true) {
-                            item(key = "demoCta") {
-                                DemoModeCtaAdaptive(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(all = dimension.grid_2),
-                                    description = stringResource(resource = Res.string.usage_demo_introduction),
-                                    ctaButtonLabel = stringResource(resource = Res.string.provide_api_key),
-                                    onCtaButtonClicked = uiEvent.onNavigateToAccountTab,
-                                    useWideLayout = uiState.requestedAdaptiveLayout != WindowWidthSizeClass.Compact,
-                                )
+                        LazyColumn(
+                            contentPadding = PaddingValues(bottom = dimension.grid_4),
+                            state = lazyListState,
+                        ) {
+                            if (uiState.isDemoMode == true) {
+                                item(key = "demoCta") {
+                                    DemoModeCtaAdaptive(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(all = dimension.grid_2),
+                                        description = stringResource(resource = Res.string.usage_demo_introduction),
+                                        ctaButtonLabel = stringResource(resource = Res.string.provide_api_key),
+                                        onCtaButtonClicked = uiEvent.onNavigateToAccountTab,
+                                        useWideLayout = uiState.requestedAdaptiveLayout != WindowWidthSizeClass.Compact,
+                                    )
+                                }
                             }
-                        }
 
-                        if (uiState.consumptionGroupedCells.isEmpty()) {
-                            item(key = "noData") {
-                                MessageActionScreen(
-                                    modifier = Modifier.fillMaxSize(),
-                                    icon = painterResource(resource = Res.drawable.file_dotted),
-                                    text = stringResource(resource = Res.string.error_screen_no_data_title),
-                                    description = stringResource(resource = Res.string.error_screen_no_data_description_no_auth),
-                                )
-                            }
-                        } else {
-                            uiState.barChartData?.let { barChartData ->
-                                item(key = "chart") {
-                                    BoxWithConstraints {
-                                        val constraintModifier = when (uiState.requestedChartLayout) {
-                                            is RequestedChartLayout.Portrait -> {
-                                                Modifier
-                                                    .fillMaxWidth()
-                                                    .aspectRatio(4 / 3f)
+                            if (uiState.consumptionGroupedCells.isEmpty()) {
+                                item(key = "noData") {
+                                    MessageActionScreen(
+                                        modifier = Modifier.fillMaxSize(),
+                                        icon = painterResource(resource = Res.drawable.file_dotted),
+                                        text = stringResource(resource = Res.string.error_screen_no_data_title),
+                                        description = stringResource(resource = Res.string.error_screen_no_data_description_no_auth),
+                                    )
+                                }
+                            } else {
+                                uiState.barChartData?.let { barChartData ->
+                                    item(key = "chart") {
+                                        BoxWithConstraints {
+                                            val constraintModifier = when (uiState.requestedChartLayout) {
+                                                is RequestedChartLayout.Portrait -> {
+                                                    Modifier
+                                                        .fillMaxWidth()
+                                                        .aspectRatio(4 / 3f)
+                                                }
+
+                                                is RequestedChartLayout.LandScape -> {
+                                                    Modifier
+                                                        .fillMaxWidth()
+                                                        .height(uiState.requestedChartLayout.requestedMaxHeight)
+                                                }
                                             }
 
-                                            is RequestedChartLayout.LandScape -> {
-                                                Modifier
-                                                    .fillMaxWidth()
-                                                    .height(uiState.requestedChartLayout.requestedMaxHeight)
-                                            }
+                                            VerticalBarChart(
+                                                modifier = constraintModifier.padding(all = dimension.grid_2),
+                                                showToolTipOnClick = uiState.showToolTipOnClick,
+                                                entries = barChartData.verticalBarPlotEntries,
+                                                yAxisRange = uiState.consumptionRange,
+                                                yAxisTitle = stringResource(resource = Res.string.kwh),
+                                                colorPalette = colorPalette,
+                                                labelGenerator = { index ->
+                                                    barChartData.labels[index]
+                                                },
+                                                tooltipGenerator = { index ->
+                                                    barChartData.tooltips[index]
+                                                },
+                                            )
                                         }
-
-                                        VerticalBarChart(
-                                            modifier = constraintModifier.padding(all = dimension.grid_2),
-                                            showToolTipOnClick = uiState.showToolTipOnClick,
-                                            entries = barChartData.verticalBarPlotEntries,
-                                            yAxisRange = uiState.consumptionRange,
-                                            yAxisTitle = stringResource(resource = Res.string.kwh),
-                                            colorPalette = colorPalette,
-                                            labelGenerator = { index ->
-                                                barChartData.labels[index]
-                                            },
-                                            tooltipGenerator = { index ->
-                                                barChartData.tooltips[index]
-                                            },
-                                        )
                                     }
                                 }
-                            }
 
-                            item(key = "tariffAndProjections") {
-                                TariffProjectionsCardAdaptive(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(
-                                            horizontal = dimension.grid_3,
-                                            vertical = dimension.grid_1,
-                                        ),
-                                    layoutType = uiState.requestedAdaptiveLayout,
-                                    tariffSummary = uiState.userProfile?.tariffSummary,
-                                    insights = uiState.insights,
-                                    mpan = uiState.userProfile?.selectedMpan,
-                                )
-                            }
-
-                            item(key = "headingConsumptionBreakdowns") {
-                                LargeTitleWithIcon(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(all = dimension.grid_2),
-                                    icon = painterResource(resource = Res.drawable.bolt),
-                                    label = stringResource(resource = Res.string.usage_energy_consumption_breakdown),
-                                )
-                            }
-
-                            uiState.consumptionGroupedCells.forEach { consumptionGroup ->
-                                item(key = "${consumptionGroup.title}Title") {
-                                    RateGroupTitle(
+                                item(key = "tariffAndProjections") {
+                                    TariffProjectionsCardAdaptive(
                                         modifier = Modifier
                                             .fillMaxWidth()
                                             .padding(
-                                                vertical = dimension.grid_2,
-                                                horizontal = dimension.grid_4,
+                                                horizontal = dimension.grid_3,
+                                                vertical = dimension.grid_1,
                                             ),
-                                        consumptionGroup = consumptionGroup,
+                                        layoutType = uiState.requestedAdaptiveLayout,
+                                        tariffSummary = uiState.userProfile?.tariffSummary,
+                                        insights = uiState.insights,
+                                        mpan = uiState.userProfile?.selectedMpan,
                                     )
                                 }
 
-                                // We can do fancier grouping, but for now evenly-distributed is ok
-                                val partitionedItems = consumptionGroup.consumptions.partitionList(columns = uiState.requestedUsageColumns)
-                                val maxRows = partitionedItems.maxOf { it.size }
-
-                                items(maxRows) { rowIndex ->
-                                    RateGroupCells(
+                                item(key = "headingConsumptionBreakdowns") {
+                                    LargeTitleWithIcon(
                                         modifier = Modifier
                                             .fillMaxWidth()
-                                            .padding(
-                                                horizontal = dimension.grid_4,
-                                                vertical = dimension.grid_0_25,
-                                            ),
-                                        partitionedItems = partitionedItems,
-                                        rowIndex = rowIndex,
-                                        maxInRange = uiState.consumptionRange.endInclusive,
-                                        presentationStyle = uiState.consumptionQueryFilter.presentationStyle,
-                                        colorPalette = colorPalette,
+                                            .padding(all = dimension.grid_2),
+                                        icon = painterResource(resource = Res.drawable.bolt),
+                                        label = stringResource(resource = Res.string.usage_energy_consumption_breakdown),
                                     )
+                                }
+
+                                uiState.consumptionGroupedCells.forEach { consumptionGroup ->
+                                    item(key = "${consumptionGroup.title}Title") {
+                                        RateGroupTitle(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(
+                                                    vertical = dimension.grid_2,
+                                                    horizontal = dimension.grid_4,
+                                                ),
+                                            consumptionGroup = consumptionGroup,
+                                        )
+                                    }
+
+                                    // We can do fancier grouping, but for now evenly-distributed is ok
+                                    val partitionedItems = consumptionGroup.consumptions.partitionList(columns = uiState.requestedUsageColumns)
+                                    val maxRows = partitionedItems.maxOf { it.size }
+
+                                    items(maxRows) { rowIndex ->
+                                        RateGroupCells(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(
+                                                    horizontal = dimension.grid_4,
+                                                    vertical = dimension.grid_0_25,
+                                                ),
+                                            partitionedItems = partitionedItems,
+                                            rowIndex = rowIndex,
+                                            maxInRange = uiState.consumptionRange.endInclusive,
+                                            presentationStyle = uiState.consumptionQueryFilter.presentationStyle,
+                                            colorPalette = colorPalette,
+                                        )
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Since the elastic behaviour for sticky header on iOS make it very awkward, we moved it out from the LazyColumn so it is now fixed on the screen.

Also fixed usage screen and account screen not to show no data screen while initial loading.
