### PR TITLE
(#163) AgileScreen: render negative unit rates 

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/VerticalBarChart.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/VerticalBarChart.kt
@@ -183,12 +183,21 @@ fun VerticalBarChart(
                                     ),
                                 ],
                             ),
-                            shape = RoundedCornerShape(
-                                topStart = 8.dp,
-                                topEnd = 8.dp,
-                                bottomEnd = 0.dp,
-                                bottomStart = 0.dp,
-                            ),
+                            shape = if (entries[index].y.yMin >= 0) {
+                                RoundedCornerShape(
+                                    topStart = 8.dp,
+                                    topEnd = 8.dp,
+                                    bottomEnd = 0.dp,
+                                    bottomStart = 0.dp,
+                                )
+                            } else {
+                                RoundedCornerShape(
+                                    topStart = 0.dp,
+                                    topEnd = 0.dp,
+                                    bottomEnd = 8.dp,
+                                    bottomStart = 8.dp,
+                                )
+                            },
                             hoverElement = {
                                 RichTooltip {
                                     Text(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
@@ -42,6 +42,7 @@ import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.account_error_load_account
 import org.jetbrains.compose.resources.getString
 import kotlin.math.ceil
+import kotlin.math.floor
 import kotlin.time.Duration
 
 class AgileViewModel(
@@ -136,7 +137,7 @@ class AgileViewModel(
                 val rateRange = if (rates.isEmpty()) {
                     0.0..0.0 // Return a default range if the list is empty
                 } else {
-                    0.0..ceil(rates.maxOf { it.vatInclusivePrice } * 10) / 10.0
+                    floor(rates.minOf { it.vatInclusivePrice } * 10) / 10.0..ceil(rates.maxOf { it.vatInclusivePrice } * 10) / 10.0
                 }
 
                 val verticalBarPlotEntries: List<VerticalBarPlotEntry<Int, Double>> = buildList {
@@ -144,7 +145,11 @@ class AgileViewModel(
                         add(
                             element = DefaultVerticalBarPlotEntry(
                                 x = index,
-                                y = DefaultVerticalBarPosition(yMin = 0.0, yMax = rate.vatInclusivePrice),
+                                y = if (rate.vatInclusivePrice >= 0) {
+                                    DefaultVerticalBarPosition(yMin = 0.0, yMax = rate.vatInclusivePrice)
+                                } else {
+                                    DefaultVerticalBarPosition(yMin = rate.vatInclusivePrice, yMax = 0.0)
+                                },
                             ),
                         )
                     }


### PR DESCRIPTION
Updated the chart data handling so we don't assume the minimum unit rate is 0.0. The range is now calculated using the real floor and ceiling from the data set we have received. The bar chart also properly shows negative unit rates in a correct style. 

Before:
<img width="800" alt="Screenshot 2024-06-07 at 16 04 04" src="https://github.com/ryanw-mobile/OctoMeter/assets/22452240/e06c5c43-8a5e-4481-86d0-5507b1a78e7c">

After:
<img width="800" alt="Screenshot 2024-06-07 at 22 31 39" src="https://github.com/ryanw-mobile/OctoMeter/assets/22452240/c2641a95-a8d0-43be-8423-ea5ce9fae776">
