### PR TITLE
(#183) Fix Agile chart to properly set range floor to 0 for all-positive rate dataset

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
@@ -43,6 +43,7 @@ import kunigami.composeapp.generated.resources.account_error_load_account
 import org.jetbrains.compose.resources.getString
 import kotlin.math.ceil
 import kotlin.math.floor
+import kotlin.math.min
 import kotlin.time.Duration
 
 class AgileViewModel(
@@ -137,7 +138,7 @@ class AgileViewModel(
                 val rateRange = if (rates.isEmpty()) {
                     0.0..0.0 // Return a default range if the list is empty
                 } else {
-                    floor(rates.minOf { it.vatInclusivePrice } * 10) / 10.0..ceil(rates.maxOf { it.vatInclusivePrice } * 10) / 10.0
+                    min(0.0, floor(rates.minOf { it.vatInclusivePrice } * 10) / 10.0)..ceil(rates.maxOf { it.vatInclusivePrice } * 10) / 10.0
                 }
 
                 val verticalBarPlotEntries: List<VerticalBarPlotEntry<Int, Double>> = buildList {


### PR DESCRIPTION
We made changes to support showing negative rates by removing the hardcoded 0 range floor.
Now when the data set is all positive, the floor is determined to be the min of the rate instead of 0,
so the chart's y-axis is not starting to zero.

This quick fix is to set rateRange floor to be 0 when all rates are positive