### PR TITLE
(#205) Phase out kotest assertions and introduce Kotlin Power Assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ improved later:
 * [Kotlinx DateTime](https://github.com/Kotlin/kotlinx-datetime) - Apache 2.0 - A multiplatform Kotlin library for working with date and time
 * [Kotlinx Coroutines](https://github.com/Kotlin/kotlinx.coroutines) - Apache 2.0 - Libraries for Kotlin coroutines
 * [Kotlinx Serialization](https://github.com/Kotlin/kotlinx.serialization) - Apache 2.0 - Kotlin multiplatform serialization library
-* [Kotest](https://kotest.io/) - Apache 2.0 - Kotlin test framework
 * [Material3 Window Size Class Multiplatform](https://github.com/material-components/material-components-android) - Apache 2.0 - Material Design components for Jetpack Compose
 * [Koin](https://insert-koin.io/) - Apache 2.0 - Dependency injection framework for Kotlin
 * [LeakCanary](https://square.github.io/leakcanary/) - Apache 2.0 - A memory leak detection library for Android
@@ -129,6 +128,7 @@ improved later:
 * [Compose Compiler Plugin](https://developer.android.com/jetpack/compose) - JetBrains - Plugin for Jetpack Compose
 * [Kotlin Multiplatform Plugin](https://kotlinlang.org/docs/multiplatform.html) - JetBrains - Plugin for Kotlin Multiplatform projects
 * [Kotlin CocoaPods Plugin](https://kotlinlang.org/docs/native-cocoapods.html) - JetBrains - Plugin for integrating with CocoaPods
+* [Kotlin Power Assert Plugin](https://kotlinlang.org/docs/reference/power-assert.html) - JetBrains - Plugin for enhanced assertions in Kotlin
 * [Ktlint Plugin](https://github.com/JLLeitschuh/ktlint-gradle) - JLLeitschuh - Plugin for Kotlin linter
 * [Kover Plugin](https://github.com/Kotlin/kotlinx-kover) - JetBrains - Code coverage tool for Kotlin
 * [Serialization Plugin](https://github.com/Kotlin/kotlinx.serialization) - JetBrains - Plugin for Kotlin serialization

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -26,6 +26,7 @@ plugins {
     alias(libs.plugins.buildConfig)
     alias(libs.plugins.kotlinCocoapods)
     alias(libs.plugins.baselineprofile)
+    alias(libs.plugins.kotlinPowerAssert)
 }
 
 val productName = "OctoMeter"
@@ -361,6 +362,17 @@ buildConfig {
     buildConfigField("VERSION_NAME", provider { libs.versions.versionName.get() })
     buildConfigField("VERSION_CODE", provider { libs.versions.versionCode.get() })
     buildConfigField("GITHUB_LINK", provider { "https://github.com/ryanw-mobile/OctoMeter" })
+}
+
+@OptIn(ExperimentalKotlinGradlePluginApi::class)
+powerAssert {
+    functions.addAll(
+        "kotlin.assert",
+        "kotlin.test.assertTrue",
+        "kotlin.test.assertEquals",
+        "kotlin.test.assertNull",
+        "kotlin.require",
+    )
 }
 
 kover {

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -129,7 +136,6 @@ kotlin {
             implementation(kotlin("test-annotations-common"))
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.ktor.client.mock)
-            implementation(libs.kotest.assertions.core)
             implementation(libs.koin.test)
         }
     }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/AccountEndpointTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/AccountEndpointTest.kt
@@ -9,8 +9,6 @@ package com.rwmobi.kunigami.data.source.network
 
 import com.rwmobi.kunigami.data.source.network.samples.GetAccountSampleData
 import com.rwmobi.kunigami.domain.exceptions.HttpException
-import io.kotest.assertions.throwables.shouldThrowExactly
-import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -24,6 +22,9 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.fail
 
 class AccountEndpointTest {
     private val fakeBaseUrl = "https://some.fakeurl.com"
@@ -70,7 +71,7 @@ class AccountEndpointTest {
             apiKey = fakeApiKey,
             accountNumber = fakeAccountNumber,
         )
-        result shouldBe GetAccountSampleData.dto
+        assertEquals(GetAccountSampleData.dto, result)
     }
 
     @Test
@@ -88,7 +89,7 @@ class AccountEndpointTest {
             apiKey = fakeApiKey,
             accountNumber = fakeAccountNumber,
         )
-        result shouldBe null
+        assertNull(result)
     }
 
     @Test
@@ -102,11 +103,14 @@ class AccountEndpointTest {
             ),
         )
 
-        shouldThrowExactly<HttpException> {
+        try {
             accountEndpoint.getAccount(
                 apiKey = fakeApiKey,
                 accountNumber = fakeAccountNumber,
             )
+            fail("Expected HttpException")
+        } catch (e: HttpException) {
+            // Successful if HttpException is thrown
         }
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/ElectricityMeterPointsEndpointTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/ElectricityMeterPointsEndpointTest.kt
@@ -9,8 +9,6 @@ package com.rwmobi.kunigami.data.source.network
 
 import com.rwmobi.kunigami.data.source.network.samples.GetConsumptionSampleData
 import com.rwmobi.kunigami.domain.exceptions.HttpException
-import io.kotest.assertions.throwables.shouldThrowExactly
-import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -24,6 +22,9 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.fail
 
 class ElectricityMeterPointsEndpointTest {
     private val fakeBaseUrl = "https://some.fakeurl.com"
@@ -72,7 +73,7 @@ class ElectricityMeterPointsEndpointTest {
             mpan = fakeMpan,
             meterSerialNumber = fakeMeterSerialNumber,
         )
-        result shouldBe GetConsumptionSampleData.dto
+        assertEquals(GetConsumptionSampleData.dto, result)
     }
 
     @Test
@@ -91,7 +92,7 @@ class ElectricityMeterPointsEndpointTest {
             mpan = fakeMpan,
             meterSerialNumber = fakeMeterSerialNumber,
         )
-        result shouldBe null
+        assertNull(result)
     }
 
     @Test
@@ -105,12 +106,15 @@ class ElectricityMeterPointsEndpointTest {
             ),
         )
 
-        shouldThrowExactly<HttpException> {
+        try {
             electricityMeterPointsEndpoint.getConsumption(
                 apiKey = fakeApiKey,
                 mpan = fakeMpan,
                 meterSerialNumber = fakeMeterSerialNumber,
             )
+            fail("Expected HttpException")
+        } catch (e: HttpException) {
+            // Successful if HttpException is thrown
         }
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/ProductsEndpointTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/ProductsEndpointTest.kt
@@ -14,8 +14,6 @@ import com.rwmobi.kunigami.data.source.network.samples.GetProductsSampleData
 import com.rwmobi.kunigami.data.source.network.samples.GetStandardUnitRatesSampleData
 import com.rwmobi.kunigami.data.source.network.samples.GetStandingChargesSampleData
 import com.rwmobi.kunigami.domain.exceptions.HttpException
-import io.kotest.assertions.throwables.shouldThrowExactly
-import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -29,6 +27,9 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.fail
 
 class ProductsEndpointTest {
     private val fakeBaseUrl = "https://some.fakeurl.com"
@@ -70,7 +71,7 @@ class ProductsEndpointTest {
         )
 
         val result = productsEndpoint.getProducts()
-        result shouldBe GetProductsSampleData.dto
+        assertEquals(GetProductsSampleData.dto, result)
     }
 
     @Test
@@ -85,7 +86,7 @@ class ProductsEndpointTest {
         )
 
         val result = productsEndpoint.getProducts()
-        result shouldBe null
+        assertNull(result)
     }
 
     @Test
@@ -99,8 +100,11 @@ class ProductsEndpointTest {
             ),
         )
 
-        shouldThrowExactly<HttpException> {
+        try {
             productsEndpoint.getProducts()
+            fail("Expected HttpException")
+        } catch (e: HttpException) {
+            // Successful if HttpException is thrown
         }
     }
 
@@ -117,7 +121,7 @@ class ProductsEndpointTest {
         )
 
         val result = productsEndpoint.getProduct(productCode = "sample-product-code")
-        result shouldBe GetProductSampleData.dto_var_22_11_01
+        assertEquals(GetProductSampleData.dto_var_22_11_01, result)
     }
 
     @Test
@@ -132,7 +136,7 @@ class ProductsEndpointTest {
         )
 
         val result = productsEndpoint.getProduct(productCode = "sample-product-code")
-        result shouldBe null
+        assertNull(result)
     }
 
     @Test
@@ -147,7 +151,7 @@ class ProductsEndpointTest {
         )
 
         val result = productsEndpoint.getProduct(productCode = "sample-product-code")
-        result shouldBe GetProductSampleData.dto_agile_flex_22_11_25
+        assertEquals(GetProductSampleData.dto_agile_flex_22_11_25, result)
     }
 
     @Test
@@ -162,7 +166,7 @@ class ProductsEndpointTest {
         )
 
         val result = productsEndpoint.getProduct(productCode = "sample-product-code")
-        result shouldBe GetProductSampleData.dto_oe_fix_12m_24_04_11
+        assertEquals(GetProductSampleData.dto_oe_fix_12m_24_04_11, result)
     }
 
     @Test
@@ -176,8 +180,11 @@ class ProductsEndpointTest {
             ),
         )
 
-        shouldThrowExactly<HttpException> {
+        try {
             productsEndpoint.getProduct(productCode = "sample-product-code")
+            fail("Expected HttpException")
+        } catch (e: HttpException) {
+            // Successful if HttpException is thrown
         }
     }
 
@@ -197,7 +204,7 @@ class ProductsEndpointTest {
             productCode = "fake-product-code",
             tariffCode = "fake-tariff-code",
         )
-        result shouldBe GetStandardUnitRatesSampleData.dto
+        assertEquals(GetStandardUnitRatesSampleData.dto, result)
     }
 
     @Test
@@ -215,7 +222,7 @@ class ProductsEndpointTest {
             productCode = "fake-product-code",
             tariffCode = "fake-tariff-code",
         )
-        result shouldBe null
+        assertNull(result)
     }
 
     @Test
@@ -229,11 +236,14 @@ class ProductsEndpointTest {
             ),
         )
 
-        shouldThrowExactly<HttpException> {
+        try {
             productsEndpoint.getStandardUnitRates(
                 productCode = "fake-product-code",
                 tariffCode = "fake-tariff-code",
             )
+            fail("Expected HttpException")
+        } catch (e: HttpException) {
+            // Successful if HttpException is thrown
         }
     }
 
@@ -253,7 +263,7 @@ class ProductsEndpointTest {
             productCode = "fake-product-code",
             tariffCode = "fake-tariff-code",
         )
-        result shouldBe GetStandingChargesSampleData.dto
+        assertEquals(GetStandingChargesSampleData.dto, result)
     }
 
     @Test
@@ -271,7 +281,7 @@ class ProductsEndpointTest {
             productCode = "fake-product-code",
             tariffCode = "fake-tariff-code",
         )
-        result shouldBe null
+        assertNull(result)
     }
 
     @Test
@@ -285,11 +295,14 @@ class ProductsEndpointTest {
             ),
         )
 
-        shouldThrowExactly<HttpException> {
+        try {
             productsEndpoint.getStandingCharges(
                 productCode = "fake-product-code",
                 tariffCode = "fake-tariff-code",
             )
+            fail("Expected HttpException")
+        } catch (e: HttpException) {
+            // Successful if HttpException is thrown
         }
     }
 
@@ -309,7 +322,7 @@ class ProductsEndpointTest {
             productCode = "fake-product-code",
             tariffCode = "fake-tariff-code",
         )
-        result shouldBe GetDayUnitRatesSampleData.dto
+        assertEquals(GetDayUnitRatesSampleData.dto, result)
     }
 
     @Test
@@ -327,7 +340,7 @@ class ProductsEndpointTest {
             productCode = "fake-product-code",
             tariffCode = "fake-tariff-code",
         )
-        result shouldBe null
+        assertNull(result)
     }
 
     @Test
@@ -341,11 +354,14 @@ class ProductsEndpointTest {
             ),
         )
 
-        shouldThrowExactly<HttpException> {
+        try {
             productsEndpoint.getDayUnitRates(
                 productCode = "fake-product-code",
                 tariffCode = "fake-tariff-code",
             )
+            fail("Expected HttpException")
+        } catch (e: HttpException) {
+            // Successful if HttpException is thrown
         }
     }
 
@@ -365,7 +381,7 @@ class ProductsEndpointTest {
             productCode = "fake-product-code",
             tariffCode = "fake-tariff-code",
         )
-        result shouldBe GetNightUnitRatesSampleData.dto
+        assertEquals(GetNightUnitRatesSampleData.dto, result)
     }
 
     @Test
@@ -383,7 +399,7 @@ class ProductsEndpointTest {
             productCode = "fake-product-code",
             tariffCode = "fake-tariff-code",
         )
-        result shouldBe null
+        assertNull(result)
     }
 
     @Test
@@ -397,11 +413,14 @@ class ProductsEndpointTest {
             ),
         )
 
-        shouldThrowExactly<HttpException> {
+        try {
             productsEndpoint.getNightUnitRates(
                 productCode = "fake-product-code",
                 tariffCode = "fake-tariff-code",
             )
+            fail("Expected HttpException")
+        } catch (e: HttpException) {
+            // Successful if HttpException is thrown
         }
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/DoubleExtensionsKtTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/DoubleExtensionsKtTest.kt
@@ -1,7 +1,14 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
 import com.rwmobi.kunigami.domain.extensions.roundToNearestEvenHundredth
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
-import io.kotest.matchers.doubles.shouldBeExactly
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class DoubleExtensionsKtTest {
 
@@ -10,7 +17,7 @@ class DoubleExtensionsKtTest {
         val input = 0.015
         val expected = 0.02
         val result = input.roundToNearestEvenHundredth()
-        result shouldBeExactly expected
+        assertEquals(expected, result)
     }
 
     @Test
@@ -18,7 +25,7 @@ class DoubleExtensionsKtTest {
         val input = 0.025
         val expected = 0.02
         val result = input.roundToNearestEvenHundredth()
-        result shouldBeExactly expected
+        assertEquals(expected, result)
     }
 
     @Test
@@ -26,7 +33,7 @@ class DoubleExtensionsKtTest {
         val input = 0.045
         val expected = 0.04
         val result = input.roundToNearestEvenHundredth()
-        result shouldBeExactly expected
+        assertEquals(expected, result)
     }
 
     @Test
@@ -34,7 +41,7 @@ class DoubleExtensionsKtTest {
         val input = 0.055
         val expected = 0.06
         val result = input.roundToNearestEvenHundredth()
-        result shouldBeExactly expected
+        assertEquals(expected, result)
     }
 
     @Test
@@ -42,7 +49,7 @@ class DoubleExtensionsKtTest {
         val input = 0.1234
         val expected = 0.12
         val result = input.roundToTwoDecimalPlaces()
-        result shouldBeExactly expected
+        assertEquals(expected, result)
     }
 
     @Test
@@ -50,7 +57,7 @@ class DoubleExtensionsKtTest {
         val input = 0.1265
         val expected = 0.13
         val result = input.roundToTwoDecimalPlaces()
-        result shouldBeExactly expected
+        assertEquals(expected, result)
     }
 
     @Test
@@ -58,7 +65,7 @@ class DoubleExtensionsKtTest {
         val input = 0.1245
         val expected = 0.12
         val result = input.roundToTwoDecimalPlaces()
-        result shouldBeExactly expected
+        assertEquals(expected, result)
     }
 
     @Test
@@ -66,6 +73,6 @@ class DoubleExtensionsKtTest {
         val input = 0.1255
         val expected = 0.13
         val result = input.roundToTwoDecimalPlaces()
-        result shouldBeExactly expected
+        assertEquals(expected, result)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensionsKtTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensionsKtTest.kt
@@ -7,13 +7,12 @@
 
 package com.rwmobi.kunigami.domain.extensions
 
-import io.kotest.matchers.longs.shouldBeExactly
-import io.kotest.matchers.shouldBe
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class InstantExtensionsKtTest {
 
@@ -22,40 +21,43 @@ class InstantExtensionsKtTest {
     @Test
     fun `toIso8601WithoutSeconds should format correctly`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 30, second = 15).toInstant(TimeZone.UTC)
-        instant.toIso8601WithoutSeconds() shouldBe "2023-05-01T10:30Z"
+        val expected = "2023-05-01T10:30Z"
+        assertEquals(expected, instant.toIso8601WithoutSeconds())
     }
 
     @Test
     fun `atStartOfHour should round down correctly`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
         val expected = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 0, second = 0).toInstant(timeZone)
-        instant.atStartOfHour() shouldBe expected
+        assertEquals(expected, instant.atStartOfHour())
     }
 
     @Test
     fun `atStartOfDay should round down to start of day`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
         val expected = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 0, minute = 0, second = 0).toInstant(timeZone)
-        instant.atStartOfDay() shouldBe expected
+        assertEquals(expected, instant.atStartOfDay())
     }
 
     @Test
     fun `atEndOfDay should round up to end of day`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
         val expected = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 23, minute = 59, second = 59, nanosecond = 999_999_999).toInstant(timeZone)
-        instant.atEndOfDay() shouldBe expected
+        assertEquals(expected, instant.atEndOfDay())
     }
 
     @Test
     fun `getLocalHHMMString should format correctly`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
-        instant.getLocalHHMMString() shouldBe "10:45"
+        val expected = "10:45"
+        assertEquals(expected, instant.getLocalHHMMString())
     }
 
     @Test
     fun `getLocalHourString should format correctly`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
-        instant.getLocalHourString() shouldBe "10"
+        val expected = "10"
+        assertEquals(expected, instant.getLocalHourString())
     }
 
     // This is not a very good test because it depends on platform AND local settings
@@ -63,105 +65,106 @@ class InstantExtensionsKtTest {
     fun `toLocalDateTimeString should format correctly`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
         val localDateString = instant.getLocalDateString()
-        instant.toLocalDateTimeString() shouldBe "$localDateString 10:45"
+        val expected = "$localDateString 10:45"
+        assertEquals(expected, instant.toLocalDateTimeString())
     }
 
     @Test
     fun `getLocalYear should return correct year`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
-        instant.getLocalYear() shouldBe 2023
+        val expected = 2023
+        assertEquals(expected, instant.getLocalYear())
     }
 
     @Test
     fun `getLocalDayOfMonth should return correct day`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
-        instant.getLocalDayOfMonth() shouldBe 1
+        val expected = 1
+        assertEquals(expected, instant.getLocalDayOfMonth())
     }
 
     @Test
     fun `getLocalEnglishAbbreviatedDayOfWeekName should return correct weekday`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
-        instant.getLocalEnglishAbbreviatedDayOfWeekName() shouldBe "Mon"
+        val expected = "Mon"
+        assertEquals(expected, instant.getLocalEnglishAbbreviatedDayOfWeekName())
     }
 
     @Test
     fun `getLocalDayOfWeekAndDayString should return correct weekday and day`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
-        instant.getLocalDayOfWeekAndDayString() shouldBe "Mon 01"
+        val expected = "Mon 01"
+        assertEquals(expected, instant.getLocalDayOfWeekAndDayString())
     }
 
     @Test
     fun `getLocalDayMonthString should return correct day and month`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
-        instant.getLocalDayMonthString() shouldBe "01 May"
+        val expected = "01 May"
+        assertEquals(expected, instant.getLocalDayMonthString())
     }
 
     @Test
     fun `getLocalMonthString should return correct month`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
-        instant.getLocalMonthString() shouldBe "May"
+        val expected = "May"
+        assertEquals(expected, instant.getLocalMonthString())
     }
 
     @Test
     fun `getLocalMonthYearString should return correct month and year`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
-        instant.getLocalMonthYearString() shouldBe "May 2023"
+        val expected = "May 2023"
+        assertEquals(expected, instant.getLocalMonthYearString())
     }
 
     @Test
     fun `getNextHalfHourCountdownMillis should return correct millis when current time is exactly on the hour`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 0, second = 0, nanosecond = 0).toInstant(timeZone)
-        val millis = instant.getNextHalfHourCountdownMillis()
-        val expectedMillis = 30 * 60 * 1000L // 30 minutes in milliseconds
-        millis shouldBeExactly expectedMillis
+        val expected = 30 * 60 * 1000L // 30 minutes in milliseconds
+        assertEquals(expected, instant.getNextHalfHourCountdownMillis())
     }
 
     @Test
     fun `getNextHalfHourCountdownMillis should return correct millis when current time is exactly on the half hour`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 30, second = 0, nanosecond = 0).toInstant(timeZone)
-        val millis = instant.getNextHalfHourCountdownMillis()
-        val expectedMillis = 30 * 60 * 1000L // 30 minutes in milliseconds
-        millis shouldBeExactly expectedMillis
+        val expected = 30 * 60 * 1000L // 30 minutes in milliseconds
+        assertEquals(expected, instant.getNextHalfHourCountdownMillis())
     }
 
     @Test
     fun `getNextHalfHourCountdownMillis should return correct millis when current time is just past the hour`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 1, second = 0, nanosecond = 0).toInstant(timeZone)
-        val millis = instant.getNextHalfHourCountdownMillis()
-        val expectedMillis = 29 * 60 * 1000L // 29 minutes in milliseconds
-        millis shouldBeExactly expectedMillis
+        val expected = 29 * 60 * 1000L // 29 minutes in milliseconds
+        assertEquals(expected, instant.getNextHalfHourCountdownMillis())
     }
 
     @Test
     fun `getNextHalfHourCountdownMillis should return correct millis when current time is just past the half hour`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 31, second = 0, nanosecond = 0).toInstant(timeZone)
-        val millis = instant.getNextHalfHourCountdownMillis()
-        val expectedMillis = 29 * 60 * 1000L // 29 minutes in milliseconds
-        millis shouldBeExactly expectedMillis
+        val expected = 29 * 60 * 1000L // 29 minutes in milliseconds
+        assertEquals(expected, instant.getNextHalfHourCountdownMillis())
     }
 
     @Test
     fun `getNextHalfHourCountdownMillis should return correct millis when current time is just before the half hour`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 29, second = 30, nanosecond = 0).toInstant(timeZone)
-        val millis = instant.getNextHalfHourCountdownMillis()
-        val expectedMillis = 30 * 1000L // 30 seconds in milliseconds
-        millis shouldBeExactly expectedMillis
+        val expected = 30 * 1000L // 30 seconds in milliseconds
+        assertEquals(expected, instant.getNextHalfHourCountdownMillis())
     }
 
     @Test
     fun `getNextHalfHourCountdownMillis should return correct millis when current time is just before the hour`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 59, second = 30, nanosecond = 0).toInstant(timeZone)
-        val millis = instant.getNextHalfHourCountdownMillis()
-        val expectedMillis = 30 * 1000L // 30 seconds in milliseconds
-        millis shouldBeExactly expectedMillis
+        val expected = 30 * 1000L // 30 seconds in milliseconds
+        assertEquals(expected, instant.getNextHalfHourCountdownMillis())
     }
 
     @Test
     fun `getNextHalfHourCountdownMillis should return correct millis including nanoseconds`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 29, second = 59, nanosecond = 999_000_000).toInstant(timeZone)
-        val millis = instant.getNextHalfHourCountdownMillis()
-        val expectedMillis = 1L // 1 millisecond
-        millis shouldBeExactly expectedMillis
+        val expected = 1L // 1 millisecond
+        assertEquals(expected, instant.getNextHalfHourCountdownMillis())
     }
 
     /***
@@ -176,7 +179,7 @@ class InstantExtensionsKtTest {
             .toInstant(londonZone)
         val actualStartOfDay = expectedStartOfDay.atStartOfDay()
 
-        actualStartOfDay shouldBe expectedStartOfDay
+        assertEquals(expectedStartOfDay, actualStartOfDay)
     }
 
     @Test
@@ -186,7 +189,7 @@ class InstantExtensionsKtTest {
             .toInstant(londonZone)
         val actualEndOfDay = expectedEndOfDay.atEndOfDay()
 
-        actualEndOfDay shouldBe expectedEndOfDay
+        assertEquals(expectedEndOfDay, actualEndOfDay)
     }
 
     @Test
@@ -197,7 +200,7 @@ class InstantExtensionsKtTest {
             .toInstant(londonZone)
         val actualStartOfDay = expectedStartOfDay.atStartOfDay()
 
-        actualStartOfDay shouldBe expectedStartOfDay
+        assertEquals(expectedStartOfDay, actualStartOfDay)
     }
 
     @Test
@@ -208,6 +211,6 @@ class InstantExtensionsKtTest {
             .toInstant(londonZone)
         val actualEndOfDay = expectedEndOfDay.atEndOfDay()
 
-        actualEndOfDay shouldBe expectedEndOfDay
+        assertEquals(expectedEndOfDay, actualEndOfDay)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/RateTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/RateTest.kt
@@ -8,11 +8,12 @@
 package com.rwmobi.kunigami.domain.model
 
 import com.rwmobi.kunigami.domain.samples.RateSampleData
-import io.kotest.matchers.shouldBe
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class RateTest {
 
@@ -30,7 +31,7 @@ class RateTest {
             second = 0,
         ).toInstant(timeZone)
 
-        rate.isActive(referencePoint) shouldBe true
+        assertTrue(rate.isActive(referencePoint))
     }
 
     @Test
@@ -45,7 +46,7 @@ class RateTest {
             second = 59,
         ).toInstant(timeZone)
 
-        rate.isActive(referencePoint) shouldBe false
+        assertFalse(rate.isActive(referencePoint))
     }
 
     @Test
@@ -60,7 +61,7 @@ class RateTest {
             second = 0,
         ).toInstant(timeZone)
 
-        rate.isActive(referencePoint) shouldBe false
+        assertFalse(rate.isActive(referencePoint))
     }
 
     @Test
@@ -75,7 +76,7 @@ class RateTest {
             second = 0,
         ).toInstant(timeZone)
 
-        rate.isActive(referencePoint) shouldBe true
+        assertTrue(rate.isActive(referencePoint))
     }
 
     @Test
@@ -90,6 +91,6 @@ class RateTest {
             second = 59,
         ).toInstant(timeZone)
 
-        rate.isActive(referencePoint) shouldBe false
+        assertFalse(rate.isActive(referencePoint))
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/TariffTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/TariffTest.kt
@@ -8,7 +8,7 @@
 package com.rwmobi.kunigami.domain.model
 
 import com.rwmobi.kunigami.domain.model.product.TariffSummary
-import kotlinx.datetime.Clock
+import com.rwmobi.kunigami.domain.samples.TariffSampleData
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -16,17 +16,16 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class TariffTest {
+    val tariffCode1125A = "E-1R-AGILE-FLEX-22-11-25-A"
+    val tariffCode0411C = "E-2R-OE-FIX-12M-24-04-11-C"
+    val tariffCode1101A = "E-2R-VAR-22-11-01-A"
+    val tariffCode1101P = "E-2R-VAR-22-11-01-P"
 
     @Test
     fun `extractProductCode should return correct product code`() {
-        val tariffCode1 = "E-1R-AGILE-FLEX-22-11-25-A"
-        assertEquals("AGILE-FLEX-22-11-25", TariffSummary.extractProductCode(tariffCode1))
-
-        val tariffCode2 = "E-2R-OE-FIX-12M-24-04-11-C"
-        assertEquals("OE-FIX-12M-24-04-11", TariffSummary.extractProductCode(tariffCode2))
-
-        val tariffCode3 = "E-2R-VAR-22-11-01-A"
-        assertEquals("VAR-22-11-01", TariffSummary.extractProductCode(tariffCode3))
+        assertEquals("AGILE-FLEX-22-11-25", TariffSummary.extractProductCode(tariffCode1125A))
+        assertEquals("OE-FIX-12M-24-04-11", TariffSummary.extractProductCode(tariffCode0411C))
+        assertEquals("VAR-22-11-01", TariffSummary.extractProductCode(tariffCode1101A))
 
         val invalidTariffCode = "E-1R"
         assertNull(TariffSummary.extractProductCode(invalidTariffCode))
@@ -34,14 +33,9 @@ class TariffTest {
 
     @Test
     fun `getRetailRegion should return correct retail region`() {
-        val tariffCode1 = "E-1R-AGILE-FLEX-22-11-25-A"
-        assertEquals("A", TariffSummary.getRetailRegion(tariffCode1))
-
-        val tariffCode2 = "E-2R-OE-FIX-12M-24-04-11-C"
-        assertEquals("C", TariffSummary.getRetailRegion(tariffCode2))
-
-        val tariffCode3 = "E-2R-VAR-22-11-01-P"
-        assertEquals("P", TariffSummary.getRetailRegion(tariffCode3))
+        assertEquals("A", TariffSummary.getRetailRegion(tariffCode1125A))
+        assertEquals("C", TariffSummary.getRetailRegion(tariffCode0411C))
+        assertEquals("P", TariffSummary.getRetailRegion(tariffCode1101P))
 
         val invalidTariffCode = "E-1R-AGILE-FLEX-22-11-25-1"
         assertNull(TariffSummary.getRetailRegion(invalidTariffCode))
@@ -49,64 +43,31 @@ class TariffTest {
 
     @Test
     fun `isSingleRate should return true for single rate tariff code`() {
-        val singleRateTariffCode = "E-1R-AGILE-FLEX-22-11-25-A"
+        val singleRateTariffCode = tariffCode1125A
         assertTrue(TariffSummary.isSingleRate(singleRateTariffCode))
 
-        val nonSingleRateTariffCode = "E-2R-OE-FIX-12M-24-04-11-C"
+        val nonSingleRateTariffCode = tariffCode0411C
         assertFalse(TariffSummary.isSingleRate(nonSingleRateTariffCode))
 
-        val invalidTariffCode = "E-R-VAR-22-11-01-A"
+        val invalidTariffCode = "E-R"
         assertFalse(TariffSummary.isSingleRate(invalidTariffCode))
     }
 
     @Test
     fun `extractProductCode instance method should return correct product code`() {
-        val tariffSummary = TariffSummary(
-            productCode = "AGILE-FLEX-22-11-25",
-            tariffCode = "E-1R-AGILE-FLEX-22-11-25-A",
-            fullName = "Agile Flex",
-            displayName = "Agile Flex Tariff",
-            description = "With Agile Octopus, you get access to half-hourly energy prices, tied to wholesale prices and updated daily.  The unit rate is capped at 100p/kWh (including VAT).",
-            vatInclusiveUnitRate = 15.5,
-            vatInclusiveStandingCharge = 20.0,
-            availableFrom = Clock.System.now(),
-            availableTo = null,
-            isVariable = true,
-        )
+        val tariffSummary = TariffSampleData.agileFlex221125
         assertEquals("AGILE-FLEX-22-11-25", tariffSummary.extractProductCode())
     }
 
     @Test
     fun `getRetailRegion instance method should return correct retail region`() {
-        val tariffSummary = TariffSummary(
-            productCode = "AGILE-FLEX-22-11-25",
-            tariffCode = "E-1R-AGILE-FLEX-22-11-25-A",
-            fullName = "Agile Flex",
-            displayName = "Agile Flex Tariff",
-            description = "With Agile Octopus, you get access to half-hourly energy prices, tied to wholesale prices and updated daily.  The unit rate is capped at 100p/kWh (including VAT).",
-            vatInclusiveUnitRate = 15.5,
-            vatInclusiveStandingCharge = 20.0,
-            availableFrom = Clock.System.now(),
-            availableTo = null,
-            isVariable = true,
-        )
+        val tariffSummary = TariffSampleData.agileFlex221125
         assertEquals("A", tariffSummary.getRetailRegion())
     }
 
     @Test
     fun `isSingleRate instance method should return true for single rate tariff code`() {
-        val tariffSummary = TariffSummary(
-            productCode = "AGILE-FLEX-22-11-25",
-            tariffCode = "E-1R-AGILE-FLEX-22-11-25-A",
-            fullName = "Agile Flex",
-            displayName = "Agile Flex Tariff",
-            description = "With Agile Octopus, you get access to half-hourly energy prices, tied to wholesale prices and updated daily.  The unit rate is capped at 100p/kWh (including VAT).",
-            vatInclusiveUnitRate = 15.5,
-            vatInclusiveStandingCharge = 20.0,
-            availableFrom = Clock.System.now(),
-            availableTo = null,
-            isVariable = true,
-        )
+        val tariffSummary = TariffSampleData.agileFlex221125
         assertTrue(tariffSummary.isSingleRate())
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/TariffTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/TariffTest.kt
@@ -8,52 +8,55 @@
 package com.rwmobi.kunigami.domain.model
 
 import com.rwmobi.kunigami.domain.model.product.TariffSummary
-import io.kotest.matchers.shouldBe
 import kotlinx.datetime.Clock
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class TariffTest {
 
     @Test
     fun `extractProductCode should return correct product code`() {
         val tariffCode1 = "E-1R-AGILE-FLEX-22-11-25-A"
-        TariffSummary.extractProductCode(tariffCode1) shouldBe "AGILE-FLEX-22-11-25"
+        assertEquals("AGILE-FLEX-22-11-25", TariffSummary.extractProductCode(tariffCode1))
 
         val tariffCode2 = "E-2R-OE-FIX-12M-24-04-11-C"
-        TariffSummary.extractProductCode(tariffCode2) shouldBe "OE-FIX-12M-24-04-11"
+        assertEquals("OE-FIX-12M-24-04-11", TariffSummary.extractProductCode(tariffCode2))
 
         val tariffCode3 = "E-2R-VAR-22-11-01-A"
-        TariffSummary.extractProductCode(tariffCode3) shouldBe "VAR-22-11-01"
+        assertEquals("VAR-22-11-01", TariffSummary.extractProductCode(tariffCode3))
 
         val invalidTariffCode = "E-1R"
-        TariffSummary.extractProductCode(invalidTariffCode) shouldBe null
+        assertNull(TariffSummary.extractProductCode(invalidTariffCode))
     }
 
     @Test
     fun `getRetailRegion should return correct retail region`() {
         val tariffCode1 = "E-1R-AGILE-FLEX-22-11-25-A"
-        TariffSummary.getRetailRegion(tariffCode1) shouldBe "A"
+        assertEquals("A", TariffSummary.getRetailRegion(tariffCode1))
 
         val tariffCode2 = "E-2R-OE-FIX-12M-24-04-11-C"
-        TariffSummary.getRetailRegion(tariffCode2) shouldBe "C"
+        assertEquals("C", TariffSummary.getRetailRegion(tariffCode2))
 
         val tariffCode3 = "E-2R-VAR-22-11-01-P"
-        TariffSummary.getRetailRegion(tariffCode3) shouldBe "P"
+        assertEquals("P", TariffSummary.getRetailRegion(tariffCode3))
 
         val invalidTariffCode = "E-1R-AGILE-FLEX-22-11-25-1"
-        TariffSummary.getRetailRegion(invalidTariffCode) shouldBe null
+        assertNull(TariffSummary.getRetailRegion(invalidTariffCode))
     }
 
     @Test
     fun `isSingleRate should return true for single rate tariff code`() {
         val singleRateTariffCode = "E-1R-AGILE-FLEX-22-11-25-A"
-        TariffSummary.isSingleRate(singleRateTariffCode) shouldBe true
+        assertTrue(TariffSummary.isSingleRate(singleRateTariffCode))
 
         val nonSingleRateTariffCode = "E-2R-OE-FIX-12M-24-04-11-C"
-        TariffSummary.isSingleRate(nonSingleRateTariffCode) shouldBe false
+        assertFalse(TariffSummary.isSingleRate(nonSingleRateTariffCode))
 
         val invalidTariffCode = "E-R-VAR-22-11-01-A"
-        TariffSummary.isSingleRate(invalidTariffCode) shouldBe false
+        assertFalse(TariffSummary.isSingleRate(invalidTariffCode))
     }
 
     @Test
@@ -70,7 +73,7 @@ class TariffTest {
             availableTo = null,
             isVariable = true,
         )
-        tariffSummary.extractProductCode() shouldBe "AGILE-FLEX-22-11-25"
+        assertEquals("AGILE-FLEX-22-11-25", tariffSummary.extractProductCode())
     }
 
     @Test
@@ -87,7 +90,7 @@ class TariffTest {
             availableTo = null,
             isVariable = true,
         )
-        tariffSummary.getRetailRegion() shouldBe "A"
+        assertEquals("A", tariffSummary.getRetailRegion())
     }
 
     @Test
@@ -104,6 +107,6 @@ class TariffTest {
             availableTo = null,
             isVariable = true,
         )
-        tariffSummary.isSingleRate() shouldBe true
+        assertTrue(tariffSummary.isSingleRate())
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/GetConsumptionUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/GetConsumptionUseCaseTest.kt
@@ -11,14 +11,15 @@ import com.rwmobi.kunigami.domain.model.consumption.Consumption
 import com.rwmobi.kunigami.domain.model.consumption.ConsumptionDataGroup
 import com.rwmobi.kunigami.domain.repository.FakeRestApiRepository
 import com.rwmobi.kunigami.domain.repository.FakeUserPreferencesRepository
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class GetConsumptionUseCaseTest {
@@ -80,8 +81,8 @@ class GetConsumptionUseCaseTest {
             groupBy = groupBy,
         )
 
-        result.isSuccess shouldBe true
-        result.getOrNull() shouldBe expectedConsumption.sortedBy { it.intervalStart }
+        assertTrue(result.isSuccess)
+        assertEquals(expectedConsumption.sortedBy { it.intervalStart }, result.getOrNull())
     }
 
     @Test
@@ -95,15 +96,15 @@ class GetConsumptionUseCaseTest {
         fakeUserPreferenceRepository.mpan = mpan
         fakeUserPreferenceRepository.meterSerialNumber = meterSerialNumber
 
-        val result = getConsumptionUseCase(
-            periodFrom = fakePeriodFrom,
-            periodTo = fakePeriodTo,
-            groupBy = groupBy,
-        )
+        val exception = assertFailsWith<IllegalArgumentException> {
+            getConsumptionUseCase(
+                periodFrom = fakePeriodFrom,
+                periodTo = fakePeriodTo,
+                groupBy = groupBy,
+            ).getOrThrow()
+        }
 
-        result.isFailure shouldBe true
-        result.exceptionOrNull().shouldBeInstanceOf<IllegalArgumentException>()
-        result.exceptionOrNull()!!.message shouldBe "API Key is null"
+        assertEquals("API Key is null", exception.message)
     }
 
     @Test
@@ -117,15 +118,15 @@ class GetConsumptionUseCaseTest {
         fakeUserPreferenceRepository.mpan = mpan
         fakeUserPreferenceRepository.meterSerialNumber = meterSerialNumber
 
-        val result = getConsumptionUseCase(
-            periodFrom = fakePeriodFrom,
-            periodTo = fakePeriodTo,
-            groupBy = groupBy,
-        )
+        val exception = assertFailsWith<IllegalArgumentException> {
+            getConsumptionUseCase(
+                periodFrom = fakePeriodFrom,
+                periodTo = fakePeriodTo,
+                groupBy = groupBy,
+            ).getOrThrow()
+        }
 
-        result.isFailure shouldBe true
-        result.exceptionOrNull().shouldBeInstanceOf<IllegalArgumentException>()
-        result.exceptionOrNull()!!.message shouldBe "MPAN is null"
+        assertEquals("MPAN is null", exception.message)
     }
 
     @Test
@@ -139,15 +140,15 @@ class GetConsumptionUseCaseTest {
         fakeUserPreferenceRepository.mpan = mpan
         fakeUserPreferenceRepository.meterSerialNumber = meterSerialNumber
 
-        val result = getConsumptionUseCase(
-            periodFrom = fakePeriodFrom,
-            periodTo = fakePeriodTo,
-            groupBy = groupBy,
-        )
+        val exception = assertFailsWith<IllegalArgumentException> {
+            getConsumptionUseCase(
+                periodFrom = fakePeriodFrom,
+                periodTo = fakePeriodTo,
+                groupBy = groupBy,
+            ).getOrThrow()
+        }
 
-        result.isFailure shouldBe true
-        result.exceptionOrNull().shouldBeInstanceOf<IllegalArgumentException>()
-        result.exceptionOrNull()!!.message shouldBe "Meter Serial Number is null"
+        assertEquals("Meter Serial Number is null", exception.message)
     }
 
     @Test
@@ -163,15 +164,15 @@ class GetConsumptionUseCaseTest {
         fakeUserPreferenceRepository.meterSerialNumber = meterSerialNumber
         fakeRestApiRepository.setConsumptionResponse = Result.failure(RuntimeException(errorMessage))
 
-        val result = getConsumptionUseCase(
-            periodFrom = fakePeriodFrom,
-            periodTo = fakePeriodTo,
-            groupBy = groupBy,
-        )
+        val exception = assertFailsWith<RuntimeException> {
+            getConsumptionUseCase(
+                periodFrom = fakePeriodFrom,
+                periodTo = fakePeriodTo,
+                groupBy = groupBy,
+            ).getOrThrow()
+        }
 
-        result.isFailure shouldBe true
-        result.exceptionOrNull().shouldBeInstanceOf<RuntimeException>()
-        result.exceptionOrNull()!!.message shouldBe errorMessage
+        assertEquals(errorMessage, exception.message)
     }
 
     // Demo mode
@@ -205,7 +206,7 @@ class GetConsumptionUseCaseTest {
             groupBy = groupBy,
         )
 
-        result.isSuccess shouldBe true
-        result.getOrNull() shouldBe expectedConsumption.sortedBy { it.intervalStart }
+        assertTrue(result.isSuccess)
+        assertEquals(expectedConsumption.sortedBy { it.intervalStart }, result.getOrNull())
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/GetFilteredProductsUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/GetFilteredProductsUseCaseTest.kt
@@ -11,15 +11,14 @@ import com.rwmobi.kunigami.domain.model.product.ProductDirection
 import com.rwmobi.kunigami.domain.model.product.ProductFeature
 import com.rwmobi.kunigami.domain.model.product.ProductSummary
 import com.rwmobi.kunigami.domain.repository.FakeRestApiRepository
-import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class GetFilteredProductsUseCaseTest {
@@ -93,10 +92,8 @@ class GetFilteredProductsUseCaseTest {
 
         val result = getFilteredProductsUseCase()
 
-        result.isSuccess shouldBe true
-        result.getOrNull() shouldContainExactly listOf(
-            productSummaries[0],
-        )
+        assertTrue(result.isSuccess)
+        assertEquals(listOf(productSummaries[0]), result.getOrNull())
     }
 
     @Test
@@ -106,9 +103,10 @@ class GetFilteredProductsUseCaseTest {
 
         val result = getFilteredProductsUseCase()
 
-        result.isFailure shouldBe true
-        result.exceptionOrNull().shouldBeInstanceOf<RuntimeException>()
-        result.exceptionOrNull()!!.message shouldBe errorMessage
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is RuntimeException)
+        assertEquals(errorMessage, exception!!.message)
     }
 
     @Test
@@ -132,7 +130,7 @@ class GetFilteredProductsUseCaseTest {
 
         val result = getFilteredProductsUseCase()
 
-        result.isSuccess shouldBe true
-        result.getOrNull() shouldBe emptyList()
+        assertTrue(result.isSuccess)
+        assertEquals(emptyList<ProductSummary>(), result.getOrNull())
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/GetStandardUnitRateUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/GetStandardUnitRateUseCaseTest.kt
@@ -10,15 +10,14 @@ package com.rwmobi.kunigami.domain.usecase
 import com.rwmobi.kunigami.domain.repository.FakeRestApiRepository
 import com.rwmobi.kunigami.domain.repository.FakeUserPreferencesRepository
 import com.rwmobi.kunigami.domain.samples.RateSampleData
-import io.kotest.matchers.collections.shouldBeSortedBy
-import io.kotest.matchers.collections.shouldHaveSize
-import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class GetStandardUnitRateUseCaseTest {
 
@@ -49,10 +48,10 @@ class GetStandardUnitRateUseCaseTest {
             periodTo = Instant.parse("2023-01-04T00:00:00Z"),
         )
 
-        result.isSuccess shouldBe true
+        assertTrue(result.isSuccess)
         val sortedRates = result.getOrThrow()
-        sortedRates shouldHaveSize rates.size
-        sortedRates shouldBeSortedBy { it.validFrom }
+        assertEquals(rates.size, sortedRates.size)
+        assertEquals(rates.sortedBy { it.validFrom }, sortedRates)
     }
 
     @Test
@@ -67,8 +66,8 @@ class GetStandardUnitRateUseCaseTest {
             periodTo = Instant.parse("2023-01-04T00:00:00Z"),
         )
 
-        result.isFailure shouldBe true
-        result.exceptionOrNull()!!.message shouldBe exceptionMessage
+        assertTrue(result.isFailure)
+        assertEquals(exceptionMessage, result.exceptionOrNull()!!.message)
     }
 
     @Test
@@ -82,8 +81,8 @@ class GetStandardUnitRateUseCaseTest {
             periodTo = Instant.parse("2023-01-04T00:00:00Z"),
         )
 
-        result.isSuccess shouldBe true
+        assertTrue(result.isSuccess)
         val rates = result.getOrThrow()
-        rates shouldHaveSize 0
+        assertEquals(0, rates.size)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/GetTariffRatesUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/GetTariffRatesUseCaseTest.kt
@@ -9,14 +9,14 @@ package com.rwmobi.kunigami.domain.usecase
 
 import com.rwmobi.kunigami.domain.model.product.TariffSummary
 import com.rwmobi.kunigami.domain.repository.FakeRestApiRepository
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class GetTariffRatesUseCaseTest {
@@ -54,8 +54,8 @@ class GetTariffRatesUseCaseTest {
 
         val result = getTariffRatesUseCase(productCode, tariffCode)
 
-        result.isSuccess shouldBe true
-        result.getOrNull() shouldBe expectedTariffSummary
+        assertTrue(result.isSuccess)
+        assertEquals(expectedTariffSummary, result.getOrNull())
     }
 
     @Test
@@ -68,8 +68,8 @@ class GetTariffRatesUseCaseTest {
 
         val result = getTariffRatesUseCase(productCode, tariffCode)
 
-        result.isFailure shouldBe true
-        result.exceptionOrNull().shouldBeInstanceOf<RuntimeException>()
-        result.exceptionOrNull()!!.message shouldBe errorMessage
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is RuntimeException)
+        assertEquals(errorMessage, result.exceptionOrNull()?.message)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/SyncUserProfileUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/SyncUserProfileUseCaseTest.kt
@@ -67,7 +67,7 @@ class SyncUserProfileUseCaseTest {
         assertTrue(result.isSuccess)
         val userProfile = result.getOrNull()
         assertIs<UserProfile>(userProfile)
-        assertEquals(account.electricityMeterPoints.first().mpan, userProfile!!.selectedMpan)
+        assertEquals(account.electricityMeterPoints.first().mpan, userProfile.selectedMpan)
         assertEquals(account.electricityMeterPoints.first().meterSerialNumbers.first(), userProfile.selectedMeterSerialNumber)
         assertEquals(account, userProfile.account)
     }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/SyncUserProfileUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/SyncUserProfileUseCaseTest.kt
@@ -12,13 +12,15 @@ import com.rwmobi.kunigami.domain.model.account.UserProfile
 import com.rwmobi.kunigami.domain.repository.FakeRestApiRepository
 import com.rwmobi.kunigami.domain.repository.FakeUserPreferencesRepository
 import com.rwmobi.kunigami.domain.samples.AccountSampleData
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SyncUserProfileUseCaseTest {
@@ -43,8 +45,8 @@ class SyncUserProfileUseCaseTest {
 
         val result = syncUserProfileUseCase.invoke()
 
-        result.isFailure shouldBe true
-        result.exceptionOrNull().shouldBeInstanceOf<IncompleteCredentialsException>()
+        assertTrue(result.isFailure)
+        assertIs<IncompleteCredentialsException>(result.exceptionOrNull())
     }
 
     @Test
@@ -62,12 +64,12 @@ class SyncUserProfileUseCaseTest {
 
         val result = syncUserProfileUseCase()
 
-        result.isSuccess shouldBe true
+        assertTrue(result.isSuccess)
         val userProfile = result.getOrNull()
-        userProfile.shouldBeInstanceOf<UserProfile>()
-        userProfile.selectedMpan shouldBe account.electricityMeterPoints.first().mpan
-        userProfile.selectedMeterSerialNumber shouldBe account.electricityMeterPoints.first().meterSerialNumbers.first()
-        userProfile.account shouldBe account
+        assertIs<UserProfile>(userProfile)
+        assertEquals(account.electricityMeterPoints.first().mpan, userProfile!!.selectedMpan)
+        assertEquals(account.electricityMeterPoints.first().meterSerialNumbers.first(), userProfile.selectedMeterSerialNumber)
+        assertEquals(account, userProfile.account)
     }
 
     @Test
@@ -83,8 +85,8 @@ class SyncUserProfileUseCaseTest {
 
         val result = syncUserProfileUseCase()
 
-        result.isSuccess shouldBe true
-        result.getOrNull() shouldBe null
+        assertTrue(result.isSuccess)
+        assertNull(result.getOrNull())
     }
 
     @Test
@@ -106,7 +108,7 @@ class SyncUserProfileUseCaseTest {
 
         val result = syncUserProfileUseCase()
 
-        result.isSuccess shouldBe true
-        result.getOrNull() shouldBe null
+        assertTrue(result.isSuccess)
+        assertNull(result.getOrNull())
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/UpdateMeterPreferenceUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/UpdateMeterPreferenceUseCaseTest.kt
@@ -8,12 +8,13 @@
 package com.rwmobi.kunigami.domain.usecase
 
 import com.rwmobi.kunigami.domain.repository.FakeUserPreferencesRepository
-import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class UpdateMeterPreferenceUseCaseTest {
@@ -37,8 +38,8 @@ class UpdateMeterPreferenceUseCaseTest {
 
         val result = updateMeterPreferenceUseCase(mpan, meterSerialNumber)
 
-        result.isSuccess shouldBe true
-        fakeUserPreferencesRepository.mpan shouldBe mpan
-        fakeUserPreferencesRepository.meterSerialNumber shouldBe meterSerialNumber
+        assertTrue(result.isSuccess)
+        assertEquals(mpan, fakeUserPreferencesRepository.mpan)
+        assertEquals(meterSerialNumber, fakeUserPreferencesRepository.meterSerialNumber)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/extensions/ListExtensionsKtTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/extensions/ListExtensionsKtTest.kt
@@ -7,9 +7,9 @@
 
 package com.rwmobi.kunigami.ui.extensions
 
-import io.kotest.matchers.collections.shouldHaveSize
-import io.kotest.matchers.shouldBe
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ListExtensionsKtTest {
 
@@ -17,71 +17,71 @@ class ListExtensionsKtTest {
     fun `partitionList should return original list wrapped in a list when columns is zero`() {
         val list = listOf(1, 2, 3)
         val result = list.partitionList(0)
-        result shouldHaveSize 1
-        result.first() shouldBe list
+        assertEquals(1, result.size)
+        assertEquals(list, result[0])
     }
 
     @Test
     fun `partitionList should return original list wrapped in a list when columns is negative`() {
         val list = listOf(1, 2, 3)
         val result = list.partitionList(-1)
-        result shouldHaveSize 1
-        result.first() shouldBe list
+        assertEquals(1, result.size)
+        assertEquals(list, result[0])
     }
 
     @Test
     fun `partitionList should partition list into given number of columns`() {
         val list = listOf(1, 2, 3, 4, 5, 6)
         val result = list.partitionList(2)
-        result shouldHaveSize 2
-        result[0] shouldBe listOf(1, 2, 3)
-        result[1] shouldBe listOf(4, 5, 6)
+        assertEquals(2, result.size)
+        assertEquals(listOf(1, 2, 3), result[0])
+        assertEquals(listOf(4, 5, 6), result[1])
     }
 
     @Test
     fun `partitionList should handle list size not evenly divisible by columns`() {
         val list = listOf(1, 2, 3, 4, 5)
         val result = list.partitionList(2)
-        result shouldHaveSize 2
-        result[0] shouldBe listOf(1, 2, 3)
-        result[1] shouldBe listOf(4, 5)
+        assertEquals(2, result.size)
+        assertEquals(listOf(1, 2, 3), result[0])
+        assertEquals(listOf(4, 5), result[1])
     }
 
     @Test
     fun `partitionList should handle more columns than items`() {
         val list = listOf(1, 2, 3)
         val result = list.partitionList(4)
-        result shouldHaveSize 4
-        result[0] shouldBe listOf(1)
-        result[1] shouldBe listOf(2)
-        result[2] shouldBe listOf(3)
-        result[3] shouldBe emptyList()
+        assertEquals(4, result.size)
+        assertEquals(listOf(1), result[0])
+        assertEquals(listOf(2), result[1])
+        assertEquals(listOf(3), result[2])
+        assertTrue(result[3].isEmpty())
     }
 
     @Test
     fun `partitionList should handle empty list`() {
         val list = emptyList<Int>()
         val result = list.partitionList(3)
-        result shouldHaveSize 3
-        result.forEach { it shouldBe emptyList() }
+        assertEquals(3, result.size)
+        result.forEach { assertTrue(it.isEmpty()) }
     }
 
     @Test
     fun `partitionList should not remove the last column if columns is 2`() {
         val list = listOf(1, 2, 3, 4, 5)
         val result = list.partitionList(2)
-        result shouldHaveSize 2
-        result[0] shouldBe listOf(1, 2, 3)
-        result[1] shouldBe listOf(4, 5)
+        assertEquals(2, result.size)
+        assertEquals(listOf(1, 2, 3), result[0])
+        assertEquals(listOf(4, 5), result[1])
     }
 
     @Test
     fun `partitionList should remove the last empty column if columns is greater than 2`() {
         val list = listOf(1, 2, 3, 4)
         val result = list.partitionList(3)
-        result shouldHaveSize 3
-        result[0] shouldBe listOf(1, 2)
-        result[1] shouldBe listOf(3, 4)
-        result[2] shouldBe emptyList()
+        assertEquals(3, result.size)
+        assertEquals(listOf(1, 2), result[0])
+        assertEquals(listOf(3, 4), result[1])
+        assertTrue(result[2].isEmpty())
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionPresentationStyleTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionPresentationStyleTest.kt
@@ -8,7 +8,6 @@
 package com.rwmobi.kunigami.ui.model.consumption
 
 import com.rwmobi.kunigami.domain.model.consumption.ConsumptionDataGroup
-import io.kotest.matchers.shouldBe
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.presentation_style_day_half_hourly
 import kunigami.composeapp.generated.resources.presentation_style_month_thirty_days
@@ -16,41 +15,42 @@ import kunigami.composeapp.generated.resources.presentation_style_month_weeks
 import kunigami.composeapp.generated.resources.presentation_style_week_seven_days
 import kunigami.composeapp.generated.resources.presentation_style_year_twelve_months
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class ConsumptionPresentationStyleTest {
 
     @Test
     fun `DAY_HALF_HOURLY should map to HALF_HOURLY ConsumptionDataGroup`() {
-        ConsumptionPresentationStyle.DAY_HALF_HOURLY.getConsumptionDataGroup() shouldBe ConsumptionDataGroup.HALF_HOURLY
+        assertEquals(ConsumptionDataGroup.HALF_HOURLY, ConsumptionPresentationStyle.DAY_HALF_HOURLY.getConsumptionDataGroup())
     }
 
     @Test
     fun `WEEK_SEVEN_DAYS should map to DAY ConsumptionDataGroup`() {
-        ConsumptionPresentationStyle.WEEK_SEVEN_DAYS.getConsumptionDataGroup() shouldBe ConsumptionDataGroup.DAY
+        assertEquals(ConsumptionDataGroup.DAY, ConsumptionPresentationStyle.WEEK_SEVEN_DAYS.getConsumptionDataGroup())
     }
 
     @Test
     fun `MONTH_WEEKS should map to WEEK ConsumptionDataGroup`() {
-        ConsumptionPresentationStyle.MONTH_WEEKS.getConsumptionDataGroup() shouldBe ConsumptionDataGroup.WEEK
+        assertEquals(ConsumptionDataGroup.WEEK, ConsumptionPresentationStyle.MONTH_WEEKS.getConsumptionDataGroup())
     }
 
     @Test
     fun `MONTH_THIRTY_DAYS should map to DAY ConsumptionDataGroup`() {
-        ConsumptionPresentationStyle.MONTH_THIRTY_DAYS.getConsumptionDataGroup() shouldBe ConsumptionDataGroup.DAY
+        assertEquals(ConsumptionDataGroup.DAY, ConsumptionPresentationStyle.MONTH_THIRTY_DAYS.getConsumptionDataGroup())
     }
 
     @Test
     fun `YEAR_TWELVE_MONTHS should map to MONTH ConsumptionDataGroup`() {
-        ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS.getConsumptionDataGroup() shouldBe ConsumptionDataGroup.MONTH
+        assertEquals(ConsumptionDataGroup.MONTH, ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS.getConsumptionDataGroup())
     }
 
     // Not a very good test, but we keep it for now.
     @Test
     fun `stringResource should match the expected resource`() {
-        ConsumptionPresentationStyle.DAY_HALF_HOURLY.stringResource shouldBe Res.string.presentation_style_day_half_hourly
-        ConsumptionPresentationStyle.WEEK_SEVEN_DAYS.stringResource shouldBe Res.string.presentation_style_week_seven_days
-        ConsumptionPresentationStyle.MONTH_WEEKS.stringResource shouldBe Res.string.presentation_style_month_weeks
-        ConsumptionPresentationStyle.MONTH_THIRTY_DAYS.stringResource shouldBe Res.string.presentation_style_month_thirty_days
-        ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS.stringResource shouldBe Res.string.presentation_style_year_twelve_months
+        assertEquals(Res.string.presentation_style_day_half_hourly, ConsumptionPresentationStyle.DAY_HALF_HOURLY.stringResource)
+        assertEquals(Res.string.presentation_style_week_seven_days, ConsumptionPresentationStyle.WEEK_SEVEN_DAYS.stringResource)
+        assertEquals(Res.string.presentation_style_month_weeks, ConsumptionPresentationStyle.MONTH_WEEKS.stringResource)
+        assertEquals(Res.string.presentation_style_month_thirty_days, ConsumptionPresentationStyle.MONTH_THIRTY_DAYS.stringResource)
+        assertEquals(Res.string.presentation_style_year_twelve_months, ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS.stringResource)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilterTest.kt
@@ -12,7 +12,6 @@ import com.rwmobi.kunigami.domain.extensions.getLocalDateString
 import com.rwmobi.kunigami.domain.extensions.getLocalEnglishAbbreviatedDayOfWeekName
 import com.rwmobi.kunigami.domain.extensions.getLocalMonthYearString
 import com.rwmobi.kunigami.domain.extensions.getLocalYear
-import io.kotest.matchers.shouldBe
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.DayOfWeek
@@ -27,6 +26,9 @@ import kotlinx.datetime.plus
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.nanoseconds
 
@@ -38,27 +40,27 @@ class ConsumptionQueryFilterTest {
     @Test
     fun `calculateStartDate should return correct start date for DAY_HALF_HOURLY`() {
         val startDate = ConsumptionQueryFilter.calculateStartDate(now, ConsumptionPresentationStyle.DAY_HALF_HOURLY)
-        startDate shouldBe now.atStartOfDay()
+        assertEquals(now.atStartOfDay(), startDate)
     }
 
     @Test
     fun `calculateEndDate should return correct end date for DAY_HALF_HOURLY`() {
         val endDate = ConsumptionQueryFilter.calculateEndDate(now, ConsumptionPresentationStyle.DAY_HALF_HOURLY)
-        endDate shouldBe now.atEndOfDay()
+        assertEquals(now.atEndOfDay(), endDate)
     }
 
     @Test
     fun `calculateStartDate should return correct start date for WEEK_SEVEN_DAYS`() {
         val startDate = ConsumptionQueryFilter.calculateStartDate(now, ConsumptionPresentationStyle.WEEK_SEVEN_DAYS)
         val expectedStartDate = now.toLocalDateTime(timeZone).date.minus(now.toLocalDateTime(timeZone).date.dayOfWeek.isoDayNumber - 1, DateTimeUnit.DAY).atStartOfDayIn(timeZone)
-        startDate shouldBe expectedStartDate
+        assertEquals(expectedStartDate, startDate)
     }
 
     @Test
     fun `calculateEndDate should return correct end date for WEEK_SEVEN_DAYS`() {
         val endDate = ConsumptionQueryFilter.calculateEndDate(now, ConsumptionPresentationStyle.WEEK_SEVEN_DAYS)
         val expectedEndDate = now.toLocalDateTime(timeZone).date.plus(7 - now.toLocalDateTime(timeZone).date.dayOfWeek.isoDayNumber, DateTimeUnit.DAY).atTime(23, 59, 59, 999_999_999).toInstant(timeZone)
-        endDate shouldBe expectedEndDate
+        assertEquals(expectedEndDate, endDate)
     }
 
     @Test
@@ -68,7 +70,7 @@ class ConsumptionQueryFilterTest {
         val startOfThisMonth = LocalDate(localDateTime.year, localDateTime.monthNumber, 1).atStartOfDayIn(timeZone)
         val daysSinceSunday = startOfThisMonth.toLocalDateTime(timeZone).date.dayOfWeek.isoDayNumber
         val expectedStartDate = startOfThisMonth.minus((daysSinceSunday - 1).days)
-        startDate shouldBe expectedStartDate
+        assertEquals(expectedStartDate, startDate)
     }
 
     @Test
@@ -79,14 +81,14 @@ class ConsumptionQueryFilterTest {
         val endOfMonth = (startOfNextMonth - 1.nanoseconds).toLocalDateTime(timeZone)
         val daysUntilSunday = DayOfWeek.SUNDAY.isoDayNumber - endOfMonth.date.dayOfWeek.isoDayNumber
         val expectedEndDate = endOfMonth.date.plus(daysUntilSunday, DateTimeUnit.DAY).atTime(23, 59, 59, 999_999_999).toInstant(timeZone)
-        endDate shouldBe expectedEndDate
+        assertEquals(expectedEndDate, endDate)
     }
 
     @Test
     fun `calculateStartDate should return correct start date for MONTH_THIRTY_DAYS`() {
         val startDate = ConsumptionQueryFilter.calculateStartDate(now, ConsumptionPresentationStyle.MONTH_THIRTY_DAYS)
         val expectedStartDate = LocalDate(now.toLocalDateTime(timeZone).year, now.toLocalDateTime(timeZone).monthNumber, 1).atStartOfDayIn(timeZone)
-        startDate shouldBe expectedStartDate
+        assertEquals(expectedStartDate, startDate)
     }
 
     @Test
@@ -94,27 +96,27 @@ class ConsumptionQueryFilterTest {
         val endDate = ConsumptionQueryFilter.calculateEndDate(now, ConsumptionPresentationStyle.MONTH_THIRTY_DAYS)
         val startOfNextMonth = LocalDate(now.toLocalDateTime(timeZone).year, now.toLocalDateTime(timeZone).monthNumber, 1).plus(1, DateTimeUnit.MONTH).atStartOfDayIn(timeZone)
         val expectedEndDate = startOfNextMonth - 1.nanoseconds
-        endDate shouldBe expectedEndDate
+        assertEquals(expectedEndDate, endDate)
     }
 
     @Test
     fun `calculateStartDate should return correct start date for YEAR_TWELVE_MONTHS`() {
         val startDate = ConsumptionQueryFilter.calculateStartDate(now, ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS)
         val expectedStartDate = LocalDate(now.toLocalDateTime(timeZone).year, 1, 1).atStartOfDayIn(timeZone)
-        startDate shouldBe expectedStartDate
+        assertEquals(expectedStartDate, startDate)
     }
 
     @Test
     fun `calculateEndDate should return correct end date for YEAR_TWELVE_MONTHS`() {
         val endDate = ConsumptionQueryFilter.calculateEndDate(now, ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS)
         val expectedEndDate = LocalDate(now.toLocalDateTime(timeZone).year, 12, 31).atTime(23, 59, 59, 999_999_999).toInstant(timeZone)
-        endDate shouldBe expectedEndDate
+        assertEquals(expectedEndDate, endDate)
     }
 
     @Test
     fun `getConsumptionPeriodString should return correct string for DAY_HALF_HOURLY`() {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.DAY_HALF_HOURLY, referencePoint = now)
-        filter.getConsumptionPeriodString() shouldBe "${now.getLocalEnglishAbbreviatedDayOfWeekName()}, ${now.getLocalDateString()}"
+        assertEquals("${now.getLocalEnglishAbbreviatedDayOfWeekName()}, ${now.getLocalDateString()}", filter.getConsumptionPeriodString())
     }
 
     @Test
@@ -122,51 +124,51 @@ class ConsumptionQueryFilterTest {
         val start = now.atStartOfDay()
         val end = now.atEndOfDay()
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.WEEK_SEVEN_DAYS, referencePoint = now, requestedStart = start, requestedEnd = end)
-        filter.getConsumptionPeriodString() shouldBe "${start.getLocalDateString().substringBefore(",")} - ${end.getLocalDateString()}"
+        assertEquals("${start.getLocalDateString().substringBefore(",")} - ${end.getLocalDateString()}", filter.getConsumptionPeriodString())
     }
 
     @Test
     fun `getConsumptionPeriodString should return correct string for MONTH_WEEKS`() {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.MONTH_WEEKS, referencePoint = now)
-        filter.getConsumptionPeriodString() shouldBe now.getLocalMonthYearString()
+        assertEquals(now.getLocalMonthYearString(), filter.getConsumptionPeriodString())
     }
 
     @Test
     fun `getConsumptionPeriodString should return correct string for MONTH_THIRTY_DAYS`() {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.MONTH_THIRTY_DAYS, referencePoint = now)
-        filter.getConsumptionPeriodString() shouldBe now.getLocalMonthYearString()
+        assertEquals(now.getLocalMonthYearString(), filter.getConsumptionPeriodString())
     }
 
     @Test
     fun `getConsumptionPeriodString should return correct string for YEAR_TWELVE_MONTHS`() {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS, referencePoint = now)
-        filter.getConsumptionPeriodString() shouldBe now.getLocalYear().toString()
+        assertEquals(now.getLocalYear().toString(), filter.getConsumptionPeriodString())
     }
 
     @Test
     fun `canNavigateForward should return false if current time is before forward point of reference`() {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.DAY_HALF_HOURLY, referencePoint = now)
-        filter.canNavigateForward() shouldBe false
+        assertFalse(filter.canNavigateForward())
     }
 
     @Test
     fun `canNavigateBackward should return false if new requested end is before account move-in date`() {
         val accountMoveInDate = Instant.DISTANT_FUTURE
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.DAY_HALF_HOURLY, referencePoint = now)
-        filter.canNavigateBackward(accountMoveInDate) shouldBe false
+        assertFalse(filter.canNavigateBackward(accountMoveInDate))
     }
 
     @Test
     fun `navigateBackward should return null if cannot navigate backward`() {
         val accountMoveInDate = Instant.DISTANT_FUTURE
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.DAY_HALF_HOURLY, referencePoint = now)
-        filter.navigateBackward(accountMoveInDate) shouldBe null
+        assertNull(filter.navigateBackward(accountMoveInDate))
     }
 
     @Test
     fun `navigateForward should return null if cannot navigate forward`() {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.DAY_HALF_HOURLY, referencePoint = now)
-        filter.navigateForward() shouldBe null
+        assertNull(filter.navigateForward())
     }
 
     @Test
@@ -175,7 +177,7 @@ class ConsumptionQueryFilterTest {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.DAY_HALF_HOURLY, referencePoint = reference)
         val newFilter = filter.navigateBackward(accountMoveInDate = Instant.DISTANT_PAST)
         val expected = Instant.parse("2012-03-24T00:00:00Z")
-        newFilter!!.referencePoint shouldBe expected
+        assertEquals(expected, newFilter!!.referencePoint)
     }
 
     @Test
@@ -184,7 +186,7 @@ class ConsumptionQueryFilterTest {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.WEEK_SEVEN_DAYS, referencePoint = reference)
         val newFilter = filter.navigateBackward(accountMoveInDate = Instant.DISTANT_PAST)
         val expected = Instant.parse("2012-03-18T00:00:00Z")
-        newFilter!!.referencePoint shouldBe expected
+        assertEquals(expected, newFilter!!.referencePoint)
     }
 
     @Test
@@ -193,7 +195,7 @@ class ConsumptionQueryFilterTest {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.MONTH_WEEKS, referencePoint = reference)
         val newFilter = filter.navigateBackward(accountMoveInDate = Instant.DISTANT_PAST)
         val expected = Instant.parse("2012-03-01T00:00:00Z")
-        newFilter!!.referencePoint shouldBe expected
+        assertEquals(expected, newFilter!!.referencePoint)
     }
 
     @Test
@@ -202,7 +204,7 @@ class ConsumptionQueryFilterTest {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.MONTH_THIRTY_DAYS, referencePoint = reference)
         val newFilter = filter.navigateBackward(accountMoveInDate = Instant.DISTANT_PAST)
         val expected = Instant.parse("2012-03-01T00:00:00Z")
-        newFilter!!.referencePoint shouldBe expected
+        assertEquals(expected, newFilter!!.referencePoint)
     }
 
     @Test
@@ -211,7 +213,7 @@ class ConsumptionQueryFilterTest {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS, referencePoint = reference)
         val newFilter = filter.navigateBackward(accountMoveInDate = Instant.DISTANT_PAST)
         val expected = Instant.parse("2011-12-31T00:00:00Z")
-        newFilter!!.referencePoint shouldBe expected
+        assertEquals(expected, newFilter!!.referencePoint)
     }
 
     @Test
@@ -220,7 +222,7 @@ class ConsumptionQueryFilterTest {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.DAY_HALF_HOURLY, referencePoint = reference)
         val newFilter = filter.navigateForward()
         val expected = Instant.parse("2012-03-25T23:00:00Z")
-        newFilter!!.referencePoint shouldBe expected
+        assertEquals(expected, newFilter!!.referencePoint)
     }
 
     @Test
@@ -229,7 +231,7 @@ class ConsumptionQueryFilterTest {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.WEEK_SEVEN_DAYS, referencePoint = reference)
         val newFilter = filter.navigateForward()
         val expected = Instant.parse("2012-03-31T23:00:00Z")
-        newFilter!!.referencePoint shouldBe expected
+        assertEquals(expected, newFilter!!.referencePoint)
     }
 
     @Test
@@ -238,7 +240,7 @@ class ConsumptionQueryFilterTest {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.MONTH_WEEKS, referencePoint = reference)
         val newFilter = filter.navigateForward()
         val expected = Instant.parse("2012-03-31T23:00:00Z")
-        newFilter!!.referencePoint shouldBe expected
+        assertEquals(expected, newFilter!!.referencePoint)
     }
 
     @Test
@@ -247,7 +249,7 @@ class ConsumptionQueryFilterTest {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.MONTH_THIRTY_DAYS, referencePoint = reference)
         val newFilter = filter.navigateForward()
         val expected = Instant.parse("2012-03-31T23:00:00Z")
-        newFilter!!.referencePoint shouldBe expected
+        assertEquals(expected, newFilter!!.referencePoint)
     }
 
     @Test
@@ -256,7 +258,7 @@ class ConsumptionQueryFilterTest {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS, referencePoint = reference)
         val newFilter = filter.navigateForward()
         val expected = Instant.parse("2013-01-01T00:00:00Z")
-        newFilter!!.referencePoint shouldBe expected
+        assertEquals(expected, newFilter!!.referencePoint)
     }
 
     /***
@@ -271,7 +273,7 @@ class ConsumptionQueryFilterTest {
         val transitionInstant = Instant.parse("2012-03-25T00:00:00Z") // Midnight UTC as the start of the day.
         val startDate = ConsumptionQueryFilter.calculateStartDate(transitionInstant, ConsumptionPresentationStyle.DAY_HALF_HOURLY)
         val expectedStartDate = Instant.parse("2012-03-25T00:00:00Z")
-        startDate shouldBe expectedStartDate
+        assertEquals(expectedStartDate, startDate)
     }
 
     @Test
@@ -280,7 +282,7 @@ class ConsumptionQueryFilterTest {
         val transitionInstant = Instant.parse("2012-03-25T00:00:00Z")
         val endDate = ConsumptionQueryFilter.calculateEndDate(transitionInstant, ConsumptionPresentationStyle.DAY_HALF_HOURLY)
         val expectedEndDate = Instant.parse("2012-03-25T22:59:59.999999999Z") // 23:00 UTC because we lose an hour (the day is only 23 hours long).
-        endDate shouldBe expectedEndDate
+        assertEquals(expectedEndDate, endDate)
     }
 
     @Test
@@ -289,7 +291,7 @@ class ConsumptionQueryFilterTest {
         val transitionInstant = Instant.parse("2012-10-28T00:00:00Z")
         val startDate = ConsumptionQueryFilter.calculateStartDate(transitionInstant, ConsumptionPresentationStyle.DAY_HALF_HOURLY)
         val expectedStartDate = Instant.parse("2012-10-27T23:00:00Z")
-        startDate shouldBe expectedStartDate
+        assertEquals(expectedStartDate, startDate)
     }
 
     @Test
@@ -298,7 +300,7 @@ class ConsumptionQueryFilterTest {
         val transitionInstant = Instant.parse("2012-10-28T00:00:00Z")
         val endDate = ConsumptionQueryFilter.calculateEndDate(transitionInstant, ConsumptionPresentationStyle.DAY_HALF_HOURLY)
         val expectedEndDate = Instant.parse("2012-10-28T23:59:59.999999999Z") // It is still 23:59:59.999999999 UTC, reflecting 25 hours total.
-        endDate shouldBe expectedEndDate
+        assertEquals(expectedEndDate, endDate)
     }
 
     @Test
@@ -307,7 +309,7 @@ class ConsumptionQueryFilterTest {
         val newFilter = filter.navigateBackward(Instant.DISTANT_PAST) // Assume account move-in date allows backward navigation
         // Expected timestamp for one day before the BST transition
         val expectedTimestamp = LocalDate(year = 2012, monthNumber = 3, dayOfMonth = 24).atStartOfDayIn(timeZone)
-        newFilter!!.referencePoint shouldBe expectedTimestamp
+        assertEquals(expectedTimestamp, newFilter!!.referencePoint)
     }
 
     @Test
@@ -316,7 +318,7 @@ class ConsumptionQueryFilterTest {
         val newFilter = filter.navigateForward() // Assuming no constraints on moving forward
         // Expected timestamp for one day after the GMT transition
         val expectedTimestamp = LocalDate(year = 2012, monthNumber = 10, dayOfMonth = 29).atStartOfDayIn(timeZone)
-        newFilter!!.referencePoint shouldBe expectedTimestamp
+        assertEquals(expectedTimestamp, newFilter!!.referencePoint)
     }
 
     @Test
@@ -326,7 +328,7 @@ class ConsumptionQueryFilterTest {
         val newFilter = filter.navigateBackward(Instant.DISTANT_PAST)
         // Expected timestamp for two days before the GMT transition
         val expectedTimestamp = LocalDate(year = 2012, monthNumber = 10, dayOfMonth = 26).atStartOfDayIn(timeZone)
-        newFilter!!.referencePoint shouldBe expectedTimestamp
+        assertEquals(expectedTimestamp, newFilter!!.referencePoint)
     }
 
     @Test
@@ -336,6 +338,6 @@ class ConsumptionQueryFilterTest {
         val newFilter = filter.navigateForward()
         // Forward to the transition day
         val expectedTimestamp = LocalDate(year = 2012, monthNumber = 10, dayOfMonth = 28).atStartOfDayIn(timeZone)
-        newFilter!!.referencePoint shouldBe expectedTimestamp
+        assertEquals(expectedTimestamp, newFilter!!.referencePoint)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,6 @@ kermit = "2.0.4"
 koalaplotCore = "0.6.0"
 koin = "3.5.6"
 koinCompose = "1.1.5"
-kotest = "5.9.1"
 kotlin = "2.0.0"
 kotlinxDatetime = "0.6.0"
 kotlinxSerialization = "1.7.0"
@@ -73,7 +72,6 @@ kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
-kotest-assertions-core = { group = "io.kotest", name = "kotest-assertions-core", version.ref = "kotest" }
 material3-windowsizeclass-multiplatform = { group = "dev.chrisbanes.material3", name = "material3-window-size-class-multiplatform", version.ref = "material3WindowSizeClassMultiplatform" }
 # mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 koin-core = { group = "io.insert-koin", name = "koin-core", version.ref = "koin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -102,6 +102,7 @@ androidLibrary = { id = "com.android.library", version.ref = "agp" }
 android-test = { id = "com.android.test", version.ref = "agp" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinCocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
+kotlinPowerAssert = { id = "org.jetbrains.kotlin.plugin.power-assert", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }


### PR DESCRIPTION
This closes #205 and #215 .

Removed all Kotest assertion instances. 
Added Kotlin Power Assert plugin - nothing changed in the test code, just run the test using the AS plugin or  ./gradlew :composeApp:desktopTest --info  to print the extra assertion error 