### PR TITLE
Agile Screen: Compare Tariff Code and show Retail Region descriptive text

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -82,6 +82,22 @@
     <string name="tariffs_direct_debit_monthly">Direct Debit Monthly</string>
     <string name="tariffs_error_load_tariffs">Unable to retrieve tariffs</string>
 
+    <!-- Retail Regions -->
+    <string name="retail_region_eastern_england">Eastern England</string>
+    <string name="retail_region_east_midlands">East Midlands</string>
+    <string name="retail_region_london">London</string>
+    <string name="retail_region_merseyside_northern_wales">Merseyside and Northern Wales</string>
+    <string name="retail_region_west_midlands">West Midlands</string>
+    <string name="retail_region_north_eastern_england">North Eastern England</string>
+    <string name="retail_region_north_western_england">North Western England</string>
+    <string name="retail_region_southern_england">Southern England</string>
+    <string name="retail_region_south_eastern_england">South Eastern England</string>
+    <string name="retail_region_southern_wales">Southern Wales</string>
+    <string name="retail_region_south_western_england">South Western England</string>
+    <string name="retail_region_southern_scotland">Southern Scotland</string>
+    <string name="retail_region_yorkshire">Yorkshire</string>
+    <string name="retail_region_northern_scotland">Northern Scotland</string>
+
     <!-- Product Features -->
     <string name="product_feature_variable">Variable</string>
     <string name="product_feature_green">Green</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -65,7 +65,7 @@
     <string name="agile_expire_time">%1$s:%2$s</string>
     <string name="agile_expires_in">Expires in %1$s:%2$s</string>
     <string name="agile_different_tariff">You are on a different tariff</string>
-    <string name="agile_product_code_retail_region">%1$s (Region %2$s)</string>
+    <string name="agile_product_code_retail_region">%1$s (%2$s)</string>
     <string name="agile_tariff_standard_unit_rate_two_lines">Unit Rate:\n%1$d p/kWh</string>
     <string name="agile_tariff_standing_charge_two_lines">Standing Charge:\n%1$d p/day</string>
     <string name="agile_tariff_standard_unit_rate">Unit Rate: %1$d p/kWh</string>
@@ -97,6 +97,7 @@
     <string name="retail_region_southern_scotland">Southern Scotland</string>
     <string name="retail_region_yorkshire">Yorkshire</string>
     <string name="retail_region_northern_scotland">Northern Scotland</string>
+    <string name="retail_region_unknown">Unknown Region</string>
 
     <!-- Product Features -->
     <string name="product_feature_variable">Variable</string>

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/TariffSummary.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/TariffSummary.kt
@@ -52,4 +52,5 @@ data class TariffSummary(
     fun extractProductCode(): String? = extractProductCode(tariffCode = tariffCode)
     fun getRetailRegion(): String? = getRetailRegion(tariffCode = tariffCode)
     fun isSingleRate(): Boolean = isSingleRate(tariffCode = tariffCode)
+    fun isSameTariff(tariffCode: String?) = this.tariffCode == tariffCode
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -212,6 +212,9 @@ fun AgileScreen(
                             }
 
                             item(key = "tariffDetails") {
+                                val differentTariffSummary = uiState.userProfile?.tariffSummary
+                                    ?.takeUnless { it.isSameTariff(uiState.agileTariffSummary?.tariffCode) }
+
                                 AgileTariffCardAdaptive(
                                     modifier = Modifier
                                         .fillMaxWidth()
@@ -221,7 +224,7 @@ fun AgileScreen(
                                             top = dimension.grid_1,
                                         ),
                                     agileTariffSummary = uiState.agileTariffSummary,
-                                    differentTariffSummary = uiState.userProfile?.tariffSummary,
+                                    differentTariffSummary = differentTariffSummary,
                                     colorPalette = colorPalette,
                                     rateRange = uiState.rateRange,
                                     rateGroupedCells = uiState.rateGroupedCells,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -45,6 +45,7 @@ import com.rwmobi.kunigami.ui.destinations.agile.components.RateGroupTitle
 import com.rwmobi.kunigami.ui.extensions.partitionList
 import com.rwmobi.kunigami.ui.model.SpecialErrorScreen
 import com.rwmobi.kunigami.ui.model.chart.RequestedChartLayout
+import com.rwmobi.kunigami.ui.model.product.RetailRegion
 import com.rwmobi.kunigami.ui.model.rate.RateGroupWithPartitions
 import com.rwmobi.kunigami.ui.theme.getDimension
 import io.github.koalaplot.core.style.LineStyle
@@ -58,8 +59,8 @@ import kunigami.composeapp.generated.resources.agile_product_code_retail_region
 import kunigami.composeapp.generated.resources.agile_unit_rate_details
 import kunigami.composeapp.generated.resources.agile_vat_unit_rate
 import kunigami.composeapp.generated.resources.provide_api_key
+import kunigami.composeapp.generated.resources.retail_region_unknown
 import kunigami.composeapp.generated.resources.revenue
-import kunigami.composeapp.generated.resources.unknown
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -111,10 +112,14 @@ fun AgileScreen(
                             .fillMaxSize()
                             .conditionalBlur(enabled = uiState.isLoading && uiState.barChartData == null),
                     ) {
-                        val subtitle = uiState.agileTariffSummary?.let {
-                            val regionCode = it.getRetailRegion() ?: stringResource(resource = Res.string.unknown)
-                            stringResource(resource = Res.string.agile_product_code_retail_region, it.productCode, regionCode)
+                        val subtitle = uiState.agileTariffSummary?.let { summary ->
+                            val regionCode = RetailRegion.fromCode(summary.getRetailRegion())?.stringResource
+                                ?.let { stringResource(it) }
+                                ?: stringResource(resource = Res.string.retail_region_unknown)
+
+                            stringResource(resource = Res.string.agile_product_code_retail_region, summary.productCode, regionCode)
                         }
+
                         DualTitleBar(
                             modifier = Modifier
                                 .background(color = MaterialTheme.colorScheme.secondary)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/product/RetailRegion.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/product/RetailRegion.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.kunigami.ui.model.product
+
+import kunigami.composeapp.generated.resources.Res
+import kunigami.composeapp.generated.resources.retail_region_east_midlands
+import kunigami.composeapp.generated.resources.retail_region_eastern_england
+import kunigami.composeapp.generated.resources.retail_region_london
+import kunigami.composeapp.generated.resources.retail_region_merseyside_northern_wales
+import kunigami.composeapp.generated.resources.retail_region_north_eastern_england
+import kunigami.composeapp.generated.resources.retail_region_north_western_england
+import kunigami.composeapp.generated.resources.retail_region_northern_scotland
+import kunigami.composeapp.generated.resources.retail_region_south_eastern_england
+import kunigami.composeapp.generated.resources.retail_region_south_western_england
+import kunigami.composeapp.generated.resources.retail_region_southern_england
+import kunigami.composeapp.generated.resources.retail_region_southern_scotland
+import kunigami.composeapp.generated.resources.retail_region_southern_wales
+import kunigami.composeapp.generated.resources.retail_region_west_midlands
+import kunigami.composeapp.generated.resources.retail_region_yorkshire
+import org.jetbrains.compose.resources.StringResource
+
+enum class RetailRegion(val code: String, val stringResource: StringResource) {
+    EASTERN_ENGLAND("A", Res.string.retail_region_eastern_england),
+    EAST_MIDLANDS("B", Res.string.retail_region_east_midlands),
+    LONDON("C", Res.string.retail_region_london),
+    MERSEYSIDE_NORTHERN_WALES("D", Res.string.retail_region_merseyside_northern_wales),
+    WEST_MIDLANDS("E", Res.string.retail_region_west_midlands),
+    NORTH_EASTERN_ENGLAND("F", Res.string.retail_region_north_eastern_england),
+    NORTH_WESTERN_ENGLAND("G", Res.string.retail_region_north_western_england),
+    SOUTHERN_ENGLAND("H", Res.string.retail_region_southern_england),
+    SOUTH_EASTERN_ENGLAND("J", Res.string.retail_region_south_eastern_england),
+    SOUTHERN_WALES("K", Res.string.retail_region_southern_wales),
+    SOUTH_WESTERN_ENGLAND("L", Res.string.retail_region_south_western_england),
+    SOUTHERN_SCOTLAND("N", Res.string.retail_region_southern_scotland),
+    YORKSHIRE("M", Res.string.retail_region_yorkshire),
+    NORTHERN_SCOTLAND("P", Res.string.retail_region_northern_scotland),
+    ;
+
+    companion object {
+        fun fromCode(code: String): RetailRegion? {
+            return entries.find { it.code == code }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/product/RetailRegion.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/product/RetailRegion.kt
@@ -42,7 +42,7 @@ enum class RetailRegion(val code: String, val stringResource: StringResource) {
     ;
 
     companion object {
-        fun fromCode(code: String): RetailRegion? {
+        fun fromCode(code: String?): RetailRegion? {
             return entries.find { it.code == code }
         }
     }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/product/RetailRegionTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/product/RetailRegionTest.kt
@@ -1,0 +1,90 @@
+package com.rwmobi.kunigami.ui.model.product
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class RetailRegionTest {
+
+    // Grouping tests for valid codes
+    @Test
+    fun fromCode_ShouldReturnCorrectRegion_WhenCodeIsA() {
+        assertEquals(RetailRegion.EASTERN_ENGLAND, RetailRegion.fromCode("A"))
+    }
+
+    @Test
+    fun fromCode_ShouldReturnCorrectRegion_WhenCodeIsB() {
+        assertEquals(RetailRegion.EAST_MIDLANDS, RetailRegion.fromCode("B"))
+    }
+
+    @Test
+    fun fromCode_ShouldReturnCorrectRegion_WhenCodeIsC() {
+        assertEquals(RetailRegion.LONDON, RetailRegion.fromCode("C"))
+    }
+
+    @Test
+    fun fromCode_ShouldReturnCorrectRegion_WhenCodeIsD() {
+        assertEquals(RetailRegion.MERSEYSIDE_NORTHERN_WALES, RetailRegion.fromCode("D"))
+    }
+
+    @Test
+    fun fromCode_ShouldReturnCorrectRegion_WhenCodeIsE() {
+        assertEquals(RetailRegion.WEST_MIDLANDS, RetailRegion.fromCode("E"))
+    }
+
+    @Test
+    fun fromCode_ShouldReturnCorrectRegion_WhenCodeIsF() {
+        assertEquals(RetailRegion.NORTH_EASTERN_ENGLAND, RetailRegion.fromCode("F"))
+    }
+
+    @Test
+    fun fromCode_ShouldReturnCorrectRegion_WhenCodeIsG() {
+        assertEquals(RetailRegion.NORTH_WESTERN_ENGLAND, RetailRegion.fromCode("G"))
+    }
+
+    @Test
+    fun fromCode_ShouldReturnCorrectRegion_WhenCodeIsH() {
+        assertEquals(RetailRegion.SOUTHERN_ENGLAND, RetailRegion.fromCode("H"))
+    }
+
+    @Test
+    fun fromCode_ShouldReturnCorrectRegion_WhenCodeIsJ() {
+        assertEquals(RetailRegion.SOUTH_EASTERN_ENGLAND, RetailRegion.fromCode("J"))
+    }
+
+    @Test
+    fun fromCode_ShouldReturnCorrectRegion_WhenCodeIsK() {
+        assertEquals(RetailRegion.SOUTHERN_WALES, RetailRegion.fromCode("K"))
+    }
+
+    @Test
+    fun fromCode_ShouldReturnCorrectRegion_WhenCodeIsL() {
+        assertEquals(RetailRegion.SOUTH_WESTERN_ENGLAND, RetailRegion.fromCode("L"))
+    }
+
+    @Test
+    fun fromCode_ShouldReturnCorrectRegion_WhenCodeIsN() {
+        assertEquals(RetailRegion.SOUTHERN_SCOTLAND, RetailRegion.fromCode("N"))
+    }
+
+    @Test
+    fun fromCode_ShouldReturnCorrectRegion_WhenCodeIsM() {
+        assertEquals(RetailRegion.YORKSHIRE, RetailRegion.fromCode("M"))
+    }
+
+    @Test
+    fun fromCode_ShouldReturnCorrectRegion_WhenCodeIsP() {
+        assertEquals(RetailRegion.NORTHERN_SCOTLAND, RetailRegion.fromCode("P"))
+    }
+
+    // Grouping tests for invalid codes
+    @Test
+    fun fromCode_ShouldReturnNull_WhenCodeIsInvalid() {
+        assertNull(RetailRegion.fromCode("X"))
+    }
+
+    @Test
+    fun fromCode_ShouldReturnNull_WhenCodeIsEmpty() {
+        assertNull(RetailRegion.fromCode(""))
+    }
+}


### PR DESCRIPTION
Implement the missing tariff code matching function so now agile screen can detect if the selected Agile tariff is the same as the user's active tariff.

Implement lookup table for Retail Region.

This comes with unit test.