### PR TITLE
Ktor: switch engine from CIO to OkHttp for Android

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -84,6 +84,7 @@ kotlin {
             implementation(libs.androidx.lifecycle.runtime.compose)
             implementation(libs.androidx.security.crypto)
             implementation(libs.kotlinx.coroutines.android)
+            implementation(libs.ktor.client.okhttp)
             implementation(libs.koin.android)
         }
         commonMain.dependencies {

--- a/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/di/PlatformModule.kt
+++ b/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/di/PlatformModule.kt
@@ -10,11 +10,11 @@ package com.rwmobi.kunigami.di
 import com.russhwolf.settings.Settings
 import com.rwmobi.kunigami.data.source.local.preferences.provideSettings
 import io.ktor.client.engine.HttpClientEngine
-import io.ktor.client.engine.cio.CIO
+import io.ktor.client.engine.okhttp.OkHttp
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
 val platformModule = module {
-    single<HttpClientEngine> { CIO.create() }
+    single<HttpClientEngine> { OkHttp.create() }
     single<Settings> { provideSettings(context = androidContext().applicationContext) }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,7 @@ compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", versi
 compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "composeUiTooling" }
 ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor" }
+ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-darwin = { group = "io.ktor", name = "ktor-client-darwin", version.ref = "ktor" }


### PR DESCRIPTION
This is because to use Android Studio's network inspector, the easiest way is to change CIO to OkHttp without any extra configuration.

For practical consideration, we have no reason to stick to CIO