### PR TITLE
(#147) Kotlinx.datetime usage refactoring and add BST unit tests

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -22,6 +22,9 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Set timezone
+        run: echo "TZ=Europe/London" >> $GITHUB_ENV
+
       - name: set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/renovate_check.yml
+++ b/.github/workflows/renovate_check.yml
@@ -20,6 +20,9 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Set timezone
+        run: echo "TZ=Europe/London" >> $GITHUB_ENV
+
       - name: set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/tag_create_release.yml
+++ b/.github/workflows/tag_create_release.yml
@@ -17,6 +17,9 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Set timezone
+        run: echo "TZ=Europe/London" >> $GITHUB_ENV
+
       - name: set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -304,7 +304,7 @@ configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
         reporter(ReporterType.SARIF)
     }
     filter {
-        exclude("BuildConfig.kt")
+        exclude("**/BuildConfig.kt")
         exclude("**/generated/**")
         include("**/kotlin/**")
     }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -313,6 +313,12 @@ configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
 tasks.named("preBuild") {
     dependsOn(tasks.named("ktlintFormat"))
 }
+
+tasks.withType<Test> {
+    // Set the timezone to 'Europe/London' for all tests
+    jvmArgs("-Duser.timezone=Europe/London")
+}
+
 dependencies {
     implementation(libs.androidx.profileinstaller)
     "baselineProfile"(project(":baselineprofile"))

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -304,6 +304,7 @@ configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
         reporter(ReporterType.SARIF)
     }
     filter {
+        exclude("BuildConfig.kt")
         exclude("**/generated/**")
         include("**/kotlin/**")
     }

--- a/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.android.kt
@@ -14,7 +14,7 @@ import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.Locale
 
-actual fun Instant.toLocalDateString(): String {
+actual fun Instant.getLocalDateString(): String {
     val localDate = toLocalDateTime(TimeZone.currentSystemDefault()).date
     val javaDate = java.time.LocalDate.of(localDate.year, localDate.monthNumber, localDate.dayOfMonth)
     val formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/ElectricityMeterPointsEndpoint.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/ElectricityMeterPointsEndpoint.kt
@@ -10,7 +10,7 @@ package com.rwmobi.kunigami.data.source.network
 import com.rwmobi.kunigami.data.source.network.dto.consumption.ConsumptionApiResponse
 import com.rwmobi.kunigami.data.source.network.extensions.encodeApiKey
 import com.rwmobi.kunigami.domain.exceptions.HttpException
-import com.rwmobi.kunigami.domain.extensions.formatInstantWithoutSeconds
+import com.rwmobi.kunigami.domain.extensions.toIso8601WithoutSeconds
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
@@ -47,8 +47,8 @@ class ElectricityMeterPointsEndpoint(
             val response = httpClient.get("$endpointUrl/$mpan/meters/$meterSerialNumber/consumption") {
                 header("Authorization", "Basic ${encodeApiKey(apiKey)}")
                 parameter("page_size", pageSize)
-                parameter("period_from", periodFrom?.formatInstantWithoutSeconds())
-                parameter("period_to", periodTo?.formatInstantWithoutSeconds())
+                parameter("period_from", periodFrom?.toIso8601WithoutSeconds())
+                parameter("period_to", periodTo?.toIso8601WithoutSeconds())
                 parameter("order_by", orderBy)
                 parameter("group_by", groupBy)
             }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/ProductsEndpoint.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/ProductsEndpoint.kt
@@ -11,7 +11,7 @@ import com.rwmobi.kunigami.data.source.network.dto.prices.PricesApiResponse
 import com.rwmobi.kunigami.data.source.network.dto.products.ProductsApiResponse
 import com.rwmobi.kunigami.data.source.network.dto.singleproduct.SingleProductApiResponse
 import com.rwmobi.kunigami.domain.exceptions.HttpException
-import com.rwmobi.kunigami.domain.extensions.formatInstantWithoutSeconds
+import com.rwmobi.kunigami.domain.extensions.toIso8601WithoutSeconds
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
@@ -95,8 +95,8 @@ class ProductsEndpoint(
     ): PricesApiResponse? {
         return withContext(dispatcher) {
             val response = httpClient.get("$endpointUrl/$productCode/electricity-tariffs/$tariffCode/standard-unit-rates") {
-                parameter("period_from", periodFrom?.formatInstantWithoutSeconds())
-                parameter("period_to", periodTo?.formatInstantWithoutSeconds())
+                parameter("period_from", periodFrom?.toIso8601WithoutSeconds())
+                parameter("period_to", periodTo?.toIso8601WithoutSeconds())
             }
 
             when (response.status) {
@@ -124,8 +124,8 @@ class ProductsEndpoint(
     ): PricesApiResponse? {
         return withContext(dispatcher) {
             val response = httpClient.get("$endpointUrl/$productCode/electricity-tariffs/$tariffCode/standing-charges") {
-                parameter("period_from", periodFrom?.formatInstantWithoutSeconds())
-                parameter("period_to", periodTo?.formatInstantWithoutSeconds())
+                parameter("period_from", periodFrom?.toIso8601WithoutSeconds())
+                parameter("period_to", periodTo?.toIso8601WithoutSeconds())
             }
 
             when (response.status) {
@@ -152,8 +152,8 @@ class ProductsEndpoint(
     ): PricesApiResponse? {
         return withContext(dispatcher) {
             val response = httpClient.get("$endpointUrl/$productCode/electricity-tariffs/$tariffCode/day-unit-rates") {
-                parameter("period_from", periodFrom?.formatInstantWithoutSeconds())
-                parameter("period_to", periodTo?.formatInstantWithoutSeconds())
+                parameter("period_from", periodFrom?.toIso8601WithoutSeconds())
+                parameter("period_to", periodTo?.toIso8601WithoutSeconds())
             }
 
             when (response.status) {
@@ -180,8 +180,8 @@ class ProductsEndpoint(
     ): PricesApiResponse? {
         return withContext(dispatcher) {
             val response = httpClient.get("$endpointUrl/$productCode/electricity-tariffs/$tariffCode/night-unit-rates") {
-                parameter("period_from", periodFrom?.formatInstantWithoutSeconds())
-                parameter("period_to", periodTo?.formatInstantWithoutSeconds())
+                parameter("period_from", periodFrom?.toIso8601WithoutSeconds())
+                parameter("period_to", periodTo?.toIso8601WithoutSeconds())
             }
 
             when (response.status) {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountInformationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountInformationScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.rwmobi.kunigami.domain.extensions.toLocalDateString
+import com.rwmobi.kunigami.domain.extensions.getLocalDateString
 import com.rwmobi.kunigami.domain.model.account.UserProfile
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.components.MessageActionScreen
@@ -127,14 +127,14 @@ internal fun AccountInformationScreen(
             uiState.userProfile.account.movedInAt?.let {
                 Text(
                     style = MaterialTheme.typography.bodyMedium,
-                    text = stringResource(resource = Res.string.account_moved_in, it.toLocalDateString()),
+                    text = stringResource(resource = Res.string.account_moved_in, it.getLocalDateString()),
                 )
             }
 
             uiState.userProfile.account.movedOutAt?.let {
                 Text(
                     style = MaterialTheme.typography.bodyMedium,
-                    text = stringResource(resource = Res.string.account_moved_out, it.toLocalDateString()),
+                    text = stringResource(resource = Res.string.account_moved_out, it.getLocalDateString()),
                 )
             }
 

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/TariffLayoutAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/TariffLayoutAdaptive.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import com.rwmobi.kunigami.domain.extensions.toLocalDateString
+import com.rwmobi.kunigami.domain.extensions.getLocalDateString
 import com.rwmobi.kunigami.domain.model.account.Agreement
 import com.rwmobi.kunigami.domain.model.product.TariffSummary
 import com.rwmobi.kunigami.ui.theme.getDimension
@@ -93,11 +93,11 @@ private fun TariffLayoutCompact(
         val tariffPeriod = agreement.validTo?.let {
             stringResource(
                 resource = Res.string.account_tariff_end_date,
-                it.toLocalDateString(),
+                it.getLocalDateString(),
             )
         } ?: stringResource(
             resource = Res.string.account_tariff_start_date,
-            agreement.validFrom.toLocalDateString(),
+            agreement.validFrom.getLocalDateString(),
         )
 
         Text(
@@ -190,11 +190,11 @@ private fun TariffLayoutWide(
             val tariffPeriod = agreement.validTo?.let {
                 stringResource(
                     resource = Res.string.account_tariff_end_date,
-                    it.toLocalDateString(),
+                    it.getLocalDateString(),
                 )
             } ?: stringResource(
                 resource = Res.string.account_tariff_start_date,
-                agreement.validFrom.toLocalDateString(),
+                agreement.validFrom.getLocalDateString(),
             )
 
             Text(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupCells.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupCells.kt
@@ -14,8 +14,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
+import com.rwmobi.kunigami.domain.extensions.getLocalHHMMString
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
-import com.rwmobi.kunigami.domain.extensions.toLocalHourMinuteString
 import com.rwmobi.kunigami.domain.model.rate.Rate
 import com.rwmobi.kunigami.ui.components.IndicatorTextValueGridItem
 import com.rwmobi.kunigami.ui.extensions.getPercentageColorIndex
@@ -43,7 +43,7 @@ internal fun RateGroupCells(
                     indicatorColor = colorPalette[
                         item.vatInclusivePrice.getPercentageColorIndex(maxValue = maxInRange),
                     ],
-                    label = item.validFrom.toLocalHourMinuteString(),
+                    label = item.validFrom.getLocalHHMMString(),
                     value = item.vatInclusivePrice.roundToTwoDecimalPlaces()
                         .toString(precision = 2),
                 )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductFacts.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductFacts.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Density
-import com.rwmobi.kunigami.domain.extensions.toLocalDateString
+import com.rwmobi.kunigami.domain.extensions.getLocalDateString
 import com.rwmobi.kunigami.domain.model.product.ProductDetails
 import com.rwmobi.kunigami.ui.components.TagWithIcon
 import com.rwmobi.kunigami.ui.theme.getDimension
@@ -76,9 +76,9 @@ internal fun ProductFacts(
 
         Spacer(modifier = Modifier.size(size = dimension.grid_1))
 
-        val availableFromDate = productDetails.availableFrom.toLocalDateString()
+        val availableFromDate = productDetails.availableFrom.getLocalDateString()
         val availableTo = productDetails.availableTo?.let {
-            stringResource(resource = Res.string.tariffs_available_to, it.toLocalDateString())
+            stringResource(resource = Res.string.tariffs_available_to, it.getLocalDateString())
         } ?: ""
 
         Text(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/RateGroupCells.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/RateGroupCells.kt
@@ -14,11 +14,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
-import com.rwmobi.kunigami.domain.extensions.toLocalDay
-import com.rwmobi.kunigami.domain.extensions.toLocalDayMonth
-import com.rwmobi.kunigami.domain.extensions.toLocalHourMinuteString
-import com.rwmobi.kunigami.domain.extensions.toLocalMonth
-import com.rwmobi.kunigami.domain.extensions.toLocalWeekdayDay
+import com.rwmobi.kunigami.domain.extensions.getLocalDayMonthString
+import com.rwmobi.kunigami.domain.extensions.getLocalDayOfMonth
+import com.rwmobi.kunigami.domain.extensions.getLocalDayOfWeekAndDayString
+import com.rwmobi.kunigami.domain.extensions.getLocalHHMMString
+import com.rwmobi.kunigami.domain.extensions.getLocalMonthString
 import com.rwmobi.kunigami.domain.model.consumption.Consumption
 import com.rwmobi.kunigami.ui.components.IndicatorTextValueGridItem
 import com.rwmobi.kunigami.ui.extensions.getPercentageColorIndex
@@ -44,11 +44,11 @@ internal fun RateGroupCells(
             val item = partitionedItems.getOrNull(columnIndex)?.getOrNull(rowIndex)
             if (item != null) {
                 val label = when (presentationStyle) {
-                    ConsumptionPresentationStyle.DAY_HALF_HOURLY -> item.intervalStart.toLocalHourMinuteString()
-                    ConsumptionPresentationStyle.WEEK_SEVEN_DAYS -> item.intervalStart.toLocalWeekdayDay()
-                    ConsumptionPresentationStyle.MONTH_WEEKS -> item.intervalStart.toLocalDayMonth()
-                    ConsumptionPresentationStyle.MONTH_THIRTY_DAYS -> item.intervalStart.toLocalDay()
-                    ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS -> item.intervalStart.toLocalMonth()
+                    ConsumptionPresentationStyle.DAY_HALF_HOURLY -> item.intervalStart.getLocalHHMMString()
+                    ConsumptionPresentationStyle.WEEK_SEVEN_DAYS -> item.intervalStart.getLocalDayOfWeekAndDayString()
+                    ConsumptionPresentationStyle.MONTH_WEEKS -> item.intervalStart.getLocalDayMonthString()
+                    ConsumptionPresentationStyle.MONTH_THIRTY_DAYS -> item.intervalStart.getLocalDayOfMonth().toString()
+                    ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS -> item.intervalStart.getLocalMonthString()
                 }
                 IndicatorTextValueGridItem(
                     modifier = Modifier.weight(1f),

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
@@ -8,16 +8,16 @@
 package com.rwmobi.kunigami.ui.model.consumption
 
 import androidx.compose.runtime.Immutable
-import com.rwmobi.kunigami.domain.extensions.roundToDayEnd
-import com.rwmobi.kunigami.domain.extensions.roundToDayStart
-import com.rwmobi.kunigami.domain.extensions.toLocalDateString
-import com.rwmobi.kunigami.domain.extensions.toLocalDay
-import com.rwmobi.kunigami.domain.extensions.toLocalDayMonth
-import com.rwmobi.kunigami.domain.extensions.toLocalHourMinuteString
-import com.rwmobi.kunigami.domain.extensions.toLocalMonth
-import com.rwmobi.kunigami.domain.extensions.toLocalMonthYear
-import com.rwmobi.kunigami.domain.extensions.toLocalWeekday
-import com.rwmobi.kunigami.domain.extensions.toLocalYear
+import com.rwmobi.kunigami.domain.extensions.atEndOfDay
+import com.rwmobi.kunigami.domain.extensions.atStartOfDay
+import com.rwmobi.kunigami.domain.extensions.getLocalDateString
+import com.rwmobi.kunigami.domain.extensions.getLocalDayMonthString
+import com.rwmobi.kunigami.domain.extensions.getLocalDayOfMonth
+import com.rwmobi.kunigami.domain.extensions.getLocalEnglishAbbreviatedDayOfWeekName
+import com.rwmobi.kunigami.domain.extensions.getLocalHHMMString
+import com.rwmobi.kunigami.domain.extensions.getLocalMonthString
+import com.rwmobi.kunigami.domain.extensions.getLocalMonthYearString
+import com.rwmobi.kunigami.domain.extensions.getLocalYear
 import com.rwmobi.kunigami.domain.model.consumption.Consumption
 import io.github.koalaplot.core.util.toString
 import kotlinx.datetime.Clock
@@ -57,7 +57,7 @@ data class ConsumptionQueryFilter(
 
             return when (presentationStyle) {
                 ConsumptionPresentationStyle.DAY_HALF_HOURLY -> {
-                    pointOfReference.roundToDayStart()
+                    pointOfReference.atStartOfDay()
                 }
 
                 ConsumptionPresentationStyle.WEEK_SEVEN_DAYS -> {
@@ -100,7 +100,7 @@ data class ConsumptionQueryFilter(
 
             return when (presentationStyle) {
                 ConsumptionPresentationStyle.DAY_HALF_HOURLY -> {
-                    pointOfReference.roundToDayEnd()
+                    pointOfReference.atEndOfDay()
                 }
 
                 ConsumptionPresentationStyle.WEEK_SEVEN_DAYS -> {
@@ -143,11 +143,11 @@ data class ConsumptionQueryFilter(
      */
     fun getConsumptionPeriodString(): String {
         return when (presentationStyle) {
-            ConsumptionPresentationStyle.DAY_HALF_HOURLY -> "${pointOfReference.toLocalWeekday()}, ${pointOfReference.toLocalDateString()}"
-            ConsumptionPresentationStyle.WEEK_SEVEN_DAYS -> "${requestedStart.toLocalDateString().substringBefore(delimiter = ",")} - ${requestedEnd.toLocalDateString()}"
-            ConsumptionPresentationStyle.MONTH_WEEKS -> pointOfReference.toLocalMonthYear()
-            ConsumptionPresentationStyle.MONTH_THIRTY_DAYS -> pointOfReference.toLocalMonthYear()
-            ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS -> pointOfReference.toLocalYear()
+            ConsumptionPresentationStyle.DAY_HALF_HOURLY -> "${pointOfReference.getLocalEnglishAbbreviatedDayOfWeekName()}, ${pointOfReference.getLocalDateString()}"
+            ConsumptionPresentationStyle.WEEK_SEVEN_DAYS -> "${requestedStart.getLocalDateString().substringBefore(delimiter = ",")} - ${requestedEnd.getLocalDateString()}"
+            ConsumptionPresentationStyle.MONTH_WEEKS -> pointOfReference.getLocalMonthYearString()
+            ConsumptionPresentationStyle.MONTH_THIRTY_DAYS -> pointOfReference.getLocalMonthYearString()
+            ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS -> pointOfReference.getLocalYear().toString()
         }
     }
 
@@ -169,25 +169,25 @@ data class ConsumptionQueryFilter(
 
                 ConsumptionPresentationStyle.WEEK_SEVEN_DAYS -> {
                     consumptions.forEachIndexed { index, consumption ->
-                        put(key = index, value = consumption.intervalStart.toLocalWeekday())
+                        put(key = index, value = consumption.intervalStart.getLocalEnglishAbbreviatedDayOfWeekName())
                     }
                 }
 
                 ConsumptionPresentationStyle.MONTH_WEEKS -> {
                     consumptions.forEachIndexed { index, consumption ->
-                        put(key = index, value = consumption.intervalStart.toLocalDayMonth())
+                        put(key = index, value = consumption.intervalStart.getLocalDayMonthString())
                     }
                 }
 
                 ConsumptionPresentationStyle.MONTH_THIRTY_DAYS -> {
                     consumptions.forEachIndexed { index, consumption ->
-                        put(key = index, value = consumption.intervalStart.toLocalDay())
+                        put(key = index, value = consumption.intervalStart.getLocalDayOfMonth().toString())
                     }
                 }
 
                 ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS -> {
                     consumptions.forEachIndexed { index, consumption ->
-                        put(key = index, value = consumption.intervalStart.toLocalMonth())
+                        put(key = index, value = consumption.intervalStart.getLocalMonthString())
                     }
                 }
             }
@@ -200,7 +200,7 @@ data class ConsumptionQueryFilter(
         return when (presentationStyle) {
             ConsumptionPresentationStyle.DAY_HALF_HOURLY -> {
                 consumptions
-                    .groupBy { it.intervalStart.toLocalDateString() }
+                    .groupBy { it.intervalStart.getLocalDateString() }
                     .map { (date, items) -> ConsumptionGroupedCells(title = date, consumptions = items) }
             }
 
@@ -224,14 +224,14 @@ data class ConsumptionQueryFilter(
 
             ConsumptionPresentationStyle.MONTH_THIRTY_DAYS -> {
                 consumptions
-                    .groupBy { it.intervalStart.toLocalMonthYear() }
+                    .groupBy { it.intervalStart.getLocalMonthYearString() }
                     .map { (date, items) -> ConsumptionGroupedCells(title = date, consumptions = items) }
             }
 
             ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS -> {
                 consumptions
-                    .groupBy { it.intervalStart.toLocalYear() }
-                    .map { (date, items) -> ConsumptionGroupedCells(title = date, consumptions = items) }
+                    .groupBy { it.intervalStart.getLocalYear() }
+                    .map { (date, items) -> ConsumptionGroupedCells(title = date.toString(), consumptions = items) }
             }
         }
     }
@@ -244,8 +244,8 @@ data class ConsumptionQueryFilter(
                 consumptions.map { consumption ->
                     getString(
                         resource = Res.string.usage_chart_tooltip_range_kwh,
-                        consumption.intervalStart.toLocalHourMinuteString(),
-                        consumption.intervalEnd.toLocalHourMinuteString(),
+                        consumption.intervalStart.getLocalHHMMString(),
+                        consumption.intervalEnd.getLocalHHMMString(),
                         consumption.consumption.toString(precision = 2),
                     )
                 }
@@ -255,7 +255,7 @@ data class ConsumptionQueryFilter(
                 consumptions.map { consumption ->
                     getString(
                         resource = Res.string.usage_chart_tooltip_spot_kwh,
-                        consumption.intervalStart.toLocalDateString(),
+                        consumption.intervalStart.getLocalDateString(),
                         consumption.consumption.toString(precision = 2),
                     )
                 }
@@ -265,8 +265,8 @@ data class ConsumptionQueryFilter(
                 consumptions.map { consumption ->
                     getString(
                         resource = Res.string.usage_chart_tooltip_range_kwh,
-                        consumption.intervalStart.toLocalDayMonth(),
-                        (consumption.intervalEnd - 1.nanoseconds).toLocalDayMonth(),
+                        consumption.intervalStart.getLocalDayMonthString(),
+                        (consumption.intervalEnd - 1.nanoseconds).getLocalDayMonthString(),
                         consumption.consumption.toString(precision = 2),
                     )
                 }
@@ -276,7 +276,7 @@ data class ConsumptionQueryFilter(
                 consumptions.map { consumption ->
                     getString(
                         resource = Res.string.usage_chart_tooltip_spot_kwh,
-                        consumption.intervalStart.toLocalDayMonth(),
+                        consumption.intervalStart.getLocalDayMonthString(),
                         consumption.consumption.toString(precision = 2),
                     )
                 }
@@ -286,7 +286,7 @@ data class ConsumptionQueryFilter(
                 consumptions.map { consumption ->
                     getString(
                         resource = Res.string.usage_chart_tooltip_spot_kwh,
-                        consumption.intervalStart.toLocalMonthYear(),
+                        consumption.intervalStart.getLocalMonthYearString(),
                         consumption.consumption.toString(precision = 2),
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
@@ -12,9 +12,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import com.rwmobi.kunigami.domain.exceptions.IncompleteCredentialsException
-import com.rwmobi.kunigami.domain.extensions.roundDownToHour
-import com.rwmobi.kunigami.domain.extensions.toLocalDateString
-import com.rwmobi.kunigami.domain.extensions.toLocalHourMinuteString
+import com.rwmobi.kunigami.domain.extensions.atStartOfHour
+import com.rwmobi.kunigami.domain.extensions.getLocalDateString
+import com.rwmobi.kunigami.domain.extensions.getLocalHHMMString
 import com.rwmobi.kunigami.domain.model.account.UserProfile
 import com.rwmobi.kunigami.domain.model.rate.Rate
 import com.rwmobi.kunigami.domain.usecase.GetStandardUnitRateUseCase
@@ -123,7 +123,7 @@ class AgileViewModel(
     private suspend fun getAgileRates(
         region: String,
     ) {
-        val currentTime = Clock.System.now().roundDownToHour()
+        val currentTime = Clock.System.now().atStartOfHour()
         val periodTo = currentTime.plus(duration = Duration.parse("1d"))
 
         getStandardUnitRateUseCase(
@@ -218,14 +218,14 @@ class AgileViewModel(
 
     private fun groupChartCells(rates: List<Rate>): List<RateGroupedCells> {
         return rates
-            .groupBy { it.validFrom.toLocalDateString() }
+            .groupBy { it.validFrom.getLocalDateString() }
             .map { (date, items) -> RateGroupedCells(title = date, rates = items) }
     }
 
     private fun generateChartToolTips(rates: List<Rate>): List<String> {
         return rates.map { rate ->
-            val timeRange = rate.validFrom.toLocalHourMinuteString() +
-                (rate.validTo?.let { "- ${it.toLocalHourMinuteString()}" } ?: "")
+            val timeRange = rate.validFrom.getLocalHHMMString() +
+                (rate.validTo?.let { "- ${it.getLocalHHMMString()}" } ?: "")
             "$timeRange\n${rate.vatInclusivePrice.toString(precision = 2)}p"
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModel.kt
@@ -12,8 +12,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import com.rwmobi.kunigami.domain.exceptions.IncompleteCredentialsException
-import com.rwmobi.kunigami.domain.extensions.roundToDayEnd
-import com.rwmobi.kunigami.domain.extensions.roundToDayStart
+import com.rwmobi.kunigami.domain.extensions.atEndOfDay
+import com.rwmobi.kunigami.domain.extensions.atStartOfDay
 import com.rwmobi.kunigami.domain.extensions.roundToNearestEvenHundredth
 import com.rwmobi.kunigami.domain.model.account.UserProfile
 import com.rwmobi.kunigami.domain.model.consumption.Consumption
@@ -71,8 +71,8 @@ class UsageViewModel(
                 var newConsumptionQueryFilter = ConsumptionQueryFilter(
                     presentationStyle = ConsumptionPresentationStyle.DAY_HALF_HOURLY,
                     pointOfReference = pointOfReference,
-                    requestedStart = pointOfReference.roundToDayStart(),
-                    requestedEnd = pointOfReference.roundToDayEnd(),
+                    requestedStart = pointOfReference.atStartOfDay(),
+                    requestedEnd = pointOfReference.atEndOfDay(),
                 )
 
                 // UIState comes with a default presentationStyle. We try to go backward 5 times hoping for some valid results

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensionsKtTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensionsKtTest.kt
@@ -9,6 +9,7 @@ package com.rwmobi.kunigami.domain.extensions
 
 import io.kotest.matchers.longs.shouldBeExactly
 import io.kotest.matchers.shouldBe
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
@@ -19,97 +20,97 @@ class InstantExtensionsKtTest {
     private val timeZone = TimeZone.currentSystemDefault()
 
     @Test
-    fun `formatInstantWithoutSeconds should format correctly`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 30, 15).toInstant(TimeZone.UTC)
-        instant.formatInstantWithoutSeconds() shouldBe "2023-05-01T10:30Z"
+    fun `toIso8601WithoutSeconds should format correctly`() {
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 30, second = 15).toInstant(TimeZone.UTC)
+        instant.toIso8601WithoutSeconds() shouldBe "2023-05-01T10:30Z"
     }
 
     @Test
-    fun `roundDownToHour should round down correctly`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 45, 15).toInstant(timeZone)
-        val expected = LocalDateTime(2023, 5, 1, 10, 0, 0).toInstant(timeZone)
-        instant.roundDownToHour() shouldBe expected
+    fun `atStartOfHour should round down correctly`() {
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
+        val expected = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 0, second = 0).toInstant(timeZone)
+        instant.atStartOfHour() shouldBe expected
     }
 
     @Test
-    fun `roundToDayStart should round down to start of day`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 45, 15).toInstant(timeZone)
-        val expected = LocalDateTime(2023, 5, 1, 0, 0, 0).toInstant(timeZone)
-        instant.roundToDayStart() shouldBe expected
+    fun `atStartOfDay should round down to start of day`() {
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
+        val expected = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 0, minute = 0, second = 0).toInstant(timeZone)
+        instant.atStartOfDay() shouldBe expected
     }
 
     @Test
-    fun `roundToDayEnd should round up to end of day`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 45, 15).toInstant(timeZone)
-        val expected = LocalDateTime(2023, 5, 1, 23, 59, 59, 999_999_999).toInstant(timeZone)
-        instant.roundToDayEnd() shouldBe expected
+    fun `atEndOfDay should round up to end of day`() {
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
+        val expected = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 23, minute = 59, second = 59, nanosecond = 999_999_999).toInstant(timeZone)
+        instant.atEndOfDay() shouldBe expected
     }
 
     @Test
-    fun `toLocalHourMinuteString should format correctly`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 45, 15).toInstant(timeZone)
-        instant.toLocalHourMinuteString() shouldBe "10:45"
+    fun `getLocalHHMMString should format correctly`() {
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
+        instant.getLocalHHMMString() shouldBe "10:45"
     }
 
     @Test
-    fun `toLocalHourString should format correctly`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 45, 15).toInstant(timeZone)
-        instant.toLocalHourString() shouldBe "10"
+    fun `getLocalHourString should format correctly`() {
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
+        instant.getLocalHourString() shouldBe "10"
     }
 
     // This is not a very good test because it depends on platform AND local settings
     @Test
     fun `toLocalDateTimeString should format correctly`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 45, 15).toInstant(timeZone)
-        val localDateString = instant.toLocalDateString()
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
+        val localDateString = instant.getLocalDateString()
         instant.toLocalDateTimeString() shouldBe "$localDateString 10:45"
     }
 
     @Test
-    fun `toLocalYear should return correct year`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 45, 15).toInstant(timeZone)
-        instant.toLocalYear() shouldBe "2023"
+    fun `getLocalYear should return correct year`() {
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
+        instant.getLocalYear() shouldBe 2023
     }
 
     @Test
-    fun `toLocalDay should return correct day`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 45, 15).toInstant(timeZone)
-        instant.toLocalDay() shouldBe "1"
+    fun `getLocalDayOfMonth should return correct day`() {
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
+        instant.getLocalDayOfMonth() shouldBe 1
     }
 
     @Test
-    fun `toLocalWeekday should return correct weekday`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 45, 15).toInstant(timeZone)
-        instant.toLocalWeekday() shouldBe "Mon"
+    fun `getLocalEnglishAbbreviatedDayOfWeekName should return correct weekday`() {
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
+        instant.getLocalEnglishAbbreviatedDayOfWeekName() shouldBe "Mon"
     }
 
     @Test
-    fun `toLocalWeekdayDay should return correct weekday and day`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 45, 15).toInstant(timeZone)
-        instant.toLocalWeekdayDay() shouldBe "Mon 01"
+    fun `getLocalDayOfWeekAndDayString should return correct weekday and day`() {
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
+        instant.getLocalDayOfWeekAndDayString() shouldBe "Mon 01"
     }
 
     @Test
-    fun `toLocalDayMonth should return correct day and month`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 45, 15).toInstant(timeZone)
-        instant.toLocalDayMonth() shouldBe "01 May"
+    fun `getLocalDayMonthString should return correct day and month`() {
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
+        instant.getLocalDayMonthString() shouldBe "01 May"
     }
 
     @Test
-    fun `toLocalMonth should return correct month`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 45, 15).toInstant(timeZone)
-        instant.toLocalMonth() shouldBe "May"
+    fun `getLocalMonthString should return correct month`() {
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
+        instant.getLocalMonthString() shouldBe "May"
     }
 
     @Test
-    fun `toLocalMonthYear should return correct month and year`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 45, 15).toInstant(timeZone)
-        instant.toLocalMonthYear() shouldBe "May 2023"
+    fun `getLocalMonthYearString should return correct month and year`() {
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
+        instant.getLocalMonthYearString() shouldBe "May 2023"
     }
 
     @Test
     fun `getNextHalfHourCountdownMillis should return correct millis when current time is exactly on the hour`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 0, 0, 0).toInstant(timeZone)
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 0, second = 0, nanosecond = 0).toInstant(timeZone)
         val millis = instant.getNextHalfHourCountdownMillis()
         val expectedMillis = 30 * 60 * 1000L // 30 minutes in milliseconds
         millis shouldBeExactly expectedMillis
@@ -117,7 +118,7 @@ class InstantExtensionsKtTest {
 
     @Test
     fun `getNextHalfHourCountdownMillis should return correct millis when current time is exactly on the half hour`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 30, 0, 0).toInstant(timeZone)
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 30, second = 0, nanosecond = 0).toInstant(timeZone)
         val millis = instant.getNextHalfHourCountdownMillis()
         val expectedMillis = 30 * 60 * 1000L // 30 minutes in milliseconds
         millis shouldBeExactly expectedMillis
@@ -125,7 +126,7 @@ class InstantExtensionsKtTest {
 
     @Test
     fun `getNextHalfHourCountdownMillis should return correct millis when current time is just past the hour`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 1, 0, 0).toInstant(timeZone)
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 1, second = 0, nanosecond = 0).toInstant(timeZone)
         val millis = instant.getNextHalfHourCountdownMillis()
         val expectedMillis = 29 * 60 * 1000L // 29 minutes in milliseconds
         millis shouldBeExactly expectedMillis
@@ -133,7 +134,7 @@ class InstantExtensionsKtTest {
 
     @Test
     fun `getNextHalfHourCountdownMillis should return correct millis when current time is just past the half hour`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 31, 0, 0).toInstant(timeZone)
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 31, second = 0, nanosecond = 0).toInstant(timeZone)
         val millis = instant.getNextHalfHourCountdownMillis()
         val expectedMillis = 29 * 60 * 1000L // 29 minutes in milliseconds
         millis shouldBeExactly expectedMillis
@@ -141,7 +142,7 @@ class InstantExtensionsKtTest {
 
     @Test
     fun `getNextHalfHourCountdownMillis should return correct millis when current time is just before the half hour`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 29, 30, 0).toInstant(timeZone)
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 29, second = 30, nanosecond = 0).toInstant(timeZone)
         val millis = instant.getNextHalfHourCountdownMillis()
         val expectedMillis = 30 * 1000L // 30 seconds in milliseconds
         millis shouldBeExactly expectedMillis
@@ -149,7 +150,7 @@ class InstantExtensionsKtTest {
 
     @Test
     fun `getNextHalfHourCountdownMillis should return correct millis when current time is just before the hour`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 59, 30, 0).toInstant(timeZone)
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 59, second = 30, nanosecond = 0).toInstant(timeZone)
         val millis = instant.getNextHalfHourCountdownMillis()
         val expectedMillis = 30 * 1000L // 30 seconds in milliseconds
         millis shouldBeExactly expectedMillis
@@ -157,9 +158,56 @@ class InstantExtensionsKtTest {
 
     @Test
     fun `getNextHalfHourCountdownMillis should return correct millis including nanoseconds`() {
-        val instant = LocalDateTime(2023, 5, 1, 10, 29, 59, 999_000_000).toInstant(timeZone)
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 29, second = 59, nanosecond = 999_000_000).toInstant(timeZone)
         val millis = instant.getNextHalfHourCountdownMillis()
         val expectedMillis = 1L // 1 millisecond
         millis shouldBeExactly expectedMillis
+    }
+
+    /***
+     * British Summer Time related test cases
+     */
+    private val londonZone = TimeZone.of("Europe/London")
+
+    @Test
+    fun `atStartOfDay should return 00 00 local time on a typical day`() {
+        val date = LocalDate(year = 2024, monthNumber = 6, dayOfMonth = 15) // A typical day, not a transition day
+        val expectedStartOfDay = LocalDateTime(year = date.year, monthNumber = date.monthNumber, dayOfMonth = date.dayOfMonth, hour = 0, minute = 0, second = 0)
+            .toInstant(londonZone)
+        val actualStartOfDay = expectedStartOfDay.atStartOfDay()
+
+        actualStartOfDay shouldBe expectedStartOfDay
+    }
+
+    @Test
+    fun `atEndOfDay should return 23 59 59 local time on a typical day`() {
+        val date = LocalDate(year = 2024, monthNumber = 6, dayOfMonth = 15) // A typical day, not a transition day
+        val expectedEndOfDay = LocalDateTime(year = date.year, monthNumber = date.monthNumber, dayOfMonth = date.dayOfMonth, hour = 23, minute = 59, second = 59, nanosecond = 999_999_999)
+            .toInstant(londonZone)
+        val actualEndOfDay = expectedEndOfDay.atEndOfDay()
+
+        actualEndOfDay shouldBe expectedEndOfDay
+    }
+
+    @Test
+    fun `atStartOfDay should correctly handle the transition from GMT to BST`() {
+        // Transition from GMT to BST on March 31, 2024
+        val date = LocalDate(year = 2024, monthNumber = 3, dayOfMonth = 31)
+        val expectedStartOfDay = LocalDateTime(year = date.year, monthNumber = date.monthNumber, dayOfMonth = date.dayOfMonth, hour = 0, minute = 0, second = 0)
+            .toInstant(londonZone)
+        val actualStartOfDay = expectedStartOfDay.atStartOfDay()
+
+        actualStartOfDay shouldBe expectedStartOfDay
+    }
+
+    @Test
+    fun `atEndOfDay should correctly handle the transition from GMT to BST`() {
+        // Transition from GMT to BST on March 31, 2024, skipping from 01:00 to 02:00
+        val date = LocalDate(year = 2024, monthNumber = 3, dayOfMonth = 31)
+        val expectedEndOfDay = LocalDateTime(year = date.year, monthNumber = date.monthNumber, dayOfMonth = date.dayOfMonth, hour = 23, minute = 59, second = 59, nanosecond = 999_999_999)
+            .toInstant(londonZone)
+        val actualEndOfDay = expectedEndOfDay.atEndOfDay()
+
+        actualEndOfDay shouldBe expectedEndOfDay
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilterTest.kt
@@ -6,12 +6,12 @@
  */
 package com.rwmobi.kunigami.ui.model.consumption
 
-import com.rwmobi.kunigami.domain.extensions.roundToDayEnd
-import com.rwmobi.kunigami.domain.extensions.roundToDayStart
-import com.rwmobi.kunigami.domain.extensions.toLocalDateString
-import com.rwmobi.kunigami.domain.extensions.toLocalMonthYear
-import com.rwmobi.kunigami.domain.extensions.toLocalWeekday
-import com.rwmobi.kunigami.domain.extensions.toLocalYear
+import com.rwmobi.kunigami.domain.extensions.atEndOfDay
+import com.rwmobi.kunigami.domain.extensions.atStartOfDay
+import com.rwmobi.kunigami.domain.extensions.getLocalDateString
+import com.rwmobi.kunigami.domain.extensions.getLocalEnglishAbbreviatedDayOfWeekName
+import com.rwmobi.kunigami.domain.extensions.getLocalMonthYearString
+import com.rwmobi.kunigami.domain.extensions.getLocalYear
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import kotlinx.datetime.Clock
@@ -40,13 +40,13 @@ class ConsumptionQueryFilterTest {
     @Test
     fun `calculateStartDate should return correct start date for DAY_HALF_HOURLY`() {
         val startDate = ConsumptionQueryFilter.calculateStartDate(now, ConsumptionPresentationStyle.DAY_HALF_HOURLY)
-        startDate shouldBe now.roundToDayStart()
+        startDate shouldBe now.atStartOfDay()
     }
 
     @Test
     fun `calculateEndDate should return correct end date for DAY_HALF_HOURLY`() {
         val endDate = ConsumptionQueryFilter.calculateEndDate(now, ConsumptionPresentationStyle.DAY_HALF_HOURLY)
-        endDate shouldBe now.roundToDayEnd()
+        endDate shouldBe now.atEndOfDay()
     }
 
     @Test
@@ -116,33 +116,33 @@ class ConsumptionQueryFilterTest {
     @Test
     fun `getConsumptionPeriodString should return correct string for DAY_HALF_HOURLY`() {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.DAY_HALF_HOURLY, pointOfReference = now)
-        filter.getConsumptionPeriodString() shouldBe "${now.toLocalWeekday()}, ${now.toLocalDateString()}"
+        filter.getConsumptionPeriodString() shouldBe "${now.getLocalEnglishAbbreviatedDayOfWeekName()}, ${now.getLocalDateString()}"
     }
 
     @Test
     fun `getConsumptionPeriodString should return correct string for WEEK_SEVEN_DAYS`() {
-        val start = now.roundToDayStart()
-        val end = now.roundToDayEnd()
+        val start = now.atStartOfDay()
+        val end = now.atEndOfDay()
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.WEEK_SEVEN_DAYS, pointOfReference = now, requestedStart = start, requestedEnd = end)
-        filter.getConsumptionPeriodString() shouldBe "${start.toLocalDateString().substringBefore(",")} - ${end.toLocalDateString()}"
+        filter.getConsumptionPeriodString() shouldBe "${start.getLocalDateString().substringBefore(",")} - ${end.getLocalDateString()}"
     }
 
     @Test
     fun `getConsumptionPeriodString should return correct string for MONTH_WEEKS`() {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.MONTH_WEEKS, pointOfReference = now)
-        filter.getConsumptionPeriodString() shouldBe now.toLocalMonthYear()
+        filter.getConsumptionPeriodString() shouldBe now.getLocalMonthYearString()
     }
 
     @Test
     fun `getConsumptionPeriodString should return correct string for MONTH_THIRTY_DAYS`() {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.MONTH_THIRTY_DAYS, pointOfReference = now)
-        filter.getConsumptionPeriodString() shouldBe now.toLocalMonthYear()
+        filter.getConsumptionPeriodString() shouldBe now.getLocalMonthYearString()
     }
 
     @Test
     fun `getConsumptionPeriodString should return correct string for YEAR_TWELVE_MONTHS`() {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS, pointOfReference = now)
-        filter.getConsumptionPeriodString() shouldBe now.toLocalYear()
+        filter.getConsumptionPeriodString() shouldBe now.getLocalYear().toString()
     }
 
     @Test

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.desktop.kt
@@ -14,7 +14,7 @@ import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.Locale
 
-actual fun Instant.toLocalDateString(): String {
+actual fun Instant.getLocalDateString(): String {
     val localDate = toLocalDateTime(TimeZone.currentSystemDefault()).date
     val javaDate = java.time.LocalDate.of(localDate.year, localDate.monthNumber, localDate.dayOfMonth)
     val formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)

--- a/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.ios.kt
@@ -19,7 +19,7 @@ import platform.Foundation.NSDateFormatterNoStyle
 import platform.Foundation.NSLocale
 import platform.Foundation.currentLocale
 
-actual fun Instant.toLocalDateString(): String {
+actual fun Instant.getLocalDateString(): String {
     val dateFormatter = NSDateFormatter().apply {
         dateStyle = NSDateFormatterMediumStyle
         timeStyle = NSDateFormatterNoStyle


### PR DESCRIPTION
This closes #100 and #147 .

The key functions related to date/time manipulations were rewritten, and unit tests crossing the GMT-BST boundaries were added.

We don't have the required production data to check how it works; therefore, we will have to wait until this autumn.