### PR TITLE
(#189) add standing charge ratio indicator

### DIFF
--- a/composeApp/composeApp.podspec
+++ b/composeApp/composeApp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'composeApp'
-    spec.version                  = '1.1.0'
+    spec.version                  = '1.2.0'
     spec.homepage                 = 'https://github.com/ryanw-mobile/OctoMeter/'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -55,7 +55,8 @@
     <string name="usage_estimated_daily">Daily average: %1$s kWh / £%2$s</string>
     <string name="usage_annual_projection">Projected annual consumption</string>
     <string name="usage_demo_introduction">Demo Mode: The consumption figures shown are randomly generated.</string>
-
+    <string name="usage_consumption">Consumption</string>
+    <string name="usage_standing_charge">Standing Charge</string>
 
     <!-- Agile -->
     <string name="agile_demo_introduction">Demo Mode: The Agile Tariff shown for Retail Region A may not be available to you.</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="night_unit_rate">Night Unit Rate</string>
     <string name="unit_p_day">%1$d p/day</string>
     <string name="unit_p_kwh">%1$d p/kWh</string>
+    <string name="unit_percent">%1$d %</string>
 
     <string name="selected">Selected</string>
     <string name="loading">Loading...</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -109,7 +109,7 @@
 
     <!-- Account Screen -->
     <string name="account_clear_credential_title">Clear Credentials and Switch to Demo Mode</string>
-    <string name="account_clear_credential_description">Removing your API token and any account-specific data from local storage. Under demo mode, the application will utilise simulated local data to replicate authenticated access. Additionally, it will default to retail region A when retrieving tariffs.</string>
+    <string name="account_clear_credential_description">Removing your API token and any account-specific data from local storage. Under demo mode, the application will utilise simulated local data to replicate authenticated access. Additionally, it will default to Eastern England when retrieving tariffs.</string>
     <string name="account_clear_credential_button_cta">Clear</string>
     <string name="account_version_api_disclaimer">OctoMeter Version %1$s (Build %2$d)\n%3$s\n\nThe APIs are provided by Octopus Energy Ltd. Usage subject to their terms of service.</string>
 
@@ -136,7 +136,7 @@
 
     <!-- Onboarding -->
     <string name="onboarding_welcome_aboard">Welcome Aboard!</string>
-    <string name="onboarding_introduction_1">This app is currently running in demo mode, using simulated local data to replicate authenticated access. This means the electricity usage data displayed is not real. Additionally, the app will default to retail region A when retrieving tariffs.</string>
+    <string name="onboarding_introduction_1">This app is currently running in demo mode, using simulated local data to replicate authenticated access. This means the electricity usage data displayed is not real. Additionally, the app will default to Eastern England when retrieving tariffs.</string>
     <string name="onboarding_question_1">Are you an Octopus Energy customer with a smart meter installed?</string>
     <string name="onboarding_introduction_2">If you are a current Octopus Energy customer with a smart meter and have access to your web account, you can generate an API key for this app to pull your smart meter data. Visit: https://octopus.energy/dashboard/new/accounts/personal-details/api-access</string>
     <string name="onboarding_reminder_1">Your API key is confidential, so don't share it with anyone. If you have concerns, regenerating a new key will invalidate all previously issued keys.</string>

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/AnnualProjectionCardAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/AnnualProjectionCardAdaptive.kt
@@ -198,6 +198,7 @@ private fun Preview() {
             insights = Insights(
                 consumptionAggregateRounded = 42.290,
                 consumptionTimeSpan = 8820,
+                consumptionChargeRatio = 0.64,
                 roughCost = 2.815,
                 consumptionAnnualProjection = 48.504,
                 costAnnualProjection = 24.868,
@@ -211,6 +212,7 @@ private fun Preview() {
             insights = Insights(
                 consumptionAggregateRounded = 42.290,
                 consumptionTimeSpan = 8820,
+                consumptionChargeRatio = 0.64,
                 roughCost = 2.815,
                 consumptionAnnualProjection = 48.504,
                 costAnnualProjection = 24.868,
@@ -224,6 +226,7 @@ private fun Preview() {
             insights = Insights(
                 consumptionAggregateRounded = 42.290,
                 consumptionTimeSpan = 8820,
+                consumptionChargeRatio = 0.64,
                 roughCost = 2.815,
                 consumptionAnnualProjection = 48.504,
                 costAnnualProjection = 24.868,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/InsightsCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/InsightsCard.kt
@@ -8,13 +8,17 @@
 package com.rwmobi.kunigami.ui.destinations.usage.components
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -29,7 +33,9 @@ import com.rwmobi.kunigami.ui.model.consumption.Insights
 import com.rwmobi.kunigami.ui.theme.getDimension
 import io.github.koalaplot.core.util.toString
 import kunigami.composeapp.generated.resources.Res
+import kunigami.composeapp.generated.resources.standing_charge
 import kunigami.composeapp.generated.resources.unit_pound
+import kunigami.composeapp.generated.resources.usage_consumption
 import kunigami.composeapp.generated.resources.usage_estimated_cost
 import kunigami.composeapp.generated.resources.usage_estimated_daily
 import kunigami.composeapp.generated.resources.usage_insights_consumption
@@ -96,6 +102,31 @@ internal fun InsightsCard(
                     ),
                 )
             }
+
+            Spacer(modifier = Modifier.weight(weight = 1f))
+
+            RatioBar(
+                modifier = Modifier
+                    .padding(top = dimension.grid_1)
+                    .defaultMinSize(minHeight = dimension.grid_2)
+                    .fillMaxWidth(),
+                consumptionRatio = insights.consumptionChargeRatio,
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    style = MaterialTheme.typography.labelSmall,
+                    text = stringResource(resource = Res.string.usage_consumption),
+                )
+                Spacer(modifier = Modifier.width(dimension.grid_1))
+                Text(
+                    style = MaterialTheme.typography.labelSmall,
+                    text = stringResource(resource = Res.string.standing_charge),
+                )
+            }
         }
     }
 }
@@ -111,6 +142,7 @@ private fun Preview() {
             insights = Insights(
                 consumptionAggregateRounded = 86.693,
                 consumptionTimeSpan = 2084,
+                consumptionChargeRatio = 0.64,
                 roughCost = 2880.027,
                 consumptionDailyAverage = 71.227,
                 costDailyAverage = 52.218,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/RatioBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/RatioBar.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.kunigami.ui.destinations.usage.components
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.unit.dp
+import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import io.github.koalaplot.core.util.toString
+import kunigami.composeapp.generated.resources.Res
+import kunigami.composeapp.generated.resources.unit_percent
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun RatioBar(
+    modifier: Modifier = Modifier,
+    consumptionRatio: Double, // Ratio between 0.0 and 1.0
+) {
+    val consumptionColor = MaterialTheme.colorScheme.primary
+    val standingChargeColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+    val effectiveRatio = consumptionRatio.coerceIn(minimumValue = 0.0, maximumValue = 1.0)
+
+    Box(
+        modifier = modifier
+            .clip(shape = MaterialTheme.shapes.large)
+            .drawBehind {
+                val consumptionWidth = size.width * effectiveRatio.toFloat()
+                val standingChargeWidth = size.width - consumptionWidth
+
+                drawIntoCanvas {
+                    // Draw the consumption part
+                    drawRect(
+                        color = consumptionColor,
+                        size = size.copy(width = consumptionWidth),
+                    )
+
+                    // Draw the standing charge part
+                    drawRect(
+                        color = standingChargeColor,
+                        topLeft = androidx.compose.ui.geometry.Offset(x = consumptionWidth, y = 0f),
+                        size = size.copy(width = standingChargeWidth),
+                    )
+                }
+            },
+    ) {
+        Text(
+            modifier = Modifier.align(alignment = Alignment.Center),
+            style = MaterialTheme.typography.labelSmall,
+            color = Color.White,
+            text = stringResource(resource = Res.string.unit_percent, (consumptionRatio * 100).toString(precision = 0)),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun Preview() {
+    CommonPreviewSetup(
+        modifier = Modifier.padding(all = 8.dp),
+    ) { dimension ->
+        RatioBar(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(dimension.grid_2),
+            consumptionRatio = 0.64,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TariffProjectionsCardAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TariffProjectionsCardAdaptive.kt
@@ -198,6 +198,7 @@ private fun Preview() {
     val insights = Insights(
         consumptionAggregateRounded = 85.115,
         consumptionTimeSpan = 303,
+        consumptionChargeRatio = 0.64,
         roughCost = 90.988,
         consumptionDailyAverage = 32.611,
         costDailyAverage = 12.434,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/Insights.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/Insights.kt
@@ -10,6 +10,7 @@ package com.rwmobi.kunigami.ui.model.consumption
 data class Insights(
     val consumptionAggregateRounded: Double,
     val consumptionTimeSpan: Int,
+    val consumptionChargeRatio: Double,
     val roughCost: Double,
     val consumptionDailyAverage: Double,
     val costDailyAverage: Double,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModel.kt
@@ -266,6 +266,7 @@ class UsageViewModel(
             val consumptionAggregateRounded = consumptions.sumOf { it.consumption }.roundToNearestEvenHundredth()
             val consumptionTimeSpan = consumptions.getConsumptionTimeSpan()
             val roughCost = ((consumptionTimeSpan * tariffSummary.vatInclusiveStandingCharge) + (consumptionAggregateRounded * tariffSummary.vatInclusiveUnitRate)) / 100.0
+            val consumptionChargeRatio = (consumptionAggregateRounded * tariffSummary.vatInclusiveUnitRate / 100.0) / roughCost
             val consumptionDailyAverage = (consumptions.sumOf { it.consumption } / consumptions.getConsumptionTimeSpan()).roundToNearestEvenHundredth()
             val costDailyAverage = (tariffSummary.vatInclusiveStandingCharge + consumptionDailyAverage * tariffSummary.vatInclusiveUnitRate) / 100.0
             val consumptionAnnualProjection = (consumptions.sumOf { it.consumption } / consumptionTimeSpan * 365.25).roundToNearestEvenHundredth()
@@ -274,6 +275,7 @@ class UsageViewModel(
             Insights(
                 consumptionAggregateRounded = consumptionAggregateRounded,
                 consumptionTimeSpan = consumptionTimeSpan,
+                consumptionChargeRatio = consumptionChargeRatio,
                 roughCost = roughCost,
                 consumptionDailyAverage = consumptionDailyAverage,
                 costDailyAverage = costDailyAverage,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,8 +37,8 @@ baselineprofile = "1.2.4"
 profileinstaller = "1.3.1"
 
 # App configurations, not dependencies
-versionCode = "6"
-versionName = "1.1.0"
+versionCode = "7"
+versionName = "1.2.0"
 android-minSdk = "26"
 android-targetSdk = "34"
 android-compileSdk = "34"

--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - composeApp (1.1.0)
+  - composeApp (1.2.0)
 
 DEPENDENCIES:
   - composeApp (from `../composeApp/`)

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
Added a ratio bar to the Usage Screen showing the percentage of the money paid for the actual consumption over the standing charge.

This won't be very meaningful until we implement another ticket that we do a true half-hourly rate matching (especially when on Agile / variable tariff)

This ticket upon merging is good for v.1.20 release