### PR TITLE
(#174) Cache user profile in repository

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -418,10 +418,8 @@ kover {
                         "$productNameSpace.App*",
                         "$productNameSpace.MainKt*",
                         "$productNameSpace.NavigationLayoutType",
-                        "$productNameSpace.data.repositor.DemoRestApiRepository",
                         "$productNameSpace.ui.extensions.WindowSizeClassExtensions*",
-                        "$productNameSpace..ui.extensions.ThrowableExtensions*",
-                        "$productNameSpace.ui.extensions.GenerateRandomLong*",
+                        "$productNameSpace.ui.extensions.ThrowableExtensions*",
                         "$productNameSpace.ui.extensions.GenerateRandomLong*",
                         "$productNameSpace.data.source.local.preferences.ProvideSettings*",
                         "$productNameSpace.data.source.local.preferences.MultiplatformPreferencesStore*",
@@ -445,9 +443,7 @@ kover {
                         "$productNameSpace.ui.theme",
                         "$productNameSpace.ui.previewsampledata",
                         "androidx",
-                        "dagger.hilt.internal.aggregatedroot.codegen",
-                        "hilt_aggregated_deps",
-                        "kunigami.composeapp.generated.resources",
+                        "kunigami.composeapp.generated.*",
                     ),
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/OctopusRestApiRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/OctopusRestApiRepository.kt
@@ -44,10 +44,10 @@ class OctopusRestApiRepository(
         tariffCode: String,
     ): Result<Tariff> {
         return withContext(dispatcher) {
-            val productCode = Tariff.extractProductCode(tariffCode = tariffCode)
-            requireNotNull(productCode) { "Unable to resolve product code for $tariffCode" }
-
             runCatching {
+                val productCode = Tariff.extractProductCode(tariffCode = tariffCode)
+                requireNotNull(productCode) { "Unable to resolve product code for $tariffCode" }
+
                 val apiResponse = productsEndpoint.getProduct(productCode = productCode)
                 apiResponse?.toTariff(tariffCode = tariffCode) ?: throw IllegalArgumentException("Unable to retrieve base product $productCode")
             }.except<CancellationException, _>()

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/OctopusRestApiRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/OctopusRestApiRepository.kt
@@ -99,10 +99,10 @@ class OctopusRestApiRepository(
         requestedPage: Int?,
     ): Result<List<Rate>> {
         return withContext(dispatcher) {
-            val productCode = Tariff.extractProductCode(tariffCode = tariffCode)
-            requireNotNull(productCode) { "Unable to resolve product code for $tariffCode" }
-
             runCatching {
+                val productCode = Tariff.extractProductCode(tariffCode = tariffCode)
+                requireNotNull(productCode) { "Unable to resolve product code for $tariffCode" }
+
                 val combinedList = mutableListOf<Rate>()
                 var page: Int? = requestedPage
                 do {
@@ -132,10 +132,10 @@ class OctopusRestApiRepository(
         requestedPage: Int?,
     ): Result<List<Rate>> {
         return withContext(dispatcher) {
-            val productCode = Tariff.extractProductCode(tariffCode = tariffCode)
-            requireNotNull(productCode) { "Unable to resolve product code for $tariffCode" }
-
             runCatching {
+                val productCode = Tariff.extractProductCode(tariffCode = tariffCode)
+                requireNotNull(productCode) { "Unable to resolve product code for $tariffCode" }
+
                 val combinedList = mutableListOf<Rate>()
                 var page: Int? = requestedPage
                 do {
@@ -163,10 +163,10 @@ class OctopusRestApiRepository(
         requestedPage: Int?,
     ): Result<List<Rate>> {
         return withContext(dispatcher) {
-            val productCode = Tariff.extractProductCode(tariffCode = tariffCode)
-            requireNotNull(productCode) { "Unable to resolve product code for $tariffCode" }
-
             runCatching {
+                val productCode = Tariff.extractProductCode(tariffCode = tariffCode)
+                requireNotNull(productCode) { "Unable to resolve product code for $tariffCode" }
+
                 val combinedList = mutableListOf<Rate>()
                 var page: Int? = requestedPage
                 do {
@@ -194,10 +194,10 @@ class OctopusRestApiRepository(
         requestedPage: Int?,
     ): Result<List<Rate>> {
         return withContext(dispatcher) {
-            val productCode = Tariff.extractProductCode(tariffCode = tariffCode)
-            requireNotNull(productCode) { "Unable to resolve product code for $tariffCode" }
-
             runCatching {
+                val productCode = Tariff.extractProductCode(tariffCode = tariffCode)
+                requireNotNull(productCode) { "Unable to resolve product code for $tariffCode" }
+
                 val combinedList = mutableListOf<Rate>()
                 var page: Int? = requestedPage
                 do {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/TariffMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/TariffMapper.kt
@@ -44,27 +44,25 @@ fun SingleProductApiResponse.toTariff(
         else -> TariffPaymentTerm.UNKNOWN
     }
 
-    return with(rates) {
-        Tariff(
-            productCode = code,
-            fullName = fullName,
-            displayName = displayName,
-            description = description,
-            isVariable = isVariable,
-            availability = availableFrom..(availableTo ?: Instant.DISTANT_FUTURE),
+    return Tariff(
+        productCode = code,
+        fullName = fullName,
+        displayName = displayName,
+        description = description,
+        isVariable = isVariable,
+        availability = availableFrom..(availableTo ?: Instant.DISTANT_FUTURE),
 
-            tariffCode = code,
-            tariffActiveAt = tariffsActiveAt,
+        tariffCode = rates.code,
+        tariffActiveAt = tariffsActiveAt,
 
-            tariffPaymentTerm = tariffPaymentTerm,
-            vatInclusiveStandingCharge = standingChargeIncVat,
-            vatInclusiveOnlineDiscount = onlineDiscountIncVat,
-            vatInclusiveDualFuelDiscount = dualFuelDiscountIncVat,
-            exitFeesType = ExitFeesType.fromApiValue(value = exitFeesType),
-            vatInclusiveExitFees = exitFeesIncVat,
-            vatInclusiveStandardUnitRate = standardUnitRateIncVat,
-            vatInclusiveDayUnitRate = dayUnitRateIncVat,
-            vatInclusiveNightUnitRate = nightUnitRateIncVat,
-        )
-    }
+        tariffPaymentTerm = tariffPaymentTerm,
+        vatInclusiveStandingCharge = rates.standingChargeIncVat,
+        vatInclusiveOnlineDiscount = rates.onlineDiscountIncVat,
+        vatInclusiveDualFuelDiscount = rates.dualFuelDiscountIncVat,
+        exitFeesType = ExitFeesType.fromApiValue(value = rates.exitFeesType),
+        vatInclusiveExitFees = rates.exitFeesIncVat,
+        vatInclusiveStandardUnitRate = rates.standardUnitRateIncVat,
+        vatInclusiveDayUnitRate = rates.dayUnitRateIncVat,
+        vatInclusiveNightUnitRate = rates.nightUnitRateIncVat,
+    )
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/repository/OctopusRestApiRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/repository/OctopusRestApiRepositoryTest.kt
@@ -11,6 +11,7 @@ import com.rwmobi.kunigami.data.source.network.AccountEndpoint
 import com.rwmobi.kunigami.data.source.network.ElectricityMeterPointsEndpoint
 import com.rwmobi.kunigami.data.source.network.ProductsEndpoint
 import com.rwmobi.kunigami.data.source.network.samples.GetAccountSampleData
+import com.rwmobi.kunigami.data.source.network.samples.GetTariffSampleData
 import com.rwmobi.kunigami.domain.exceptions.HttpException
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -28,6 +29,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /***
@@ -43,6 +45,7 @@ class OctopusRestApiRepositoryTest {
     private val fakeBaseUrl = "https://some.fakeurl.com"
     private val fakeApiKey = "sk_live_xXxX1xx1xx1xx1XXxX1Xxx1x"
     private val fakeAccountNumber = "B-1234A1A1"
+    private val sampleTariffCode = "E-1R-AGILE-FLEX-22-11-25-A"
 
     private val mockEngineInternalServerError = MockEngine { _ ->
         respond(
@@ -94,6 +97,61 @@ class OctopusRestApiRepositoryTest {
         )
     }
 
+    // 🗂 getTariff
+    @Test
+    fun `getTariff should return expected domain model`() = runTest {
+        setUpRepository(
+            engine = MockEngine { _ ->
+                respond(
+                    content = ByteReadChannel(GetTariffSampleData.json),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        )
+
+        val result = octopusRestApiRepository.getTariff(
+            tariffCode = sampleTariffCode,
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals(expected = GetTariffSampleData.tariff, actual = result.getOrNull())
+    }
+
+    @Test
+    fun `getTariff should return failure when product code cannot be resorlved`() = runTest {
+        setUpRepository(
+            engine = MockEngine { _ ->
+                respond(
+                    content = ByteReadChannel(GetTariffSampleData.json),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        )
+
+        val result = octopusRestApiRepository.getTariff(
+            tariffCode = "invalid tariff code",
+        )
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+    }
+
+    @Test
+    fun `getTariff should return failure when data source throws an exception`() = runTest {
+        setUpRepository(
+            engine = mockEngineInternalServerError,
+        )
+
+        val result = octopusRestApiRepository.getTariff(
+            tariffCode = sampleTariffCode,
+        )
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is HttpException)
+    }
+
     // 🗂 getAccount
     @Test
     fun `getAccount should return expected domain model`() = runTest {
@@ -113,7 +171,7 @@ class OctopusRestApiRepositoryTest {
         )
 
         assertTrue(result.isSuccess)
-        assertEquals(result.getOrNull(), GetAccountSampleData.account)
+        assertEquals(expected = GetAccountSampleData.account, actual = result.getOrNull())
     }
 
     @Test
@@ -126,7 +184,7 @@ class OctopusRestApiRepositoryTest {
         )
 
         assertTrue(result.isSuccess)
-        assertEquals(result.getOrNull(), null)
+        assertNull(actual = result.getOrNull())
     }
 
     @Test
@@ -139,6 +197,43 @@ class OctopusRestApiRepositoryTest {
         )
 
         assertTrue(result.isFailure)
-        assertTrue(result.exceptionOrNull() is HttpException)
+        assertTrue(actual = result.exceptionOrNull() is HttpException)
+    }
+
+    @Test
+    fun `getAccount should return cached result when it hits the cache`() = runTest {
+        var shouldEndpointReturnError = false
+        setUpRepository(
+            engine = MockEngine { _ ->
+                if (!shouldEndpointReturnError) {
+                    respond(
+                        content = ByteReadChannel(GetAccountSampleData.json),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                } else {
+                    respond(
+                        content = ByteReadChannel("Internal Server Error"),
+                        status = HttpStatusCode.InternalServerError,
+                        headers = headersOf(HttpHeaders.ContentType, "text/html"),
+                    )
+                }
+            },
+        )
+
+        val firstAccess = octopusRestApiRepository.getAccount(
+            apiKey = fakeApiKey,
+            accountNumber = fakeAccountNumber,
+        )
+        assertTrue(firstAccess.isSuccess)
+        assertEquals(expected = GetAccountSampleData.account, actual = firstAccess.getOrNull())
+
+        shouldEndpointReturnError = true
+        val secondAccess = octopusRestApiRepository.getAccount(
+            apiKey = fakeApiKey,
+            accountNumber = fakeAccountNumber,
+        )
+        assertTrue(secondAccess.isSuccess)
+        assertEquals(expected = GetAccountSampleData.account, actual = secondAccess.getOrNull())
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/samples/GetProductsSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/samples/GetProductsSampleData.kt
@@ -10,6 +10,9 @@ package com.rwmobi.kunigami.data.source.network.samples
 import com.rwmobi.kunigami.data.source.network.dto.LinkDto
 import com.rwmobi.kunigami.data.source.network.dto.products.ProductDetailsDto
 import com.rwmobi.kunigami.data.source.network.dto.products.ProductsApiResponse
+import com.rwmobi.kunigami.domain.model.product.ProductDirection
+import com.rwmobi.kunigami.domain.model.product.ProductFeature
+import com.rwmobi.kunigami.domain.model.product.ProductSummary
 import kotlinx.datetime.Instant
 
 object GetProductsSampleData {
@@ -143,6 +146,74 @@ object GetProductsSampleData {
 }
         """.trimIndent()
 
+    val jsonPage1 =
+        """{
+    "count": 2,
+    "next": "https://some.endpoint.test/v1/products/AGILE-24-04-03/?page=2",
+    "previous": null,
+    "results": [
+        {
+            "code": "AGILE-24-04-03",
+            "direction": "IMPORT",
+            "full_name": "Agile Octopus April 2024 v1",
+            "display_name": "Agile Octopus",
+            "description": "With Agile Octopus, you get access to half-hourly energy prices, tied to wholesale prices and updated daily.  The unit rate is capped at 100p/kWh (including VAT).",
+            "is_variable": true,
+            "is_green": true,
+            "is_tracker": false,
+            "is_prepay": false,
+            "is_business": false,
+            "is_restricted": false,
+            "term": 12,
+            "available_from": "2024-04-03T00:00:00+01:00",
+            "available_to": null,
+            "links": [
+                {
+                    "href": "https://api.octopus.energy/v1/products/AGILE-24-04-03/",
+                    "method": "GET",
+                    "rel": "self"
+                }
+            ],
+            "brand": "OCTOPUS_ENERGY"
+        }
+    ]
+}
+        """.trimIndent()
+
+    val jsonPage2 =
+        """{
+    "count": 2,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "code": "AGILE-BB-24-04-03",
+            "direction": "IMPORT",
+            "full_name": "Agile Octopus April 2024 v1",
+            "display_name": "Agile Octopus",
+            "description": "With Agile Octopus, you get access to half-hourly energy prices, tied to wholesale prices and updated daily.  The unit rate is capped at 100p/kWh (including VAT).",
+            "is_variable": true,
+            "is_green": true,
+            "is_tracker": false,
+            "is_prepay": false,
+            "is_business": false,
+            "is_restricted": false,
+            "term": 12,
+            "available_from": "2024-04-03T00:00:00+01:00",
+            "available_to": null,
+            "links": [
+                {
+                    "href": "https://api.octopus.energy/v1/products/AGILE-BB-24-04-03/",
+                    "method": "GET",
+                    "rel": "self"
+                }
+            ],
+            "brand": "BULB"
+        }
+    ]
+}
+        """.trimIndent()
+
     val dto = ProductsApiResponse(
         count = 5,
         next = null,
@@ -269,5 +340,92 @@ object GetProductsSampleData {
                 brand = "COOP_ENERGY",
             ),
         ),
+    )
+
+    val productSummary = listOf(
+        ProductSummary(
+            code = "AGILE-24-04-03",
+            direction = ProductDirection.IMPORT,
+            fullName = "Agile Octopus April 2024 v1",
+            displayName = "Agile Octopus",
+            description = "With Agile Octopus, you get access to half-hourly energy prices, tied to wholesale prices and updated daily.  The unit rate is capped at 100p/kWh (including VAT).",
+            features = listOf(ProductFeature.VARIABLE, ProductFeature.GREEN),
+            term = 12,
+            availability = Instant.parse("2024-04-02T23:00:00Z")..Instant.DISTANT_FUTURE,
+            brand = "OCTOPUS_ENERGY",
+        ),
+        ProductSummary(
+            code = "AGILE-BB-24-04-03",
+            direction = ProductDirection.IMPORT,
+            fullName = "Agile Octopus April 2024 v1",
+            displayName = "Agile Octopus",
+            description = "With Agile Octopus, you get access to half-hourly energy prices, tied to wholesale prices and updated daily.  The unit rate is capped at 100p/kWh (including VAT).",
+            features = listOf(ProductFeature.VARIABLE, ProductFeature.GREEN),
+            term = 12,
+            availability = Instant.parse("2024-04-02T23:00:00Z")..Instant.DISTANT_FUTURE,
+            brand = "BULB",
+        ),
+        ProductSummary(
+            code = "AGILE-OUTGOING-19-05-13",
+            direction = ProductDirection.EXPORT,
+            fullName = "Agile Outgoing Octopus May 2019",
+            displayName = "Agile Outgoing Octopus",
+            description = "Outgoing Octopus Agile rate pays you for all your exported energy based on the day-ahead wholesale rate.",
+            features = listOf(ProductFeature.VARIABLE, ProductFeature.GREEN),
+            term = 12,
+            availability = Instant.parse("2018-01-01T00:00:00Z")..Instant.DISTANT_FUTURE,
+            brand = "OCTOPUS_ENERGY",
+        ),
+        ProductSummary(
+            code = "AGILE-OUTGOING-BB-23-02-28",
+            direction = ProductDirection.EXPORT,
+            fullName = "Agile Outgoing Octopus February 2023 v1",
+            displayName = "Agile Outgoing Octopus",
+            description = "Outgoing Octopus Agile rate pays you for all your exported energy based on the day-ahead wholesale rate.",
+            features = listOf(ProductFeature.VARIABLE, ProductFeature.GREEN),
+            term = 12,
+            availability = Instant.parse("2023-02-27T00:00:00Z")..Instant.DISTANT_FUTURE,
+            brand = "BULB",
+        ),
+        ProductSummary(
+            code = "COOP-FIX-12M-24-05-04",
+            direction = ProductDirection.IMPORT,
+            fullName = "Co-op 12M Fixed May 2024 v1",
+            displayName = "Co-op 12M Fixed",
+            description = "This tariff features 100% renewable electricity and fixes your unit rates and standing charge for 12 months.",
+            features = listOf(),
+            term = 12,
+            availability = Instant.parse("2024-05-03T23:00:00Z")..Instant.DISTANT_FUTURE,
+            brand = "COOP_ENERGY",
+        ),
+    )
+
+    val productSummaryPage1 = ProductSummary(
+        code = "AGILE-24-04-03",
+        direction = ProductDirection.IMPORT,
+        fullName = "Agile Octopus April 2024 v1",
+        displayName = "Agile Octopus",
+        description = "With Agile Octopus, you get access to half-hourly energy prices, tied to wholesale prices and updated daily.  The unit rate is capped at 100p/kWh (including VAT).",
+        features = listOf(ProductFeature.VARIABLE, ProductFeature.GREEN),
+        term = 12,
+        availability = Instant.parse("2024-04-02T23:00:00Z")..Instant.DISTANT_FUTURE,
+        brand = "OCTOPUS_ENERGY",
+    )
+
+    val productSummaryPage2 = ProductSummary(
+        code = "AGILE-BB-24-04-03",
+        direction = ProductDirection.IMPORT,
+        fullName = "Agile Octopus April 2024 v1",
+        displayName = "Agile Octopus",
+        description = "With Agile Octopus, you get access to half-hourly energy prices, tied to wholesale prices and updated daily.  The unit rate is capped at 100p/kWh (including VAT).",
+        features = listOf(ProductFeature.VARIABLE, ProductFeature.GREEN),
+        term = 12,
+        availability = Instant.parse("2024-04-02T23:00:00Z")..Instant.DISTANT_FUTURE,
+        brand = "BULB",
+    )
+
+    val productSummaryTwoPages = listOf(
+        productSummaryPage1,
+        productSummaryPage2,
     )
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/samples/GetTariffSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/samples/GetTariffSampleData.kt
@@ -1,0 +1,589 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.kunigami.data.source.network.samples
+
+import com.rwmobi.kunigami.domain.model.product.ExitFeesType
+import com.rwmobi.kunigami.domain.model.product.Tariff
+import com.rwmobi.kunigami.domain.model.product.TariffPaymentTerm
+import kotlinx.datetime.Instant
+
+object GetTariffSampleData {
+    val json = """{
+        "code": "AGILE-FLEX-22-11-25",
+        "full_name": "Agile Octopus November 2022 v1",
+        "display_name": "Agile Octopus",
+        "description": "With Agile Octopus, you get access to half-hourly energy prices, tied to wholesale prices and updated daily.  The unit rate is capped at 100p/kWh (including VAT).",
+        "is_variable": true,
+        "is_green": true,
+        "is_tracker": false,
+        "is_prepay": false,
+        "is_business": false,
+        "is_restricted": false,
+        "term": null,
+        "available_from": "2022-11-25T00:00:00Z",
+        "available_to": "2023-12-11T12:00:00Z",
+        "tariffs_active_at": "2024-06-23T00:24:55.986143Z",
+        "single_register_electricity_tariffs": {
+            "_A": {
+                "direct_debit_monthly": {
+                    "code": "E-1R-AGILE-FLEX-22-11-25-A",
+                    "standing_charge_exc_vat": 35.52,
+                    "standing_charge_inc_vat": 37.296,
+                    "online_discount_exc_vat": 0,
+                    "online_discount_inc_vat": 0,
+                    "dual_fuel_discount_exc_vat": 0,
+                    "dual_fuel_discount_inc_vat": 0,
+                    "exit_fees_exc_vat": 0,
+                    "exit_fees_inc_vat": 0,
+                    "exit_fees_type": "NONE",
+                    "links": [
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-A/standing-charges/",
+                            "method": "GET",
+                            "rel": "standing_charges"
+                        },
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-A/standard-unit-rates/",
+                            "method": "GET",
+                            "rel": "standard_unit_rates"
+                        }
+                    ],
+                    "standard_unit_rate_exc_vat": 15.79,
+                    "standard_unit_rate_inc_vat": 16.5795
+                }
+            },
+            "_B": {
+                "direct_debit_monthly": {
+                    "code": "E-1R-AGILE-FLEX-22-11-25-B",
+                    "standing_charge_exc_vat": 42.02,
+                    "standing_charge_inc_vat": 44.121,
+                    "online_discount_exc_vat": 0,
+                    "online_discount_inc_vat": 0,
+                    "dual_fuel_discount_exc_vat": 0,
+                    "dual_fuel_discount_inc_vat": 0,
+                    "exit_fees_exc_vat": 0,
+                    "exit_fees_inc_vat": 0,
+                    "exit_fees_type": "NONE",
+                    "links": [
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-B/standing-charges/",
+                            "method": "GET",
+                            "rel": "standing_charges"
+                        },
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-B/standard-unit-rates/",
+                            "method": "GET",
+                            "rel": "standard_unit_rates"
+                        }
+                    ],
+                    "standard_unit_rate_exc_vat": 15.04,
+                    "standard_unit_rate_inc_vat": 15.792
+                }
+            },
+            "_C": {
+                "direct_debit_monthly": {
+                    "code": "E-1R-AGILE-FLEX-22-11-25-C",
+                    "standing_charge_exc_vat": 30.01,
+                    "standing_charge_inc_vat": 31.5105,
+                    "online_discount_exc_vat": 0,
+                    "online_discount_inc_vat": 0,
+                    "dual_fuel_discount_exc_vat": 0,
+                    "dual_fuel_discount_inc_vat": 0,
+                    "exit_fees_exc_vat": 0,
+                    "exit_fees_inc_vat": 0,
+                    "exit_fees_type": "NONE",
+                    "links": [
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-C/standing-charges/",
+                            "method": "GET",
+                            "rel": "standing_charges"
+                        },
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-C/standard-unit-rates/",
+                            "method": "GET",
+                            "rel": "standard_unit_rates"
+                        }
+                    ],
+                    "standard_unit_rate_exc_vat": 15.04,
+                    "standard_unit_rate_inc_vat": 15.792
+                }
+            },
+            "_D": {
+                "direct_debit_monthly": {
+                    "code": "E-1R-AGILE-FLEX-22-11-25-D",
+                    "standing_charge_exc_vat": 44.72,
+                    "standing_charge_inc_vat": 46.956,
+                    "online_discount_exc_vat": 0,
+                    "online_discount_inc_vat": 0,
+                    "dual_fuel_discount_exc_vat": 0,
+                    "dual_fuel_discount_inc_vat": 0,
+                    "exit_fees_exc_vat": 0,
+                    "exit_fees_inc_vat": 0,
+                    "exit_fees_type": "NONE",
+                    "links": [
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-D/standing-charges/",
+                            "method": "GET",
+                            "rel": "standing_charges"
+                        },
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-D/standard-unit-rates/",
+                            "method": "GET",
+                            "rel": "standard_unit_rates"
+                        }
+                    ],
+                    "standard_unit_rate_exc_vat": 16.54,
+                    "standard_unit_rate_inc_vat": 17.367
+                }
+            },
+            "_E": {
+                "direct_debit_monthly": {
+                    "code": "E-1R-AGILE-FLEX-22-11-25-E",
+                    "standing_charge_exc_vat": 45.24,
+                    "standing_charge_inc_vat": 47.502,
+                    "online_discount_exc_vat": 0,
+                    "online_discount_inc_vat": 0,
+                    "dual_fuel_discount_exc_vat": 0,
+                    "dual_fuel_discount_inc_vat": 0,
+                    "exit_fees_exc_vat": 0,
+                    "exit_fees_inc_vat": 0,
+                    "exit_fees_type": "NONE",
+                    "links": [
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-E/standing-charges/",
+                            "method": "GET",
+                            "rel": "standing_charges"
+                        },
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-E/standard-unit-rates/",
+                            "method": "GET",
+                            "rel": "standard_unit_rates"
+                        }
+                    ],
+                    "standard_unit_rate_exc_vat": 15.79,
+                    "standard_unit_rate_inc_vat": 16.5795
+                }
+            },
+            "_F": {
+                "direct_debit_monthly": {
+                    "code": "E-1R-AGILE-FLEX-22-11-25-F",
+                    "standing_charge_exc_vat": 45.99,
+                    "standing_charge_inc_vat": 48.2895,
+                    "online_discount_exc_vat": 0,
+                    "online_discount_inc_vat": 0,
+                    "dual_fuel_discount_exc_vat": 0,
+                    "dual_fuel_discount_inc_vat": 0,
+                    "exit_fees_exc_vat": 0,
+                    "exit_fees_inc_vat": 0,
+                    "exit_fees_type": "NONE",
+                    "links": [
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-F/standing-charges/",
+                            "method": "GET",
+                            "rel": "standing_charges"
+                        },
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-F/standard-unit-rates/",
+                            "method": "GET",
+                            "rel": "standard_unit_rates"
+                        }
+                    ],
+                    "standard_unit_rate_exc_vat": 15.79,
+                    "standard_unit_rate_inc_vat": 16.5795
+                }
+            },
+            "_G": {
+                "direct_debit_monthly": {
+                    "code": "E-1R-AGILE-FLEX-22-11-25-G",
+                    "standing_charge_exc_vat": 39.63,
+                    "standing_charge_inc_vat": 41.6115,
+                    "online_discount_exc_vat": 0,
+                    "online_discount_inc_vat": 0,
+                    "dual_fuel_discount_exc_vat": 0,
+                    "dual_fuel_discount_inc_vat": 0,
+                    "exit_fees_exc_vat": 0,
+                    "exit_fees_inc_vat": 0,
+                    "exit_fees_type": "NONE",
+                    "links": [
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-G/standing-charges/",
+                            "method": "GET",
+                            "rel": "standing_charges"
+                        },
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-G/standard-unit-rates/",
+                            "method": "GET",
+                            "rel": "standard_unit_rates"
+                        }
+                    ],
+                    "standard_unit_rate_exc_vat": 15.79,
+                    "standard_unit_rate_inc_vat": 16.5795
+                }
+            },
+            "_H": {
+                "direct_debit_monthly": {
+                    "code": "E-1R-AGILE-FLEX-22-11-25-H",
+                    "standing_charge_exc_vat": 40.73,
+                    "standing_charge_inc_vat": 42.7665,
+                    "online_discount_exc_vat": 0,
+                    "online_discount_inc_vat": 0,
+                    "dual_fuel_discount_exc_vat": 0,
+                    "dual_fuel_discount_inc_vat": 0,
+                    "exit_fees_exc_vat": 0,
+                    "exit_fees_inc_vat": 0,
+                    "exit_fees_type": "NONE",
+                    "links": [
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-H/standing-charges/",
+                            "method": "GET",
+                            "rel": "standing_charges"
+                        },
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-H/standard-unit-rates/",
+                            "method": "GET",
+                            "rel": "standard_unit_rates"
+                        }
+                    ],
+                    "standard_unit_rate_exc_vat": 15.79,
+                    "standard_unit_rate_inc_vat": 16.5795
+                }
+            },
+            "_J": {
+                "direct_debit_monthly": {
+                    "code": "E-1R-AGILE-FLEX-22-11-25-J",
+                    "standing_charge_exc_vat": 39.08,
+                    "standing_charge_inc_vat": 41.034,
+                    "online_discount_exc_vat": 0,
+                    "online_discount_inc_vat": 0,
+                    "dual_fuel_discount_exc_vat": 0,
+                    "dual_fuel_discount_inc_vat": 0,
+                    "exit_fees_exc_vat": 0,
+                    "exit_fees_inc_vat": 0,
+                    "exit_fees_type": "NONE",
+                    "links": [
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-J/standing-charges/",
+                            "method": "GET",
+                            "rel": "standing_charges"
+                        },
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-J/standard-unit-rates/",
+                            "method": "GET",
+                            "rel": "standard_unit_rates"
+                        }
+                    ],
+                    "standard_unit_rate_exc_vat": 16.54,
+                    "standard_unit_rate_inc_vat": 17.367
+                }
+            },
+            "_K": {
+                "direct_debit_monthly": {
+                    "code": "E-1R-AGILE-FLEX-22-11-25-K",
+                    "standing_charge_exc_vat": 45.26,
+                    "standing_charge_inc_vat": 47.523,
+                    "online_discount_exc_vat": 0,
+                    "online_discount_inc_vat": 0,
+                    "dual_fuel_discount_exc_vat": 0,
+                    "dual_fuel_discount_inc_vat": 0,
+                    "exit_fees_exc_vat": 0,
+                    "exit_fees_inc_vat": 0,
+                    "exit_fees_type": "NONE",
+                    "links": [
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-K/standing-charges/",
+                            "method": "GET",
+                            "rel": "standing_charges"
+                        },
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-K/standard-unit-rates/",
+                            "method": "GET",
+                            "rel": "standard_unit_rates"
+                        }
+                    ],
+                    "standard_unit_rate_exc_vat": 16.54,
+                    "standard_unit_rate_inc_vat": 17.367
+                }
+            },
+            "_L": {
+                "direct_debit_monthly": {
+                    "code": "E-1R-AGILE-FLEX-22-11-25-L",
+                    "standing_charge_exc_vat": 48.57,
+                    "standing_charge_inc_vat": 50.9985,
+                    "online_discount_exc_vat": 0,
+                    "online_discount_inc_vat": 0,
+                    "dual_fuel_discount_exc_vat": 0,
+                    "dual_fuel_discount_inc_vat": 0,
+                    "exit_fees_exc_vat": 0,
+                    "exit_fees_inc_vat": 0,
+                    "exit_fees_type": "NONE",
+                    "links": [
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-L/standing-charges/",
+                            "method": "GET",
+                            "rel": "standing_charges"
+                        },
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-L/standard-unit-rates/",
+                            "method": "GET",
+                            "rel": "standard_unit_rates"
+                        }
+                    ],
+                    "standard_unit_rate_exc_vat": 17.3,
+                    "standard_unit_rate_inc_vat": 18.165
+                }
+            },
+            "_M": {
+                "direct_debit_monthly": {
+                    "code": "E-1R-AGILE-FLEX-22-11-25-M",
+                    "standing_charge_exc_vat": 45.62,
+                    "standing_charge_inc_vat": 47.901,
+                    "online_discount_exc_vat": 0,
+                    "online_discount_inc_vat": 0,
+                    "dual_fuel_discount_exc_vat": 0,
+                    "dual_fuel_discount_inc_vat": 0,
+                    "exit_fees_exc_vat": 0,
+                    "exit_fees_inc_vat": 0,
+                    "exit_fees_type": "NONE",
+                    "links": [
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-M/standing-charges/",
+                            "method": "GET",
+                            "rel": "standing_charges"
+                        },
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-M/standard-unit-rates/",
+                            "method": "GET",
+                            "rel": "standard_unit_rates"
+                        }
+                    ],
+                    "standard_unit_rate_exc_vat": 15.04,
+                    "standard_unit_rate_inc_vat": 15.792
+                }
+            },
+            "_N": {
+                "direct_debit_monthly": {
+                    "code": "E-1R-AGILE-FLEX-22-11-25-N",
+                    "standing_charge_exc_vat": 46.69,
+                    "standing_charge_inc_vat": 49.0245,
+                    "online_discount_exc_vat": 0,
+                    "online_discount_inc_vat": 0,
+                    "dual_fuel_discount_exc_vat": 0,
+                    "dual_fuel_discount_inc_vat": 0,
+                    "exit_fees_exc_vat": 0,
+                    "exit_fees_inc_vat": 0,
+                    "exit_fees_type": "NONE",
+                    "links": [
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-N/standing-charges/",
+                            "method": "GET",
+                            "rel": "standing_charges"
+                        },
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-N/standard-unit-rates/",
+                            "method": "GET",
+                            "rel": "standard_unit_rates"
+                        }
+                    ],
+                    "standard_unit_rate_exc_vat": 15.79,
+                    "standard_unit_rate_inc_vat": 16.5795
+                }
+            },
+            "_P": {
+                "direct_debit_monthly": {
+                    "code": "E-1R-AGILE-FLEX-22-11-25-P",
+                    "standing_charge_exc_vat": 47.08,
+                    "standing_charge_inc_vat": 49.434,
+                    "online_discount_exc_vat": 0,
+                    "online_discount_inc_vat": 0,
+                    "dual_fuel_discount_exc_vat": 0,
+                    "dual_fuel_discount_inc_vat": 0,
+                    "exit_fees_exc_vat": 0,
+                    "exit_fees_inc_vat": 0,
+                    "exit_fees_type": "NONE",
+                    "links": [
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-P/standing-charges/",
+                            "method": "GET",
+                            "rel": "standing_charges"
+                        },
+                        {
+                            "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-P/standard-unit-rates/",
+                            "method": "GET",
+                            "rel": "standard_unit_rates"
+                        }
+                    ],
+                    "standard_unit_rate_exc_vat": 18.05,
+                    "standard_unit_rate_inc_vat": 18.9525
+                }
+            }
+        },
+        "dual_register_electricity_tariffs": {},
+        "single_register_gas_tariffs": {},
+        "sample_quotes": {
+            "_A": {
+                "direct_debit_monthly": {
+                    "electricity_single_rate": {
+                        "annual_cost_inc_vat": 58378,
+                        "annual_cost_exc_vat": 55598
+                    }
+                }
+            },
+            "_B": {
+                "direct_debit_monthly": {
+                    "electricity_single_rate": {
+                        "annual_cost_inc_vat": 58743,
+                        "annual_cost_exc_vat": 55945
+                    }
+                }
+            },
+            "_C": {
+                "direct_debit_monthly": {
+                    "electricity_single_rate": {
+                        "annual_cost_inc_vat": 54140,
+                        "annual_cost_exc_vat": 51562
+                    }
+                }
+            },
+            "_D": {
+                "direct_debit_monthly": {
+                    "electricity_single_rate": {
+                        "annual_cost_inc_vat": 64030,
+                        "annual_cost_exc_vat": 60981
+                    }
+                }
+            },
+            "_E": {
+                "direct_debit_monthly": {
+                    "electricity_single_rate": {
+                        "annual_cost_inc_vat": 62103,
+                        "annual_cost_exc_vat": 59146
+                    }
+                }
+            },
+            "_F": {
+                "direct_debit_monthly": {
+                    "electricity_single_rate": {
+                        "annual_cost_inc_vat": 62390,
+                        "annual_cost_exc_vat": 59419
+                    }
+                }
+            },
+            "_G": {
+                "direct_debit_monthly": {
+                    "electricity_single_rate": {
+                        "annual_cost_inc_vat": 59953,
+                        "annual_cost_exc_vat": 57098
+                    }
+                }
+            },
+            "_H": {
+                "direct_debit_monthly": {
+                    "electricity_single_rate": {
+                        "annual_cost_inc_vat": 60374,
+                        "annual_cost_exc_vat": 57499
+                    }
+                }
+            },
+            "_J": {
+                "direct_debit_monthly": {
+                    "electricity_single_rate": {
+                        "annual_cost_inc_vat": 61868,
+                        "annual_cost_exc_vat": 58922
+                    }
+                }
+            },
+            "_K": {
+                "direct_debit_monthly": {
+                    "electricity_single_rate": {
+                        "annual_cost_inc_vat": 64237,
+                        "annual_cost_exc_vat": 61178
+                    }
+                }
+            },
+            "_L": {
+                "direct_debit_monthly": {
+                    "electricity_single_rate": {
+                        "annual_cost_inc_vat": 67660,
+                        "annual_cost_exc_vat": 64438
+                    }
+                }
+            },
+            "_M": {
+                "direct_debit_monthly": {
+                    "electricity_single_rate": {
+                        "annual_cost_inc_vat": 60122,
+                        "annual_cost_exc_vat": 57259
+                    }
+                }
+            },
+            "_N": {
+                "direct_debit_monthly": {
+                    "electricity_single_rate": {
+                        "annual_cost_inc_vat": 62659,
+                        "annual_cost_exc_vat": 59675
+                    }
+                }
+            },
+            "_P": {
+                "direct_debit_monthly": {
+                    "electricity_single_rate": {
+                        "annual_cost_inc_vat": 69215,
+                        "annual_cost_exc_vat": 65919
+                    }
+                }
+            }
+        },
+        "sample_consumption": {
+            "electricity_single_rate": {
+                "electricity_standard": 2700
+            },
+            "electricity_dual_rate": {
+                "electricity_day": 2262,
+                "electricity_night": 1638
+            },
+            "dual_fuel_single_rate": {
+                "electricity_standard": 2700,
+                "gas_standard": 11500
+            },
+            "dual_fuel_dual_rate": {
+                "electricity_day": 2262,
+                "electricity_night": 1638,
+                "gas_standard": 11500
+            }
+        },
+        "links": [
+            {
+                "href": "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/",
+                "method": "GET",
+                "rel": "self"
+            }
+        ],
+        "brand": "OCTOPUS_ENERGY"
+    }
+    """.trimIndent()
+
+    val tariff = Tariff(
+        productCode = "AGILE-FLEX-22-11-25",
+        fullName = "Agile Octopus November 2022 v1",
+        displayName = "Agile Octopus",
+        description = "With Agile Octopus, you get access to half-hourly energy prices, tied to wholesale prices and updated daily.  The unit rate is capped at 100p/kWh (including VAT).",
+        isVariable = true,
+        availability = Instant.parse("2022-11-25T00:00:00Z")..Instant.parse("2023-12-11T12:00:00Z"),
+        tariffPaymentTerm = TariffPaymentTerm.DIRECT_DEBIT_MONTHLY,
+        tariffCode = "E-1R-AGILE-FLEX-22-11-25-A",
+        tariffActiveAt = Instant.parse("2024-06-23T00:24:55.986143Z"),
+        vatInclusiveStandingCharge = 37.296,
+        vatInclusiveOnlineDiscount = 0.0,
+        vatInclusiveDualFuelDiscount = 0.0,
+        exitFeesType = ExitFeesType.NONE,
+        vatInclusiveExitFees = 0.0,
+        vatInclusiveStandardUnitRate = 16.5795,
+        vatInclusiveDayUnitRate = null,
+        vatInclusiveNightUnitRate = null,
+    )
+}


### PR DESCRIPTION
Set up in-memory cache for the Account object that valids within the same day within the repository.
External callers should not be aware of this change. 

Also implement some more unit tests for the repository to troubleshoot Codecov - currently it is not picking up the coverage of the entire repository package.
