### PR TITLE
(#172) Fix Android App crash in release build

### DIFF
--- a/.github/workflows/create_artifact_release.yml
+++ b/.github/workflows/create_artifact_release.yml
@@ -1,0 +1,81 @@
+name: Android Build to Artifact on Tag
+
+on:
+  create:
+
+jobs:
+  build-and-release:
+    if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/androidBuild/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decode Keystore
+        id: decode_keystore
+        uses: timheuer/base64-to-file@v1.2
+        with:
+          fileName: 'release.jks'
+          encodedString: ${{ secrets.KEYSTORE }}
+
+      - uses: actions/checkout@v4
+
+      - name: Set timezone
+        run: echo "TZ=Europe/London" >> $GITHUB_ENV
+
+      - name: set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Gradle build
+        run: ./gradlew bundleRelease assembleRelease --no-daemon
+        env:
+          CI: 'true'
+          KEYSTORE_LOCATION: ${{ steps.decode_keystore.outputs.filePath }}
+          CI_ANDROID_KEYSTORE_ALIAS: ${{ secrets.BITRISEIO_ANDROID_KEYSTORE_ALIAS }}
+          CI_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD: ${{ secrets.BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD }}
+          CI_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.BITRISEIO_ANDROID_KEYSTORE_PASSWORD }}
+
+      - name: Extract Version Number
+        run: echo "version=${GITHUB_REF#refs/tags/release/}" >> $GITHUB_ENV
+
+      - name: Upload Mapping File Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: mapping-${{ env.version }}.txt
+          path: ./composeApp/build/outputs/mapping/release/mapping.txt
+
+      - name: Find APK file
+        run: |
+          apk_path=$(find ./composeApp/build/outputs/apk/release -name "OctoMeter-*.apk" | head -n 1)
+          echo "apk_path=$apk_path" >> $GITHUB_ENV
+
+      - name: Upload APK Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: OctoMeter-${{ env.version }}.apk
+          path: ${{ env.apk_path }}
+
+      - name: Find AAB file
+        run: |
+          aab_path=$(find ./composeApp/build/outputs/bundle/release -name "OctoMeter-*.aab" | head -n 1)
+          echo "aab_path=$aab_path" >> $GITHUB_ENV
+
+      - name: Upload Release Asset AAB
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_FOR_RELEASES }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.aab_path }}
+          asset_name: OctoMeter-${{ env.version }}.aab
+          asset_content_type: application/vnd.android.package-archive
+
+      - name: Upload AAB Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: OctoMeter-${{ env.version }}.aab
+          path: ${{ env.aab_path }}

--- a/.github/workflows/tag_create_release.yml
+++ b/.github/workflows/tag_create_release.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Find APK file
         run: |
-          apk_path=$(find ./composeApp/build/outputs/apk/release -name "kunigami-*.apk" | head -n 1)
+          apk_path=$(find ./composeApp/build/outputs/apk/release -name "OctoMeter-*.apk" | head -n 1)
           echo "apk_path=$apk_path" >> $GITHUB_ENV
 
       - name: Upload Release Asset APK
@@ -83,7 +83,7 @@ jobs:
 
       - name: Find AAB file
         run: |
-          aab_path=$(find ./composeApp/build/outputs/bundle/release -name "kunigami-*.aab" | head -n 1)
+          aab_path=$(find ./composeApp/build/outputs/bundle/release -name "OctoMeter-*.aab" | head -n 1)
           echo "aab_path=$aab_path" >> $GITHUB_ENV
 
       - name: Upload Release Asset AAB

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -77,6 +77,7 @@ kotlin {
         val desktopMain by getting
 
         androidMain.dependencies {
+            // tooling.preview is causing crash
             implementation(libs.compose.ui.tooling)
             implementation(libs.androidx.activity.compose)
             implementation(libs.androidx.core.splashscreen)
@@ -264,7 +265,6 @@ android {
 
     dependencies {
         debugImplementation(libs.leakcanary.android)
-        debugImplementation(libs.compose.ui.tooling.preview)
     }
 }
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -139,7 +139,7 @@ android {
                 .forEach { output ->
                     val timestamp = SimpleDateFormat("yyyyMMdd-HHmmss").format(Date())
                     val outputFileName =
-                        "kunigami-${variant.versionName}-$timestamp-${variant.name}.apk"
+                        "OctoMeter-${variant.versionName}-$timestamp-${variant.name}.apk"
                     output.outputFileName = outputFileName
                 }
         }
@@ -199,7 +199,7 @@ android {
 
         // Bundle output filename
         val timestamp = SimpleDateFormat("yyyyMMdd-HHmmss").format(Date())
-        setProperty("archivesBaseName", "kunigami-$versionName-$timestamp")
+        setProperty("archivesBaseName", "OctoMeter-$versionName-$timestamp")
     }
 
     buildTypes {

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -77,7 +77,7 @@ kotlin {
         val desktopMain by getting
 
         androidMain.dependencies {
-            implementation(libs.compose.ui.tooling.preview)
+            implementation(libs.compose.ui.tooling)
             implementation(libs.androidx.activity.compose)
             implementation(libs.androidx.core.splashscreen)
             implementation(libs.androidx.lifecycle.runtime.compose)
@@ -263,8 +263,8 @@ android {
     }
 
     dependencies {
-        debugImplementation(libs.compose.ui.tooling)
         debugImplementation(libs.leakcanary.android)
+        debugImplementation(libs.compose.ui.tooling.preview)
     }
 }
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -213,9 +213,9 @@ android {
         }
 
         getByName("release") {
-            isShrinkResources = true
-            isMinifyEnabled = true
-            isDebuggable = false
+            isShrinkResources = false
+            isMinifyEnabled = false
+            isDebuggable = true
             setProguardFiles(
                 listOf(
                     getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -213,9 +213,9 @@ android {
         }
 
         getByName("release") {
-            isShrinkResources = false
-            isMinifyEnabled = false
-            isDebuggable = true
+            isShrinkResources = true
+            isMinifyEnabled = true
+            isDebuggable = false
             setProguardFiles(
                 listOf(
                     getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/data/source/local/preferences/ProvideSettings.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/data/source/local/preferences/ProvideSettings.android.kt
@@ -12,19 +12,36 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.SharedPreferencesSettings
+import javax.crypto.AEADBadTagException
 
 fun provideSettings(context: Context): Settings {
     val masterKey = MasterKey.Builder(context)
         .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
         .build()
 
-    val sharedPreferences = EncryptedSharedPreferences.create(
-        context,
-        "encrypted_prefs",
-        masterKey,
-        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
-    )
+    val sharedPreferencesName = "encrypted_prefs"
 
-    return SharedPreferencesSettings(sharedPreferences)
+    try {
+        val sharedPreferences = EncryptedSharedPreferences.create(
+            context,
+            sharedPreferencesName,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
+        return SharedPreferencesSettings(sharedPreferences)
+    } catch (ex: AEADBadTagException) {
+        // Delete the corrupted encrypted shared preferences
+        context.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE).edit().clear().apply()
+
+        // Retry creating EncryptedSharedPreferences
+        val sharedPreferences = EncryptedSharedPreferences.create(
+            context,
+            sharedPreferencesName,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
+        return SharedPreferencesSettings(sharedPreferences)
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.kt
@@ -6,15 +6,21 @@
  */
 package com.rwmobi.kunigami.domain.extensions
 
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.format
 import kotlinx.datetime.format.DayOfWeekNames
 import kotlinx.datetime.format.MonthNames
 import kotlinx.datetime.format.Padding
 import kotlinx.datetime.format.char
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
 
@@ -49,40 +55,25 @@ fun Instant.toIso8601WithoutSeconds(): String {
 fun Instant.atStartOfHour(): Instant {
     val currentLocalDateTime = toSystemDefaultLocalDateTime()
     return LocalDateTime(
-        year = currentLocalDateTime.year,
-        month = currentLocalDateTime.month,
-        dayOfMonth = currentLocalDateTime.dayOfMonth,
-        hour = currentLocalDateTime.hour,
-        minute = 0,
-        second = 0,
-        nanosecond = 0,
+        date = currentLocalDateTime.date,
+        time = LocalTime(
+            hour = currentLocalDateTime.hour,
+            minute = 0,
+        ),
     ).toSystemDefaultTimeZoneInstant()
 }
 
 fun Instant.atStartOfDay(): Instant {
-    val currentLocalDateTime = toSystemDefaultLocalDateTime()
-    return LocalDateTime(
-        year = currentLocalDateTime.year,
-        month = currentLocalDateTime.month,
-        dayOfMonth = currentLocalDateTime.dayOfMonth,
-        hour = 0,
-        minute = 0,
-        second = 0,
-        nanosecond = 0,
-    ).toSystemDefaultTimeZoneInstant()
+    val currentLocalDate = toSystemDefaultLocalDateTime().date
+    return currentLocalDate.atStartOfDayIn(timeZone = TimeZone.currentSystemDefault())
 }
 
 fun Instant.atEndOfDay(): Instant {
-    val currentLocalDateTime = toSystemDefaultLocalDateTime()
-    return LocalDateTime(
-        year = currentLocalDateTime.year,
-        month = currentLocalDateTime.month,
-        dayOfMonth = currentLocalDateTime.dayOfMonth,
-        hour = 23,
-        minute = 59,
-        second = 59,
-        nanosecond = 999_999_999,
-    ).toSystemDefaultTimeZoneInstant()
+    val currentLocalDate = toSystemDefaultLocalDateTime().date
+    return currentLocalDate
+        .plus(period = DatePeriod(days = 1))
+        .atStartOfDayIn(timeZone = TimeZone.currentSystemDefault())
+        .minus(value = 1, unit = DateTimeUnit.NANOSECOND)
 }
 
 /***

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,6 @@ androidx-activityCompose = "1.9.0"
 androidx-core-ktx = "1.13.1"
 androidx-espresso-core = "3.5.1"
 androidx-test-junit = "1.1.5"
-compose = "1.7.0-alpha07"
 compose-plugin = "1.6.11"
 coreSplashscreen = "1.0.1"
 coroutines = "1.8.1"
@@ -29,6 +28,12 @@ multiplatformSettings = "1.1.1"
 navigationCompose = "2.8.0-alpha02"
 buildconfig = "5.3.5"
 securityCrypto = "1.1.0-alpha06"
+junitVersion = "1.1.5"
+espressoCore = "3.5.1"
+uiautomator = "2.3.0"
+benchmarkMacroJunit4 = "1.2.4"
+baselineprofile = "1.2.4"
+profileinstaller = "1.3.1"
 
 # App configurations, not dependencies
 versionCode = "6"
@@ -36,12 +41,6 @@ versionName = "1.1.0"
 android-minSdk = "26"
 android-targetSdk = "34"
 android-compileSdk = "34"
-junitVersion = "1.1.5"
-espressoCore = "3.5.1"
-uiautomator = "2.3.0"
-benchmarkMacroJunit4 = "1.2.4"
-baselineprofile = "1.2.4"
-profileinstaller = "1.3.1"
 
 
 [libraries]
@@ -57,15 +56,15 @@ koalaplot-core = { group = "io.github.koalaplot", name = "koalaplot-core", versi
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidx-activityCompose" }
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "coreSplashscreen" }
 androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "compose" }
-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "compose" }
-kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinxDatetime" }
+compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "compose-plugin" }
+compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "compose-plugin" }
 ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-darwin = { group = "io.ktor", name = "ktor-client-darwin", version.ref = "ktor" }
 ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
+kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinxDatetime" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "coroutines" }
@@ -95,15 +94,15 @@ androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profi
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
-jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose-plugin" }
+android-test = { id = "com.android.test", version.ref = "agp" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinCocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose-plugin" }
 kotlinxKover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 gradleKtlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 buildConfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
-android-test = { id = "com.android.test", version.ref = "agp" }
-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprofile" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ androidx-core-ktx = "1.13.1"
 androidx-espresso-core = "3.5.1"
 androidx-test-junit = "1.1.5"
 compose-plugin = "1.6.11"
+composeUiTooling = "1.6.7"
 coreSplashscreen = "1.0.1"
 coroutines = "1.8.1"
 kermit = "2.0.3"
@@ -56,8 +57,8 @@ koalaplot-core = { group = "io.github.koalaplot", name = "koalaplot-core", versi
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidx-activityCompose" }
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "coreSplashscreen" }
 androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "compose-plugin" }
-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "compose-plugin" }
+compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "composeUiTooling" }
+compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "composeUiTooling" }
 ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }

--- a/renovate.json
+++ b/renovate.json
@@ -30,17 +30,6 @@
         "com.google.devtools.ksp"
       ],
       "groupName": "kotlin"
-    },
-    {
-      "matchPackageNames": [
-        "androidx.compose.ui:ui-tooling",
-        "androidx.compose.ui:ui-tooling-preview"
-      ],
-      "groupName": "composeUiTooling",
-      "automerge": false,
-      "labels": [
-        "requires-approval"
-      ]
     }
   ],
   "automerge": true,


### PR DESCRIPTION
Fixed two bugs that made the Android release crashed:

1. Compose UI Tooling incompatible with JetBrains Compose
2. Encrypted SharedPreferences failed to decrypt Google Play's restored datafile
