### PR TITLE
Github Actions: fix to build debug rather than release

### DIFF
--- a/.github/workflows/tag_create_windows_distributions.yml
+++ b/.github/workflows/tag_create_windows_distributions.yml
@@ -22,7 +22,7 @@ jobs:
           cache: gradle
 
       - name: Build and Package Project
-        run: .\gradlew packageReleaseDistributionForCurrentOS
+        run: .\gradlew packageDistributionForCurrentOS
         env:
           CI: 'false'
 


### PR DESCRIPTION
We have mistakenly used the release command, so the output path is obviously broken. 