### PR TITLE
Github Actions: turn of CI triggers for windows build

### DIFF
--- a/.github/workflows/tag_create_windows_distributions.yml
+++ b/.github/workflows/tag_create_windows_distributions.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Build and Package Project
         run: .\gradlew packageReleaseDistributionForCurrentOS
+        env:
+          CI: 'false'
 
       - name: Extract Version Number
         run: echo "version=${GITHUB_REF#refs/tags/winRelease/}" >> $GITHUB_ENV


### PR DESCRIPTION
trying to turn off CI so we don't bothered by android signing