### PR TITLE
(#153) improve tariff details screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### Production-grade Kotlin Multiplatform App targeting Android, iOS, Desktop
 
 <br />
-<p><img src="app_banner_240518.webp" style="width: 100%; max-width: 1000px; height: auto;" alt="cover image" style="width: 100%; max-width: 1000px; height: auto;"></p>
+<p align="center"><img src="app_banner_240518.webp" style="width: 100%; max-width: 1000px; height: auto;" alt="cover image" style="width: 100%; max-width: 1000px; height: auto;"></p>
 <br />
 
 ### Made in the UK, For the UK.
@@ -12,7 +12,7 @@ Complementary article: [Releasing my First True Kotlin Multiplatform App](https:
 
 This app is designed for Octopus Energy customers in the UK who have a smart meter installed. If you don’t have a smart meter, you can still try out the app. It runs in demo mode by default, showing fake user data when authentication is required.
 
-<p><img src="screenshots/240531_all_platforms_preview.webp" style="width: 100%; max-width: 1000px; height: auto;" alt="cover image" style="width: 100%; max-width: 1000px; height: auto;"></p>
+<p align="center"><img src="screenshots/240531_all_platforms_preview.webp" style="width: 100%; max-width: 1000px; height: auto;" alt="cover image" style="width: 100%; max-width: 1000px; height: auto;"></p>
 
 ### It works for me
 
@@ -29,7 +29,7 @@ The main purposes of this app are:
 For non-Octopus Energy customers, or non-UK residents, the demo mode will display random meter readings and default tariff rates to illustrate the app’s functionality.
 
 <br />
-<p><img src="https://github.com/ryanw-mobile/OctoMeter/blob/main/screenshots/240603_agile_animation.gif" style="width: 100%; max-width: 1000px; height: auto;" alt="cover image" style="width: 100%; max-width: 1000px; height: auto;"></p>
+<p align="center"><img src="https://github.com/ryanw-mobile/OctoMeter/blob/main/screenshots/240603_agile_animation.gif" style="width: 100%; max-width: 1000px; height: auto;" alt="cover image" style="width: 100%; max-width: 1000px; height: auto;"></p>
 <br />
 
 The current release meets my daily needs. However, this project will continue to be maintained and improved as a way for me to gain real-world Kotlin Multiplatform development experience. For this reason, the app was intentionally built to reach production-level quality as much as possible.

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountInformationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountInformationScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.domain.extensions.toLocalDateString
-import com.rwmobi.kunigami.domain.model.account.Account
 import com.rwmobi.kunigami.domain.model.account.UserProfile
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.components.MessageActionScreen
@@ -224,7 +223,7 @@ private fun ErrorPreview() {
             modifier = Modifier.padding(all = 32.dp),
             uiState = AccountUIState(
                 isLoading = false,
-                requestedScreenType = AccountScreenType.ErrorScreen(specialErrorScreen = SpecialErrorScreen.NetworkError),
+                requestedScreenType = AccountScreenType.Error(specialErrorScreen = SpecialErrorScreen.NetworkError),
                 requestedLayout = AccountScreenLayout.WideWrapped,
                 userProfile = UserProfile(
                     selectedMpan = "1200000345678",

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountScreen.kt
@@ -50,7 +50,7 @@ fun AccountScreen(
     val lazyListState = rememberLazyListState()
 
     Box(modifier = modifier) {
-        if (uiState.requestedScreenType is AccountScreenType.ErrorScreen) {
+        if (uiState.requestedScreenType is AccountScreenType.Error) {
             ErrorScreenHandler(
                 modifier = Modifier.fillMaxSize(),
                 specialErrorScreen = uiState.requestedScreenType.specialErrorScreen,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountScreenType.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountScreenType.kt
@@ -10,7 +10,7 @@ package com.rwmobi.kunigami.ui.destinations.account
 import com.rwmobi.kunigami.ui.model.SpecialErrorScreen
 
 sealed interface AccountScreenType {
-    data class ErrorScreen(val specialErrorScreen: SpecialErrorScreen) : AccountScreenType
+    data class Error(val specialErrorScreen: SpecialErrorScreen) : AccountScreenType
     data object Onboarding : AccountScreenType
     data object Account : AccountScreenType
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountUIState.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountUIState.kt
@@ -59,12 +59,12 @@ data class AccountUIState(
             }
 
             else -> {
-                updateUIForErrorAndStopLoading(message = throwable.message ?: getString(resource = Res.string.tariffs_error_load_tariffs))
+                handleErrorAndStopLoading(message = throwable.message ?: getString(resource = Res.string.tariffs_error_load_tariffs))
             }
         }
     }
 
-    fun updateUIForErrorAndStopLoading(message: String): AccountUIState {
+    fun handleErrorAndStopLoading(message: String): AccountUIState {
         val newErrorMessages = if (errorMessages.any { it.message == message }) {
             errorMessages
         } else {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountUIState.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountUIState.kt
@@ -46,14 +46,14 @@ data class AccountUIState(
         return when (val translatedThrowable = throwable.mapFromPlatform()) {
             is HttpException -> {
                 copy(
-                    requestedScreenType = AccountScreenType.ErrorScreen(SpecialErrorScreen.HttpError(statusCode = translatedThrowable.httpStatusCode)),
+                    requestedScreenType = AccountScreenType.Error(SpecialErrorScreen.HttpError(statusCode = translatedThrowable.httpStatusCode)),
                     isLoading = false,
                 )
             }
 
             is UnresolvedAddressException -> {
                 copy(
-                    requestedScreenType = AccountScreenType.ErrorScreen(SpecialErrorScreen.NetworkError),
+                    requestedScreenType = AccountScreenType.Error(SpecialErrorScreen.NetworkError),
                     isLoading = false,
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductDetails.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductDetails.kt
@@ -9,7 +9,8 @@ package com.rwmobi.kunigami.ui.destinations.tariffs.components
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
@@ -22,6 +23,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalDensity
 import com.rwmobi.kunigami.domain.model.product.ElectricityTariffType
 import com.rwmobi.kunigami.domain.model.product.ProductDetails
@@ -37,38 +39,31 @@ internal fun LazyListScope.productDetailsLayout(
 ) {
     item(key = "productFacts") {
         val dimension = LocalDensity.current.getDimension()
-        Box(
+        Column(
             modifier = modifier,
-            contentAlignment = Alignment.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(space = dimension.grid_2),
         ) {
             ProductFacts(
                 modifier = Modifier.widthIn(max = dimension.windowWidthCompact),
                 productDetails = productDetails,
             )
-        }
-    }
 
-    if (!productDetails.electricityTariffs.isNullOrEmpty()) {
-        item(key = "retailRegions") {
-            val dimension = LocalDensity.current.getDimension()
-            var selectedRegion by remember { mutableStateOf("_A") }
+            if (!productDetails.electricityTariffs.isNullOrEmpty()) {
+                var selectedRegion by remember { mutableStateOf("_A") }
+                RegionSelectionBar(
+                    modifier = Modifier
+                        .padding(horizontal = dimension.grid_1)
+                        .widthIn(max = dimension.windowWidthCompact)
+                        .clip(shape = MaterialTheme.shapes.extraLarge)
+                        .background(color = MaterialTheme.colorScheme.surfaceContainerHighest),
+//                        .padding(horizontal = dimension.grid_2, vertical = dimension.grid_0_5),
+                    electricityTariffs = productDetails.electricityTariffs,
+                    selectedRegion = selectedRegion,
+                    onRegionSelected = { key -> selectedRegion = key },
+                )
 
-            RegionSelectionBar(
-                modifier = Modifier
-                    .padding(vertical = dimension.grid_2)
-                    .fillMaxWidth()
-                    .background(color = MaterialTheme.colorScheme.surfaceContainerHighest)
-                    .padding(all = dimension.grid_2),
-                electricityTariffs = productDetails.electricityTariffs,
-                selectedRegion = selectedRegion,
-                onRegionSelected = { key -> selectedRegion = key },
-            )
-
-            productDetails.electricityTariffs[selectedRegion]?.let { tariffDetails ->
-                Box(
-                    modifier = modifier,
-                    contentAlignment = Alignment.Center,
-                ) {
+                productDetails.electricityTariffs[selectedRegion]?.let { tariffDetails ->
                     RegionTariffDetails(
                         modifier = Modifier
                             .widthIn(max = dimension.windowWidthCompact)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/RegionSelectionBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/RegionSelectionBar.kt
@@ -7,17 +7,24 @@
 
 package com.rwmobi.kunigami.ui.destinations.tariffs.components
 
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
+import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -26,6 +33,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import com.rwmobi.kunigami.domain.model.product.TariffDetails
 import com.rwmobi.kunigami.ui.theme.getDimension
+import kotlinx.coroutines.launch
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.tariffs_retail_region
 import org.jetbrains.compose.resources.stringResource
@@ -43,10 +51,11 @@ internal fun RegionSelectionBar(
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_2),
     ) {
         Text(
-            modifier = Modifier.wrapContentSize(),
+            modifier = Modifier
+                .wrapContentSize()
+                .padding(horizontal = dimension.grid_2),
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurface,
@@ -54,23 +63,37 @@ internal fun RegionSelectionBar(
             text = stringResource(resource = Res.string.tariffs_retail_region),
         )
 
-        FlowRow(
-            modifier = Modifier.weight(1f),
-            horizontalArrangement = Arrangement.Start,
-            verticalArrangement = Arrangement.Center,
+        // On desktop, LazyRow needs a special treatment to support dragging to scroll
+        val scrollState = rememberLazyListState()
+        val coroutineScope = rememberCoroutineScope()
+        LazyRow(
+            modifier = Modifier
+                .weight(1f)
+                .draggable(
+                    orientation = Orientation.Horizontal,
+                    state = rememberDraggableState { delta ->
+                        coroutineScope.launch {
+                            scrollState.scrollBy(-delta)
+                        }
+                    },
+                ),
+            contentPadding = PaddingValues(end = dimension.grid_2),
+            state = scrollState,
         ) {
             electricityTariffs.keys.forEach { key ->
-                Button(
-                    onClick = { if (key != selectedRegion) onRegionSelected(key) },
-                    colors = ButtonDefaults.buttonColors().copy(
-                        containerColor = if (key == selectedRegion) MaterialTheme.colorScheme.primary else Color.Transparent,
-                        contentColor = if (key == selectedRegion) contentColorFor(MaterialTheme.colorScheme.primary) else MaterialTheme.colorScheme.onSurface,
-                    ),
-                ) {
-                    Text(
-                        style = MaterialTheme.typography.labelMedium,
-                        text = key.replace(oldValue = "_", newValue = ""),
-                    )
+                item(key = key) {
+                    Button(
+                        onClick = { if (key != selectedRegion) onRegionSelected(key) },
+                        colors = ButtonDefaults.buttonColors().copy(
+                            containerColor = if (key == selectedRegion) MaterialTheme.colorScheme.primary else Color.Transparent,
+                            contentColor = if (key == selectedRegion) contentColorFor(MaterialTheme.colorScheme.primary) else MaterialTheme.colorScheme.onSurface,
+                        ),
+                    ) {
+                        Text(
+                            style = MaterialTheme.typography.labelMedium,
+                            text = key.replace(oldValue = "_", newValue = ""),
+                        )
+                    }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/RegionTariffDetails.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/RegionTariffDetails.kt
@@ -59,6 +59,7 @@ internal fun RegionTariffDetails(
                 modifier = Modifier.fillMaxWidth(),
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.secondary,
                 text = tariffCode,
             )
 

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AccountViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AccountViewModel.kt
@@ -106,7 +106,7 @@ class AccountViewModel(
                     // There is no retry for this case.
                     Logger.e(getString(resource = Res.string.account_error_update_credentials), throwable = throwable, tag = "AccountViewModel")
                     _uiState.update { currentUiState ->
-                        currentUiState.updateUIForErrorAndStopLoading(message = getString(resource = Res.string.account_error_update_credentials))
+                        currentUiState.handleErrorAndStopLoading(message = getString(resource = Res.string.account_error_update_credentials))
                     }
                 },
             )


### PR DESCRIPTION
The tariff details screen was done in a rush (as a low-priority item).

A bit of layout fine-tuning was done in this ticket so that the retail region selection is now shown using a LazyRow rather than listing them out in plain, which takes almost one-third of the screen space.

Also some code refactoring was done to make naming consistent as we spotted it.

<img src="https://github.com/ryanw-mobile/OctoMeter/assets/22452240/1514cf5f-55f7-4b76-b4be-41a2e5d91497" alt="Screenshot" width="300"/>