### PR TITLE
(#211) Fix Usage Screen retry when returning from network error

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ improved later:
 * [AndroidX UI Automator](https://developer.android.com/training/testing/ui-automator) - Apache 2.0 - UI automation testing framework
 * [AndroidX Benchmark](https://developer.android.com/jetpack/androidx/releases/benchmark) - Apache 2.0 - Benchmarking library
 * [AndroidX Profile Installer](https://developer.android.com/jetpack/androidx/releases/profileinstaller) - Apache 2.0 - Install profiles for faster startup
-* [SLF4J](http://www.slf4j.org/) - MIT - Simple Logging Facade for Java
+* [SLF4J](http://www.slf4j.org/) - MIT - Simple facade for logging systems.
 * [Skiko](https://github.com/JetBrains/skiko) - Apache 2.0 - Kotlin Multiplatform bindings to Skia
 
 ### Plugins

--- a/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.android.kt
@@ -7,7 +7,15 @@
 
 package com.rwmobi.kunigami.ui.extensions
 
-/***
- * This is needed to handle Ktor Darwin Engine exceptions which does not exist in CommonMain
- */
-actual fun Throwable.mapFromPlatform(): Throwable = this
+import io.ktor.util.network.UnresolvedAddressException
+import java.net.UnknownHostException
+
+actual fun Throwable.mapFromPlatform(): Throwable {
+    return when (this) {
+        is UnknownHostException -> {
+            UnresolvedAddressException()
+        }
+
+        else -> this
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.kt
@@ -78,6 +78,21 @@ fun Instant.atEndOfDay(): Instant {
 
 fun Instant.getDayRange(): ClosedRange<Instant> = atStartOfDay()..atEndOfDay()
 
+fun Instant.getWeekRange(): ClosedRange<Instant> {
+    val localDateTime = toSystemDefaultLocalDateTime()
+    return localDateTime.startOfWeek()..localDateTime.endOfWeek()
+}
+
+fun Instant.getMonthRange(): ClosedRange<Instant> {
+    val localDateTime = toSystemDefaultLocalDateTime()
+    return localDateTime.startOfMonth()..localDateTime.endOfMonth()
+}
+
+fun Instant.getYearRange(): ClosedRange<Instant> {
+    val localDateTime = toSystemDefaultLocalDateTime()
+    return localDateTime.startOfYear()..localDateTime.endOfYear()
+}
+
 /***
  * Returns the number of milliseconds to the upcoming 00 or 30 minutes.
  * This is for recurrent background tasks.

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.kt
@@ -76,6 +76,8 @@ fun Instant.atEndOfDay(): Instant {
         .minus(value = 1, unit = DateTimeUnit.NANOSECOND)
 }
 
+fun Instant.getDayRange(): ClosedRange<Instant> = atStartOfDay()..atEndOfDay()
+
 /***
  * Returns the number of milliseconds to the upcoming 00 or 30 minutes.
  * This is for recurrent background tasks.

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/LocalDateTimeExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/LocalDateTimeExtensions.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.kunigami.domain.extensions
+
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.atTime
+import kotlinx.datetime.isoDayNumber
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
+
+fun LocalDateTime.startOfYear(): Instant {
+    return LocalDate(year = year, monthNumber = 1, dayOfMonth = 1)
+        .atTime(hour = 12, minute = 0) // Make it GMT-BST transition safe
+        .toSystemDefaultTimeZoneInstant()
+        .atStartOfDay()
+}
+
+fun LocalDateTime.endOfYear(): Instant {
+    return LocalDate(year = year, monthNumber = 12, dayOfMonth = 31)
+        .atTime(hour = 12, minute = 0) // Make it GMT-BST transition safe
+        .toSystemDefaultTimeZoneInstant()
+        .atEndOfDay()
+}
+
+fun LocalDateTime.startOfMonth(): Instant {
+    return LocalDate(year = year, monthNumber = monthNumber, dayOfMonth = 1)
+        .atTime(hour = 12, minute = 0) // Make it GMT-BST transition safe
+        .toSystemDefaultTimeZoneInstant()
+        .atStartOfDay()
+}
+
+fun LocalDateTime.endOfMonth(): Instant {
+    return LocalDate(year = year, monthNumber = monthNumber, dayOfMonth = 1)
+        .plus(1, DateTimeUnit.MONTH)
+        .minus(1, DateTimeUnit.DAY)
+        .atTime(hour = 12, minute = 0) // Make it GMT-BST transition safe
+        .toSystemDefaultTimeZoneInstant()
+        .atEndOfDay()
+}
+
+fun LocalDateTime.startOfWeek(): Instant {
+    val dayOfWeek = date.dayOfWeek
+    val daysSinceSunday = dayOfWeek.isoDayNumber
+    return date
+        .minus(value = daysSinceSunday - 1, unit = DateTimeUnit.DAY)
+        .atTime(hour = 12, minute = 0) // Make it GMT-BST transition safe
+        .toSystemDefaultTimeZoneInstant()
+        .atStartOfDay()
+}
+
+fun LocalDateTime.endOfWeek(): Instant {
+    val daysUntilSunday = DayOfWeek.SUNDAY.isoDayNumber - dayOfWeek.isoDayNumber
+    return date
+        .plus(daysUntilSunday, DateTimeUnit.DAY)
+        .atTime(hour = 12, minute = 0) // Make it GMT-BST transition safe
+        .toSystemDefaultTimeZoneInstant()
+        .atEndOfDay()
+}

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
@@ -98,19 +98,19 @@ fun UsageScreen(
                             .fillMaxSize()
                             .conditionalBlur(enabled = uiState.isLoading),
                     ) {
-                        with(uiState.consumptionQueryFilter) {
+                        uiState.consumptionQueryFilter?.let { consumptionQueryFilter ->
                             TitleNavigationBar(
                                 modifier = Modifier
                                     .background(color = MaterialTheme.colorScheme.secondary)
                                     .fillMaxWidth()
                                     .height(height = dimension.minListItemHeight),
-                                currentPresentationStyle = presentationStyle,
-                                title = getConsumptionPeriodString(),
-                                canNavigateBack = canNavigateBackward(accountMoveInDate = uiState.userProfile?.account?.movedInAt ?: Instant.DISTANT_PAST),
-                                canNavigateForward = canNavigateForward(),
-                                onNavigateBack = uiEvent.onPreviousTimeFrame,
-                                onNavigateForward = uiEvent.onNextTimeFrame,
-                                onSwitchPresentationStyle = { uiEvent.onSwitchPresentationStyle(it) },
+                                currentPresentationStyle = consumptionQueryFilter.presentationStyle,
+                                title = consumptionQueryFilter.getConsumptionPeriodString(),
+                                canNavigateBack = consumptionQueryFilter.canNavigateBackward(accountMoveInDate = uiState.userProfile?.account?.movedInAt ?: Instant.DISTANT_PAST),
+                                canNavigateForward = consumptionQueryFilter.canNavigateForward(),
+                                onNavigateBack = { uiEvent.onPreviousTimeFrame(consumptionQueryFilter) },
+                                onNavigateForward = { uiEvent.onNextTimeFrame(consumptionQueryFilter) },
+                                onSwitchPresentationStyle = { presentationStyle -> uiEvent.onSwitchPresentationStyle(consumptionQueryFilter, presentationStyle) },
                             )
                         }
 
@@ -218,34 +218,36 @@ fun UsageScreen(
                                     )
                                 }
 
-                                consumptionGroupsWithPartitions.forEach { consumptionGroupWithPartitions ->
-                                    item(key = "${consumptionGroupWithPartitions.title}Title") {
-                                        RateGroupTitle(
-                                            modifier = Modifier
-                                                .fillMaxWidth()
-                                                .padding(
-                                                    vertical = dimension.grid_2,
-                                                    horizontal = dimension.grid_4,
-                                                ),
-                                            consumptionGroupWithPartitions = consumptionGroupWithPartitions,
-                                        )
-                                    }
+                                if (uiState.consumptionQueryFilter != null) {
+                                    consumptionGroupsWithPartitions.forEach { consumptionGroupWithPartitions ->
+                                        item(key = "${consumptionGroupWithPartitions.title}Title") {
+                                            RateGroupTitle(
+                                                modifier = Modifier
+                                                    .fillMaxWidth()
+                                                    .padding(
+                                                        vertical = dimension.grid_2,
+                                                        horizontal = dimension.grid_4,
+                                                    ),
+                                                consumptionGroupWithPartitions = consumptionGroupWithPartitions,
+                                            )
+                                        }
 
-                                    val maxRows = consumptionGroupWithPartitions.partitionedItems.maxOf { it.size }
-                                    items(maxRows) { rowIndex ->
-                                        ConsumptionGroupCells(
-                                            modifier = Modifier
-                                                .fillMaxWidth()
-                                                .padding(
-                                                    horizontal = dimension.grid_4,
-                                                    vertical = dimension.grid_0_25,
-                                                ),
-                                            partitionedItems = consumptionGroupWithPartitions.partitionedItems,
-                                            shouldHideLastColumn = shouldHideLastConsumptionGroupColumn,
-                                            rowIndex = rowIndex,
-                                            consumptionRange = uiState.consumptionRange,
-                                            presentationStyle = uiState.consumptionQueryFilter.presentationStyle,
-                                        )
+                                        val maxRows = consumptionGroupWithPartitions.partitionedItems.maxOf { it.size }
+                                        items(maxRows) { rowIndex ->
+                                            ConsumptionGroupCells(
+                                                modifier = Modifier
+                                                    .fillMaxWidth()
+                                                    .padding(
+                                                        horizontal = dimension.grid_4,
+                                                        vertical = dimension.grid_0_25,
+                                                    ),
+                                                partitionedItems = consumptionGroupWithPartitions.partitionedItems,
+                                                shouldHideLastColumn = shouldHideLastConsumptionGroupColumn,
+                                                rowIndex = rowIndex,
+                                                consumptionRange = uiState.consumptionRange,
+                                                presentationStyle = uiState.consumptionQueryFilter.presentationStyle,
+                                            )
+                                        }
                                     }
                                 }
                             }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageUIEvent.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageUIEvent.kt
@@ -9,13 +9,14 @@ package com.rwmobi.kunigami.ui.destinations.usage
 
 import androidx.compose.runtime.Immutable
 import com.rwmobi.kunigami.ui.model.consumption.ConsumptionPresentationStyle
+import com.rwmobi.kunigami.ui.model.consumption.ConsumptionQueryFilter
 
 @Immutable
 data class UsageUIEvent(
     val onInitialLoad: () -> Unit,
-    val onPreviousTimeFrame: () -> Unit,
-    val onNextTimeFrame: () -> Unit,
-    val onSwitchPresentationStyle: (presentationStyle: ConsumptionPresentationStyle) -> Unit,
+    val onPreviousTimeFrame: (consumptionQueryFilter: ConsumptionQueryFilter) -> Unit,
+    val onNextTimeFrame: (consumptionQueryFilter: ConsumptionQueryFilter) -> Unit,
+    val onSwitchPresentationStyle: (consumptionQueryFilter: ConsumptionQueryFilter, presentationStyle: ConsumptionPresentationStyle) -> Unit,
     val onErrorShown: (errorId: Long) -> Unit,
     val onNavigateToAccountTab: () -> Unit,
     val onScrolledToTop: () -> Unit,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageUIState.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageUIState.kt
@@ -42,7 +42,7 @@ data class UsageUIState(
     val requestedChartLayout: RequestedChartLayout = RequestedChartLayout.Portrait,
     val requestedAdaptiveLayout: WindowWidthSizeClass = WindowWidthSizeClass.Compact,
     val requestedUsageColumns: Int = 1,
-    val consumptionQueryFilter: ConsumptionQueryFilter = ConsumptionQueryFilter(),
+    val consumptionQueryFilter: ConsumptionQueryFilter? = null,
     val consumptionGroupedCells: List<ConsumptionGroupedCells> = emptyList(),
     val consumptionRange: ClosedFloatingPointRange<Double> = 0.0..0.0,
     val barChartData: BarChartData? = null,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
@@ -10,6 +10,7 @@ package com.rwmobi.kunigami.ui.model.consumption
 import androidx.compose.runtime.Immutable
 import com.rwmobi.kunigami.domain.extensions.atEndOfDay
 import com.rwmobi.kunigami.domain.extensions.atStartOfDay
+import com.rwmobi.kunigami.domain.extensions.getDayRange
 import com.rwmobi.kunigami.domain.extensions.getLocalDateString
 import com.rwmobi.kunigami.domain.extensions.getLocalDayMonthString
 import com.rwmobi.kunigami.domain.extensions.getLocalDayOfMonth
@@ -53,7 +54,7 @@ data class ConsumptionQueryFilter(
 
             return when (presentationStyle) {
                 ConsumptionPresentationStyle.DAY_HALF_HOURLY -> {
-                    referencePoint.atStartOfDay()..referencePoint.atEndOfDay()
+                    referencePoint.getDayRange()
                 }
 
                 ConsumptionPresentationStyle.WEEK_SEVEN_DAYS -> {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
@@ -10,7 +10,6 @@ package com.rwmobi.kunigami.ui.model.consumption
 import androidx.compose.runtime.Immutable
 import com.rwmobi.kunigami.domain.extensions.endOfMonth
 import com.rwmobi.kunigami.domain.extensions.endOfWeek
-import com.rwmobi.kunigami.domain.extensions.endOfYear
 import com.rwmobi.kunigami.domain.extensions.getDayRange
 import com.rwmobi.kunigami.domain.extensions.getLocalDateString
 import com.rwmobi.kunigami.domain.extensions.getLocalDayMonthString
@@ -20,9 +19,11 @@ import com.rwmobi.kunigami.domain.extensions.getLocalHHMMString
 import com.rwmobi.kunigami.domain.extensions.getLocalMonthString
 import com.rwmobi.kunigami.domain.extensions.getLocalMonthYearString
 import com.rwmobi.kunigami.domain.extensions.getLocalYear
+import com.rwmobi.kunigami.domain.extensions.getMonthRange
+import com.rwmobi.kunigami.domain.extensions.getWeekRange
+import com.rwmobi.kunigami.domain.extensions.getYearRange
 import com.rwmobi.kunigami.domain.extensions.startOfMonth
 import com.rwmobi.kunigami.domain.extensions.startOfWeek
-import com.rwmobi.kunigami.domain.extensions.startOfYear
 import com.rwmobi.kunigami.domain.extensions.toSystemDefaultLocalDateTime
 import com.rwmobi.kunigami.domain.extensions.toSystemDefaultTimeZoneInstant
 import com.rwmobi.kunigami.domain.model.consumption.Consumption
@@ -59,7 +60,7 @@ data class ConsumptionQueryFilter(
                 }
 
                 ConsumptionPresentationStyle.WEEK_SEVEN_DAYS -> {
-                    localDateTime.startOfWeek()..localDateTime.endOfWeek()
+                    referencePoint.getWeekRange()
                 }
 
                 ConsumptionPresentationStyle.MONTH_WEEKS -> {
@@ -69,11 +70,11 @@ data class ConsumptionQueryFilter(
                 }
 
                 ConsumptionPresentationStyle.MONTH_THIRTY_DAYS -> {
-                    localDateTime.startOfMonth()..localDateTime.endOfMonth()
+                    referencePoint.getMonthRange()
                 }
 
                 ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS -> {
-                    localDateTime.startOfYear()..localDateTime.endOfYear()
+                    referencePoint.getYearRange()
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
@@ -8,8 +8,9 @@
 package com.rwmobi.kunigami.ui.model.consumption
 
 import androidx.compose.runtime.Immutable
-import com.rwmobi.kunigami.domain.extensions.atEndOfDay
-import com.rwmobi.kunigami.domain.extensions.atStartOfDay
+import com.rwmobi.kunigami.domain.extensions.endOfMonth
+import com.rwmobi.kunigami.domain.extensions.endOfWeek
+import com.rwmobi.kunigami.domain.extensions.endOfYear
 import com.rwmobi.kunigami.domain.extensions.getDayRange
 import com.rwmobi.kunigami.domain.extensions.getLocalDateString
 import com.rwmobi.kunigami.domain.extensions.getLocalDayMonthString
@@ -19,18 +20,18 @@ import com.rwmobi.kunigami.domain.extensions.getLocalHHMMString
 import com.rwmobi.kunigami.domain.extensions.getLocalMonthString
 import com.rwmobi.kunigami.domain.extensions.getLocalMonthYearString
 import com.rwmobi.kunigami.domain.extensions.getLocalYear
+import com.rwmobi.kunigami.domain.extensions.startOfMonth
+import com.rwmobi.kunigami.domain.extensions.startOfWeek
+import com.rwmobi.kunigami.domain.extensions.startOfYear
 import com.rwmobi.kunigami.domain.extensions.toSystemDefaultLocalDateTime
 import com.rwmobi.kunigami.domain.extensions.toSystemDefaultTimeZoneInstant
 import com.rwmobi.kunigami.domain.model.consumption.Consumption
 import io.github.koalaplot.core.util.toString
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
-import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.Instant
-import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atTime
-import kotlinx.datetime.isoDayNumber
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
@@ -58,70 +59,21 @@ data class ConsumptionQueryFilter(
                 }
 
                 ConsumptionPresentationStyle.WEEK_SEVEN_DAYS -> {
-                    val dayOfWeek = localDateTime.date.dayOfWeek
-                    val daysSinceSunday = dayOfWeek.isoDayNumber
-                    val startOfWeek = localDateTime.date
-                        .minus(value = daysSinceSunday - 1, unit = DateTimeUnit.DAY)
-                        .atTime(hour = 12, minute = 0) // Make it GMT-BST transition safe
-                        .toSystemDefaultTimeZoneInstant().atStartOfDay()
-
-                    val daysUntilSunday = DayOfWeek.SUNDAY.isoDayNumber - dayOfWeek.isoDayNumber
-                    val endOfWeek = localDateTime.date
-                        .plus(daysUntilSunday, DateTimeUnit.DAY)
-                        .atTime(hour = 12, minute = 0) // Make it GMT-BST transition safe
-                        .toSystemDefaultTimeZoneInstant().atEndOfDay()
-
-                    startOfWeek..endOfWeek
+                    localDateTime.startOfWeek()..localDateTime.endOfWeek()
                 }
 
                 ConsumptionPresentationStyle.MONTH_WEEKS -> {
-                    val startOfMonth = LocalDate(year = localDateTime.year, monthNumber = localDateTime.monthNumber, dayOfMonth = 1)
-                        .atTime(hour = 12, minute = 0) // Make it GMT-BST transition safe
-                    val startDayOfWeek = startOfMonth.date.dayOfWeek
-                    val daysSinceSunday = startDayOfWeek.isoDayNumber
-                    val startOfWeek = startOfMonth.date
-                        .minus(value = daysSinceSunday - 1, unit = DateTimeUnit.DAY)
-                        .atTime(hour = 12, minute = 0) // Make it GMT-BST transition safe
-                        .toSystemDefaultTimeZoneInstant().atStartOfDay()
-
-                    val endOfMonth = LocalDate(year = localDateTime.year, monthNumber = localDateTime.monthNumber, dayOfMonth = 1)
-                        .plus(1, DateTimeUnit.MONTH)
-                        .atTime(hour = 0, minute = 0)
-                        .toSystemDefaultTimeZoneInstant() - 1.nanoseconds
-                    val endDayOfWeek = endOfMonth.toSystemDefaultLocalDateTime().date.dayOfWeek
-                    val daysUntilSunday = DayOfWeek.SUNDAY.isoDayNumber - endDayOfWeek.isoDayNumber
-                    val endOfWeek = endOfMonth.toSystemDefaultLocalDateTime().date
-                        .plus(daysUntilSunday, DateTimeUnit.DAY)
-                        .atTime(hour = 12, minute = 0) // Make it GMT-BST transition safe
-                        .toSystemDefaultTimeZoneInstant().atEndOfDay()
-
+                    val startOfWeek = localDateTime.startOfMonth().toSystemDefaultLocalDateTime().startOfWeek()
+                    val endOfWeek = localDateTime.endOfMonth().toSystemDefaultLocalDateTime().endOfWeek()
                     startOfWeek..endOfWeek
                 }
 
                 ConsumptionPresentationStyle.MONTH_THIRTY_DAYS -> {
-                    val startOfThisMonth = LocalDate(year = localDateTime.year, monthNumber = localDateTime.monthNumber, dayOfMonth = 1)
-                        .atTime(hour = 12, minute = 0) // Make it GMT-BST transition safe
-                        .toSystemDefaultTimeZoneInstant().atStartOfDay()
-
-                    val endOfThisMonth = LocalDate(year = localDateTime.year, monthNumber = localDateTime.monthNumber, dayOfMonth = 1)
-                        .plus(1, DateTimeUnit.MONTH)
-                        .minus(1, DateTimeUnit.DAY)
-                        .atTime(hour = 12, minute = 0) // Make it GMT-BST transition safe
-                        .toSystemDefaultTimeZoneInstant().atEndOfDay()
-
-                    startOfThisMonth..endOfThisMonth
+                    localDateTime.startOfMonth()..localDateTime.endOfMonth()
                 }
 
                 ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS -> {
-                    val startOfThisMonth = LocalDate(year = localDateTime.year, monthNumber = 1, dayOfMonth = 1)
-                        .atTime(hour = 12, minute = 0) // Make it GMT-BST transition safe
-                        .toSystemDefaultTimeZoneInstant().atStartOfDay()
-
-                    val endOfThisYear = LocalDate(year = localDateTime.year, monthNumber = 12, dayOfMonth = 31)
-                        .atTime(hour = 12, minute = 0) // Make it GMT-BST transition safe
-                        .toSystemDefaultTimeZoneInstant().atEndOfDay()
-
-                    startOfThisMonth..endOfThisYear
+                    localDateTime.startOfYear()..localDateTime.endOfYear()
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
@@ -45,7 +45,7 @@ import kotlin.time.Duration.Companion.nanoseconds
 data class ConsumptionQueryFilter(
     val presentationStyle: ConsumptionPresentationStyle = ConsumptionPresentationStyle.DAY_HALF_HOURLY,
     val referencePoint: Instant = Clock.System.now(),
-    val requestedPeriod: ClosedRange<Instant> = Clock.System.now()..Clock.System.now(),
+    val requestedPeriod: ClosedRange<Instant> = calculateQueryPeriod(referencePoint = Clock.System.now(), ConsumptionPresentationStyle.DAY_HALF_HOURLY),
 ) {
     companion object {
         fun calculateQueryPeriod(referencePoint: Instant, presentationStyle: ConsumptionPresentationStyle): ClosedRange<Instant> {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModel.kt
@@ -12,8 +12,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import com.rwmobi.kunigami.domain.exceptions.IncompleteCredentialsException
-import com.rwmobi.kunigami.domain.extensions.atEndOfDay
-import com.rwmobi.kunigami.domain.extensions.atStartOfDay
+import com.rwmobi.kunigami.domain.extensions.getDayRange
 import com.rwmobi.kunigami.domain.model.account.UserProfile
 import com.rwmobi.kunigami.domain.model.consumption.ConsumptionWithCost
 import com.rwmobi.kunigami.domain.model.consumption.getConsumptionRange
@@ -88,7 +87,7 @@ class UsageViewModel(
                 var newConsumptionQueryFilter = ConsumptionQueryFilter(
                     presentationStyle = ConsumptionPresentationStyle.DAY_HALF_HOURLY,
                     referencePoint = referencePoint,
-                    requestedPeriod = referencePoint.atStartOfDay()..referencePoint.atEndOfDay(),
+                    requestedPeriod = referencePoint.getDayRange(),
                 )
 
                 // UIState comes with a default presentationStyle. We try to go backward 5 times hoping for some valid results

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensionsKtTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensionsKtTest.kt
@@ -48,6 +48,13 @@ class InstantExtensionsKtTest {
     }
 
     @Test
+    fun `getDateRange should return correct range`() {
+        val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
+        val expected = instant.atStartOfDay()..instant.atEndOfDay()
+        assertEquals(expected, instant.getDayRange())
+    }
+
+    @Test
     fun `getLocalHHMMString should format correctly`() {
         val instant = LocalDateTime(year = 2023, monthNumber = 5, dayOfMonth = 1, hour = 10, minute = 45, second = 15).toInstant(timeZone)
         val expected = "10:45"

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.desktop.kt
@@ -7,7 +7,15 @@
 
 package com.rwmobi.kunigami.ui.extensions
 
-/***
- * This is needed to handle Ktor Darwin Engine exceptions which does not exist in CommonMain
- */
-actual fun Throwable.mapFromPlatform(): Throwable = this
+import io.ktor.util.network.UnresolvedAddressException
+import java.net.UnknownHostException
+
+actual fun Throwable.mapFromPlatform(): Throwable {
+    return when (this) {
+        is UnknownHostException -> {
+            UnresolvedAddressException()
+        }
+
+        else -> this
+    }
+}


### PR DESCRIPTION
In UsageViewModel, we forgot to specify `requestedScreenType = UsageScreenType.Chart,` when we want to show the chart. Since this was a default value we were not aware of it until ErrorScreen alters this value.

A quick fix to add back this value.

Also refactored a bit the ViewModel and other classes.