### PR TITLE
(#146) Hide empty columns on Agile and Usage screens

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -45,6 +45,7 @@ import com.rwmobi.kunigami.ui.destinations.agile.components.RateGroupTitle
 import com.rwmobi.kunigami.ui.extensions.partitionList
 import com.rwmobi.kunigami.ui.model.SpecialErrorScreen
 import com.rwmobi.kunigami.ui.model.chart.RequestedChartLayout
+import com.rwmobi.kunigami.ui.model.rate.RateGroupWithPartitions
 import com.rwmobi.kunigami.ui.theme.getDimension
 import io.github.koalaplot.core.style.LineStyle
 import io.github.koalaplot.core.xygraph.HorizontalLineAnnotation
@@ -122,6 +123,21 @@ fun AgileScreen(
                             title = uiState.agileTariffSummary?.displayName ?: "",
                             subtitle = subtitle,
                         )
+
+                        // Pre-calculate the list of (rateGroup.title, partitionedItems)
+                        val rateGroupsWithPartitions = remember(uiState.rateGroupedCells, uiState.requestedRateColumns) {
+                            uiState.rateGroupedCells.map { rateGroup ->
+                                RateGroupWithPartitions(
+                                    title = rateGroup.title,
+                                    partitionedItems = rateGroup.rates.partitionList(columns = uiState.requestedRateColumns),
+                                )
+                            }
+                        }
+                        val shouldHideLastRateGroupColumn = remember(rateGroupsWithPartitions) {
+                            rateGroupsWithPartitions.all {
+                                it.partitionedItems.last().isEmpty()
+                            }
+                        }
 
                         LazyColumn(
                             contentPadding = PaddingValues(bottom = dimension.grid_4),
@@ -227,8 +243,8 @@ fun AgileScreen(
                                 }
                             }
 
-                            uiState.rateGroupedCells.forEach { rateGroup ->
-                                item(key = "${rateGroup.title}Title") {
+                            rateGroupsWithPartitions.forEach { rateGroupsWithPartitions ->
+                                item(key = "${rateGroupsWithPartitions.title}Title") {
                                     RateGroupTitle(
                                         modifier = Modifier
                                             .fillMaxWidth()
@@ -236,14 +252,11 @@ fun AgileScreen(
                                                 vertical = dimension.grid_2,
                                                 horizontal = dimension.grid_4,
                                             ),
-                                        title = rateGroup.title,
+                                        title = rateGroupsWithPartitions.title,
                                     )
                                 }
 
-                                val partitionedItems = rateGroup.rates.partitionList(columns = uiState.requestedRateColumns)
-                                val maxRows = partitionedItems.maxOf { it.size }
-                                val shouldHideLastColumn = partitionedItems.last().isEmpty()
-
+                                val maxRows = rateGroupsWithPartitions.partitionedItems.maxOf { it.size }
                                 items(maxRows) { rowIndex ->
                                     RateGroupCells(
                                         modifier = Modifier
@@ -252,8 +265,8 @@ fun AgileScreen(
                                                 horizontal = dimension.grid_4,
                                                 vertical = dimension.grid_0_25,
                                             ),
-                                        partitionedItems = partitionedItems,
-                                        shouldHideLastColumn = shouldHideLastColumn,
+                                        partitionedItems = rateGroupsWithPartitions.partitionedItems,
+                                        shouldHideLastColumn = shouldHideLastRateGroupColumn,
                                         maxInRange = uiState.rateRange.endInclusive,
                                         rowIndex = rowIndex,
                                         colorPalette = colorPalette,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -240,9 +240,9 @@ fun AgileScreen(
                                     )
                                 }
 
-                                // We can do fancier grouping, but for now evenly-distributed is ok
                                 val partitionedItems = rateGroup.rates.partitionList(columns = uiState.requestedRateColumns)
                                 val maxRows = partitionedItems.maxOf { it.size }
+                                val shouldHideLastColumn = partitionedItems.last().isEmpty()
 
                                 items(maxRows) { rowIndex ->
                                     RateGroupCells(
@@ -253,6 +253,7 @@ fun AgileScreen(
                                                 vertical = dimension.grid_0_25,
                                             ),
                                         partitionedItems = partitionedItems,
+                                        shouldHideLastColumn = shouldHideLastColumn,
                                         maxInRange = uiState.rateRange.endInclusive,
                                         rowIndex = rowIndex,
                                         colorPalette = colorPalette,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupCells.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupCells.kt
@@ -41,7 +41,7 @@ internal fun RateGroupCells(
         } else {
             partitionedItems.indices
         }
-        
+
         for (columnIndex in columnRangeToRender) {
             val item = partitionedItems.getOrNull(columnIndex)?.getOrNull(rowIndex)
             if (item != null) {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupCells.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupCells.kt
@@ -27,6 +27,7 @@ internal fun RateGroupCells(
     modifier: Modifier = Modifier,
     partitionedItems: List<List<Rate>>,
     rowIndex: Int,
+    shouldHideLastColumn: Boolean,
     maxInRange: Double,
     colorPalette: List<Color>,
 ) {
@@ -35,7 +36,13 @@ internal fun RateGroupCells(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_3),
     ) {
-        for (columnIndex in partitionedItems.indices) {
+        val columnRangeToRender = if (shouldHideLastColumn) {
+            0..<partitionedItems.lastIndex
+        } else {
+            partitionedItems.indices
+        }
+        
+        for (columnIndex in columnRangeToRender) {
             val item = partitionedItems.getOrNull(columnIndex)?.getOrNull(rowIndex)
             if (item != null) {
                 IndicatorTextValueGridItem(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/RateGroupCells.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/RateGroupCells.kt
@@ -31,6 +31,7 @@ internal fun RateGroupCells(
     modifier: Modifier = Modifier,
     partitionedItems: List<List<Consumption>>,
     rowIndex: Int,
+    shouldHideLastColumn: Boolean,
     maxInRange: Double,
     presentationStyle: ConsumptionPresentationStyle,
     colorPalette: List<Color>,
@@ -40,7 +41,13 @@ internal fun RateGroupCells(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_3),
     ) {
-        for (columnIndex in partitionedItems.indices) {
+        val columnRangeToRender = if (shouldHideLastColumn) {
+            0..<partitionedItems.lastIndex
+        } else {
+            partitionedItems.indices
+        }
+
+        for (columnIndex in columnRangeToRender) {
             val item = partitionedItems.getOrNull(columnIndex)?.getOrNull(rowIndex)
             if (item != null) {
                 val label = when (presentationStyle) {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/RateGroupTitle.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/RateGroupTitle.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
-import com.rwmobi.kunigami.ui.model.consumption.ConsumptionGroupedCells
+import com.rwmobi.kunigami.ui.model.consumption.ConsumptionGroupWithPartitions
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.unit_kwh
 import org.jetbrains.compose.resources.stringResource
@@ -24,7 +24,7 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 internal fun RateGroupTitle(
     modifier: Modifier = Modifier,
-    consumptionGroup: ConsumptionGroupedCells,
+    consumptionGroupWithPartitions: ConsumptionGroupWithPartitions,
 ) {
     Row(
         modifier = modifier,
@@ -34,7 +34,7 @@ internal fun RateGroupTitle(
             modifier = Modifier.weight(1f),
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
-            text = consumptionGroup.title,
+            text = consumptionGroupWithPartitions.title,
         )
 
         Text(
@@ -43,7 +43,11 @@ internal fun RateGroupTitle(
             fontWeight = FontWeight.Bold,
             text = stringResource(
                 resource = Res.string.unit_kwh,
-                consumptionGroup.consumptions.sumOf { it.consumption }.roundToTwoDecimalPlaces(),
+                consumptionGroupWithPartitions.partitionedItems.sumOf { partitionedItems ->
+                    partitionedItems.sumOf { consumption ->
+                        consumption.consumption
+                    }
+                }.roundToTwoDecimalPlaces(),
             ),
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/extensions/ListExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/extensions/ListExtensions.kt
@@ -18,11 +18,5 @@ internal fun <T> List<T>.partitionList(columns: Int): List<List<T>> {
         partitioned[column].add(this[index])
     }
 
-    // Sometimes we can perfectly distribute the items using one less column
-    // However if columns = 2, we don't do this
-    if (partitioned.last().isEmpty() && columns > 2) {
-        partitioned.removeLast()
-    }
-
     return partitioned.map { it.toList() }
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionGroupWithPartitions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionGroupWithPartitions.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.kunigami.ui.model.consumption
+
+import com.rwmobi.kunigami.domain.model.consumption.Consumption
+
+data class ConsumptionGroupWithPartitions(
+    val title: String,
+    val partitionedItems: List<List<Consumption>>,
+)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/rate/RateGroupWithPartitions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/rate/RateGroupWithPartitions.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.kunigami.ui.model.rate
+
+import com.rwmobi.kunigami.domain.model.rate.Rate
+
+data class RateGroupWithPartitions(
+    val title: String,
+    val partitionedItems: List<List<Rate>>,
+)

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/extensions/ListExtensionsKtTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/extensions/ListExtensionsKtTest.kt
@@ -51,17 +51,18 @@ class ListExtensionsKtTest {
     fun `partitionList should handle more columns than items`() {
         val list = listOf(1, 2, 3)
         val result = list.partitionList(4)
-        result shouldHaveSize 3
+        result shouldHaveSize 4
         result[0] shouldBe listOf(1)
         result[1] shouldBe listOf(2)
         result[2] shouldBe listOf(3)
+        result[3] shouldBe emptyList()
     }
 
     @Test
     fun `partitionList should handle empty list`() {
         val list = emptyList<Int>()
         val result = list.partitionList(3)
-        result shouldHaveSize 2
+        result shouldHaveSize 3
         result.forEach { it shouldBe emptyList() }
     }
 
@@ -78,8 +79,9 @@ class ListExtensionsKtTest {
     fun `partitionList should remove the last empty column if columns is greater than 2`() {
         val list = listOf(1, 2, 3, 4)
         val result = list.partitionList(3)
-        result shouldHaveSize 2
+        result shouldHaveSize 3
         result[0] shouldBe listOf(1, 2)
         result[1] shouldBe listOf(3, 4)
+        result[2] shouldBe emptyList()
     }
 }


### PR DESCRIPTION
We had a quick but unreliable way to remove the last empty column. 
That works only within a rateCellsGroup.
This implementation takes into considerations all rateCellsGroups, so that if globally we have an empty last column, it flags for the composable to remove them during rendering (instead of modifying the data set)