### PR TITLE
(#145) Set up MacOS Desktop App distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,10 @@ I use Android Studio Koala to build the Android and Deskop apps. Xcode 15.4 for 
 
 * Android: You can download the apk from the [Release Section](https://github.com/ryanw-mobile/OctoMeter/releases).
 * iOS: Join as a tester at [Test Flight](https://testflight.apple.com/join/T6I940RE).
-* Desktop app, to build and run, execute `./gradlew runReleaseDistrubutable` or just `./gradlew run`
-* To export the desktop app into MacOS distributable, execute `./gradlew packageDmg` (I don't use
-  Windows)
-* You can't export the Jar alone. To export the Jar for desktop. Jar doesn't comes with the native
-  Skiko library so it won't run.
+* MacOS Desktop App: You can download the DMG installer from the [Release Section](https://github.com/ryanw-mobile/OctoMeter/releases).
+* I don't have a Windows machine, so I cannot provide a .exe file for Windows.
+* To build and run the Desktop app yourself, execute `./gradlew run`
+
 
 <br /><br />
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -283,7 +283,14 @@ compose.desktop {
             includeAllModules = true
 
             macOS {
+                bundleID = "com.rwmobi.kunigami"
                 iconFile.set(project.file("icons/ic_launcher_macos.icns"))
+                notarization {
+                    val providers = project.providers
+                    appleID.set(providers.environmentVariable("NOTARIZATION_APPLE_ID"))
+                    password.set(providers.environmentVariable("NOTARIZATION_PASSWORD"))
+                    teamID.set(providers.environmentVariable("NOTARIZATION_TEAM_ID"))
+                }
             }
             windows {
                 iconFile.set(project.file("icons/ic_launcher_windows.ico"))

--- a/composeApp/composeApp.podspec
+++ b/composeApp/composeApp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'composeApp'
-    spec.version                  = '1.0.0'
+    spec.version                  = '1.1.0'
     spec.homepage                 = 'https://github.com/ryanw-mobile/OctoMeter/'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@
 kotlin.code.style=official
 #Gradle
 org.gradle.jvmargs=-Xmx8192M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx8192M"
-org.gradle.configuration-cache=true
+#org.gradle.configuration-cache=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true
 org.gradle.caching=true
@@ -19,4 +19,6 @@ kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.androidGradlePluginCompatibility.nowarn=true
 kotlin.apple.xcodeCompatibility.nowarn=true
-org.gradle.configuration-cache=true
+
+compose.desktop.mac.sign=true
+compose.desktop.mac.signing.identity=Developer ID Application: RW MobiMedia UK Limited (V8M4R7N63C)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,8 +31,8 @@ buildconfig = "5.3.5"
 securityCrypto = "1.1.0-alpha06"
 
 # App configurations, not dependencies
-versionCode = "1"
-versionName = "1.0.0"
+versionCode = "3"
+versionName = "1.1.0"
 android-minSdk = "26"
 android-targetSdk = "34"
 android-compileSdk = "34"

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
We have properly set up Apple Notarization so that the installer for MasOS can be used by the public.

Also in this PR we bump the app to 1.1.0 ready for release