### PR TITLE
(#184) Fix proguard rules for desktop release builds

### DIFF
--- a/.github/workflows/tag_create_windows_distributions.yml
+++ b/.github/workflows/tag_create_windows_distributions.yml
@@ -19,7 +19,7 @@ jobs:
           cache: gradle
 
       - name: Build and Package Project
-        run: .\gradlew packageDistributionForCurrentOS
+        run: .\gradlew packageReleaseDistributionForCurrentOS
         env:
           CI: 'false'
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -306,7 +306,6 @@ compose.desktop {
             }
         }
 
-        // Release builds can be generated but not running properly at the moment
         buildTypes.release.proguard {
             obfuscate = true
             optimize = true

--- a/composeApp/compose-desktop.pro
+++ b/composeApp/compose-desktop.pro
@@ -17,7 +17,6 @@
 
 # Kotlinx Serialization
 -keep class kotlinx.serialization.** { *; }
--keepclassmembers class kotlinx.serialization.** { *; }
 -dontwarn kotlinx.serialization.**
 -keepnames class kotlinx.serialization.internal.** { *; }
 

--- a/composeApp/compose-desktop.pro
+++ b/composeApp/compose-desktop.pro
@@ -7,6 +7,7 @@
 # Keep Ktor classes
 -keep class io.ktor.** { *; }
 -dontwarn io.ktor.**
+-dontnote io.ktor.**
 
 # Keep all DTO classes in the package
 -keep class com.rwmobi.kunigami.data.source.network.dto.** { *; }

--- a/composeApp/compose-desktop.pro
+++ b/composeApp/compose-desktop.pro
@@ -6,12 +6,28 @@
 
 # Keep Ktor classes
 -keep class io.ktor.** { *; }
+-dontwarn io.ktor.**
+
+# Keep all DTO classes in the package
+-keep class com.rwmobi.kunigami.data.source.network.dto.** { *; }
+-keep class com.rwmobi.kunigami.domain.model.** { *; }
+
+# Keep the class and fields of kotlinx.datetime.Instant
+-keep class kotlinx.datetime.Instant { *; }
 
 # Kotlinx Serialization
 -keep class kotlinx.serialization.** { *; }
 -keepclassmembers class kotlinx.serialization.** { *; }
 -dontwarn kotlinx.serialization.**
 -keepnames class kotlinx.serialization.internal.** { *; }
+
+# Do not warn about missing annotations and metadata
+-dontwarn kotlin.Metadata
+-dontwarn kotlin.jvm.internal.**
+-dontwarn kotlin.reflect.jvm.internal.**
+
+# Keep necessary Kotlin attributes
+-keepattributes Signature, *Annotation*
 
 # JNA classes
 -keep class com.sun.jna.** { *; }

--- a/composeApp/compose-desktop.pro
+++ b/composeApp/compose-desktop.pro
@@ -2,13 +2,72 @@
 # You can control the set of applied configuration files using the
 # proguardFiles setting in build.gradle.
 #
+# Reference: https://github.com/Kotlin/kotlinx.coroutines/blob/13f27f729547e5c22d17d5b5de3582d450b037b4/kotlinx-coroutines-core/jvm/resources/META-INF/com.android.tools/proguard/coroutines.pro
 
--dontwarn javax.annotation.concurrent.GuardedBy
--dontwarn javax.annotation.Nullable
--dontwarn kotlinx.datetime.**
--dontwarn org.slf4j.**
--keep class org.slf4j.**{ *; }
--keep class com.sun.jna.* { *; }
--keep class * implements com.sun.jna.* { *; }
--dontwarn io.github.**
+# Keep Ktor classes
+-keep class io.ktor.** { *; }
+
+# Kotlinx Serialization
+-keep class kotlinx.serialization.** { *; }
+-keepclassmembers class kotlinx.serialization.** { *; }
+-dontwarn kotlinx.serialization.**
+-keepnames class kotlinx.serialization.internal.** { *; }
+
+# JNA classes
+-keep class com.sun.jna.** { *; }
+-keepclassmembers class * extends com.sun.jna.** { public *; }
+-keep class * implements com.sun.jna.** { *; }
 -dontnote com.sun.**
+
+# Logging classes, if logging is required
+-keep class org.slf4j.** { *; }
+-keep class org.slf4j.impl.** { *; }
+-keep class ch.qos.logback.** { *; }
+-dontwarn org.slf4j.**
+
+# OSHI classes
+-keep class oshi.** { *; }
+
+# Keep the entire MacOSThemeDetector class and its nested classes
+-keep class com.jthemedetecor.** { *; }
+-keep class com.jthemedetecor.MacOSThemeDetector$* { *; }
+
+# Annotated interfaces (including methods which are also kept in implementing classes)
+-keepattributes Annotation
+-keepattributes *Annotation*
+
+# ServiceLoader support for kotlinx.coroutines
+-keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}
+-keepnames class kotlinx.coroutines.CoroutineExceptionHandler {}
+
+# Keeping the implementations of exception handlers and Main dispatchers
+-keep class * implements kotlinx.coroutines.internal.MainDispatcherFactory
+-keep class * implements kotlinx.coroutines.CoroutineExceptionHandler
+
+# Most of volatile fields are updated with AFU and should not be mangled
+-keepclassmembers class kotlinx.coroutines.** {
+    volatile <fields>;
+}
+
+# Same story for the standard library's SafeContinuation that also uses AtomicReferenceFieldUpdater
+-keepclassmembers class kotlin.coroutines.SafeContinuation {
+    volatile <fields>;
+}
+
+# These classes are only required by kotlinx.coroutines.debug.AgentPremain, which is only loaded when
+# kotlinx-coroutines-core is used as a Java agent, so these are not needed in contexts where ProGuard is used.
+-dontwarn java.lang.instrument.ClassFileTransformer
+-dontwarn sun.misc.SignalHandler
+-dontwarn java.lang.instrument.Instrumentation
+-dontwarn sun.misc.Signal
+
+# Only used in `kotlinx.coroutines.internal.ExceptionsConstructor`.
+# The case when it is not available is hidden in a `try`-`catch`, as well as a check for Android.
+-dontwarn java.lang.ClassValue
+
+# An annotation used for build tooling, won't be directly accessed.
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# Additional dontwarn rules for common issues
+-dontwarn java.awt.**
+-dontwarn javax.annotation.**

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -229,7 +229,7 @@ fun AgileScreen(
                                             top = dimension.grid_1,
                                         ),
                                     agileTariffSummary = uiState.agileTariffSummary,
-                                    differentTariffSummary = differentTariffSummary,
+                                    differentTariffSummary = if (uiState.agileTariffSummary != null) differentTariffSummary else null,
                                     colorPalette = colorPalette,
                                     rateRange = uiState.rateRange,
                                     rateGroupedCells = uiState.rateGroupedCells,


### PR DESCRIPTION
JetBrains is not giving this a f- so we have to figure out all the Proguard rules, including the common Kotlin Coroutines and Ktor dependencies, like ages ago when we did not have R8.

This PR properly adds all the rules so that the necessary classes are kept and we can properly obfuscate and optimise the release builds for desktop apps. 

