### PR TITLE
(#227) Cache half-hourly consumption data using RoomDB in repository

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -125,6 +125,9 @@ kotlin {
             implementation(libs.androidx.room.runtime)
             implementation(libs.androidx.sqlite.bundled)
         }
+        desktopMain.kotlin {
+            srcDir("build/generated/ksp/metadata")
+        }
         desktopMain.dependencies {
             runtimeOnly("org.jetbrains.skiko:skiko-awt-runtime-$skikoTarget:$skikoVersion")
             implementation(compose.desktop.currentOs)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/DemoRestApiRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/DemoRestApiRepository.kt
@@ -47,15 +47,15 @@ class DemoRestApiRepository : RestApiRepository {
         throw NotImplementedError("Disabled in demo mode")
     }
 
-    override suspend fun getStandingCharges(tariffCode: String, requestedPage: Int?): Result<List<Rate>> {
+    override suspend fun getStandingCharges(tariffCode: String, period: ClosedRange<Instant>?, requestedPage: Int?): Result<List<Rate>> {
         throw NotImplementedError("Disabled in demo mode")
     }
 
-    override suspend fun getDayUnitRates(tariffCode: String, requestedPage: Int?): Result<List<Rate>> {
+    override suspend fun getDayUnitRates(tariffCode: String, period: ClosedRange<Instant>?, requestedPage: Int?): Result<List<Rate>> {
         throw NotImplementedError("Disabled in demo mode")
     }
 
-    override suspend fun getNightUnitRates(tariffCode: String, requestedPage: Int?): Result<List<Rate>> {
+    override suspend fun getNightUnitRates(tariffCode: String, period: ClosedRange<Instant>?, requestedPage: Int?): Result<List<Rate>> {
         throw NotImplementedError("Disabled in demo mode")
     }
 

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/OctopusRestApiRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/OctopusRestApiRepository.kt
@@ -133,6 +133,7 @@ class OctopusRestApiRepository(
      */
     override suspend fun getStandingCharges(
         tariffCode: String,
+        period: ClosedRange<Instant>?,
         requestedPage: Int?,
     ): Result<List<Rate>> {
         return withContext(dispatcher) {
@@ -146,6 +147,8 @@ class OctopusRestApiRepository(
                     val apiResponse = productsEndpoint.getStandingCharges(
                         productCode = productCode,
                         tariffCode = tariffCode,
+                        periodFrom = period?.start,
+                        periodTo = period?.endInclusive,
                         page = page,
                     )
                     combinedList.addAll(apiResponse?.results?.map { it.toRate() } ?: emptyList())
@@ -164,6 +167,7 @@ class OctopusRestApiRepository(
      */
     override suspend fun getDayUnitRates(
         tariffCode: String,
+        period: ClosedRange<Instant>?,
         requestedPage: Int?,
     ): Result<List<Rate>> {
         return withContext(dispatcher) {
@@ -177,6 +181,8 @@ class OctopusRestApiRepository(
                     val apiResponse = productsEndpoint.getDayUnitRates(
                         productCode = productCode,
                         tariffCode = tariffCode,
+                        periodFrom = period?.start,
+                        periodTo = period?.endInclusive,
                         page = page,
                     )
                     combinedList.addAll(apiResponse?.results?.map { it.toRate() } ?: emptyList())
@@ -195,6 +201,7 @@ class OctopusRestApiRepository(
      */
     override suspend fun getNightUnitRates(
         tariffCode: String,
+        period: ClosedRange<Instant>?,
         requestedPage: Int?,
     ): Result<List<Rate>> {
         return withContext(dispatcher) {
@@ -208,6 +215,8 @@ class OctopusRestApiRepository(
                     val apiResponse = productsEndpoint.getNightUnitRates(
                         productCode = productCode,
                         tariffCode = tariffCode,
+                        periodFrom = period?.start,
+                        periodTo = period?.endInclusive,
                         page = page,
                     )
                     combinedList.addAll(apiResponse?.results?.map { it.toRate() } ?: emptyList())

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/OctopusRestApiRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/OctopusRestApiRepository.kt
@@ -13,6 +13,7 @@ import com.rwmobi.kunigami.data.repository.mapper.toProductDetails
 import com.rwmobi.kunigami.data.repository.mapper.toProductSummary
 import com.rwmobi.kunigami.data.repository.mapper.toRate
 import com.rwmobi.kunigami.data.repository.mapper.toTariff
+import com.rwmobi.kunigami.data.source.local.database.interfaces.DatabaseDataSource
 import com.rwmobi.kunigami.data.source.network.AccountEndpoint
 import com.rwmobi.kunigami.data.source.network.ElectricityMeterPointsEndpoint
 import com.rwmobi.kunigami.data.source.network.ProductsEndpoint
@@ -38,6 +39,7 @@ class OctopusRestApiRepository(
     private val productsEndpoint: ProductsEndpoint,
     private val electricityMeterPointsEndpoint: ElectricityMeterPointsEndpoint,
     private val accountEndpoint: AccountEndpoint,
+    private val databaseDataSource: DatabaseDataSource,
     private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : RestApiRepository {
     override suspend fun getTariff(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/ConsumptionMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/ConsumptionMapper.kt
@@ -7,11 +7,24 @@
 
 package com.rwmobi.kunigami.data.repository.mapper
 
+import com.rwmobi.kunigami.data.source.local.database.entity.ConsumptionEntity
 import com.rwmobi.kunigami.data.source.network.dto.consumption.ConsumptionDto
 import com.rwmobi.kunigami.domain.extensions.roundToNearestEvenHundredth
 import com.rwmobi.kunigami.domain.model.consumption.Consumption
 
 fun ConsumptionDto.toConsumption() = Consumption(
     kWhConsumed = consumption.roundToNearestEvenHundredth(),
+    interval = intervalStart..intervalEnd,
+)
+
+fun ConsumptionDto.toConsumptionEntity(meterSerial: String) = ConsumptionEntity(
+    meterSerial = meterSerial,
+    intervalStart = intervalStart,
+    intervalEnd = intervalEnd,
+    kWhConsumed = consumption, // keep raw figures - caller do rounding
+)
+
+fun ConsumptionEntity.toConsumption() = Consumption(
+    kWhConsumed = kWhConsumed.roundToNearestEvenHundredth(),
     interval = intervalStart..intervalEnd,
 )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/dao/ConsumptionDao.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/dao/ConsumptionDao.kt
@@ -22,7 +22,7 @@ interface ConsumptionDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(consumptionEntity: List<ConsumptionEntity>)
 
-    @Query("SELECT * FROM consumption WHERE meter_serial = :meterSerial AND interval_start >= :intervalStart AND interval_end<= :intervalEnd ORDER BY interval_start ASC")
+    @Query("SELECT * FROM consumption WHERE meter_serial = :meterSerial AND interval_start >= :intervalStart AND interval_start < :intervalEnd ORDER BY interval_start ASC")
     suspend fun getConsumptions(meterSerial: String, intervalStart: Instant, intervalEnd: Instant): List<ConsumptionEntity>
 
     @Query("DELETE FROM consumption")

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/DataSourceModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/DataSourceModule.kt
@@ -38,7 +38,6 @@ val dataSourceModule = module {
             .fallbackToDestructiveMigrationOnDowngrade(dropAllTables = true)
             .fallbackToDestructiveMigration(dropAllTables = true)
             .setDriver(BundledSQLiteDriver())
-            .setQueryCoroutineContext(get(named("IoDispatcher")))
             .build()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/RepositoryModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/RepositoryModule.kt
@@ -21,6 +21,7 @@ val repositoryModule = module {
             productsEndpoint = get(),
             electricityMeterPointsEndpoint = get(),
             accountEndpoint = get(),
+            databaseDataSource = get(),
             dispatcher = get(named("DefaultDispatcher")),
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.kt
@@ -23,6 +23,7 @@ import kotlinx.datetime.minus
 import kotlinx.datetime.plus
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
+import kotlin.math.ceil
 
 // Time-zone aware conversion utils
 
@@ -207,6 +208,25 @@ fun Instant.getLocalMonthYearString(): String {
         year()
     }
     return localDate.format(customFormat)
+}
+
+fun ClosedRange<Instant>.getHalfHourlyTimeSlotCount(): Int {
+    // adjust the start time to 00/30 minutes
+    val adjustedStartTime = adjustToNext00Or30(start.epochSeconds)
+
+    if (endInclusive.epochSeconds <= adjustedStartTime) return 0
+
+    val durationInSeconds = endInclusive.epochSeconds - adjustedStartTime
+    return ceil(durationInSeconds / 1800.0).toInt() + 1
+}
+
+private fun adjustToNext00Or30(epochSeconds: Long): Long {
+    val minutes = (epochSeconds / 60) % 60
+    val adjustment = when {
+        minutes < 30 -> 30 - minutes
+        else -> 60 - minutes
+    }
+    return epochSeconds + adjustment * 60
 }
 
 expect fun Instant.getLocalDateString(): String

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/repository/RestApiRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/repository/RestApiRepository.kt
@@ -30,16 +30,19 @@ interface RestApiRepository {
 
     suspend fun getStandingCharges(
         tariffCode: String,
+        period: ClosedRange<Instant>? = null,
         requestedPage: Int? = null,
     ): Result<List<Rate>>
 
     suspend fun getDayUnitRates(
         tariffCode: String,
+        period: ClosedRange<Instant>?,
         requestedPage: Int? = null,
     ): Result<List<Rate>>
 
     suspend fun getNightUnitRates(
         tariffCode: String,
+        period: ClosedRange<Instant>?,
         requestedPage: Int? = null,
     ): Result<List<Rate>>
 

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/repository/DemoRestApiRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/repository/DemoRestApiRepositoryTest.kt
@@ -74,9 +74,11 @@ class DemoRestApiRepositoryTest {
 
     @Test
     fun `getDayUnitRates should throw NotImplementedError`() = runTest {
+        val now = Clock.System.now()
         assertFailsWith<NotImplementedError> {
             demoRepository.getDayUnitRates(
                 tariffCode = sampleTariffCode,
+                period = now..now,
                 requestedPage = 1,
             )
         }
@@ -84,9 +86,11 @@ class DemoRestApiRepositoryTest {
 
     @Test
     fun `getNightUnitRates should throw NotImplementedError`() = runTest {
+        val now = Clock.System.now()
         assertFailsWith<NotImplementedError> {
             demoRepository.getNightUnitRates(
                 tariffCode = sampleTariffCode,
+                period = now..now,
                 requestedPage = 1,
             )
         }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/repository/OctopusRestApiRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/repository/OctopusRestApiRepositoryTest.kt
@@ -7,6 +7,7 @@
 
 package com.rwmobi.kunigami.data.repository
 
+import com.rwmobi.kunigami.data.source.local.database.FakeDataBaseDataSource
 import com.rwmobi.kunigami.data.source.network.AccountEndpoint
 import com.rwmobi.kunigami.data.source.network.ElectricityMeterPointsEndpoint
 import com.rwmobi.kunigami.data.source.network.ProductsEndpoint
@@ -124,6 +125,7 @@ class OctopusRestApiRepositoryTest {
                 httpClient = client,
                 dispatcher = UnconfinedTestDispatcher(),
             ),
+            databaseDataSource = FakeDataBaseDataSource(),
             dispatcher = UnconfinedTestDispatcher(),
         )
     }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/repository/OctopusRestApiRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/repository/OctopusRestApiRepositoryTest.kt
@@ -36,6 +36,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration
 
 /***
  * This can be an integration test.
@@ -424,7 +425,7 @@ class OctopusRestApiRepositoryTest {
             apiKey = fakeApiKey,
             mpan = fakeMpan,
             meterSerialNumber = fakeMeterSerialNumber,
-            period = now..now,
+            period = now..now.plus(Duration.parse("1d")),
             orderBy = ConsumptionDataOrder.PERIOD,
             groupBy = ConsumptionTimeFrame.HALF_HOURLY,
         )

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/database/FakeDataBaseDataSource.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/database/FakeDataBaseDataSource.kt
@@ -12,19 +12,23 @@ import com.rwmobi.kunigami.data.source.local.database.interfaces.DatabaseDataSou
 import kotlinx.datetime.Instant
 
 class FakeDataBaseDataSource : DatabaseDataSource {
+
+    var exception: Throwable? = null
     override suspend fun insert(consumptionEntity: ConsumptionEntity) {
-        TODO("Not yet implemented")
+        exception?.let { throw it }
     }
 
     override suspend fun insert(consumptionEntity: List<ConsumptionEntity>) {
-        TODO("Not yet implemented")
+        exception?.let { throw it }
     }
 
+    var getConsumptionsResponse: List<ConsumptionEntity>? = null
     override suspend fun getConsumptions(meterSerial: String, interval: ClosedRange<Instant>): List<ConsumptionEntity> {
-        TODO("Not yet implemented")
+        exception?.let { throw it }
+        return getConsumptionsResponse ?: throw RuntimeException("Fake result getConsumptionsResponse not defined")
     }
 
     override suspend fun clear() {
-        TODO("Not yet implemented")
+        exception?.let { throw it }
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/database/FakeDataBaseDataSource.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/database/FakeDataBaseDataSource.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.kunigami.data.source.local.database
+
+import com.rwmobi.kunigami.data.source.local.database.entity.ConsumptionEntity
+import com.rwmobi.kunigami.data.source.local.database.interfaces.DatabaseDataSource
+import kotlinx.datetime.Instant
+
+class FakeDataBaseDataSource : DatabaseDataSource {
+    override suspend fun insert(consumptionEntity: ConsumptionEntity) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun insert(consumptionEntity: List<ConsumptionEntity>) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getConsumptions(meterSerial: String, interval: ClosedRange<Instant>): List<ConsumptionEntity> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun clear() {
+        TODO("Not yet implemented")
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/ElectricityMeterPointsEndpointTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/ElectricityMeterPointsEndpointTest.kt
@@ -74,7 +74,7 @@ class ElectricityMeterPointsEndpointTest {
             mpan = fakeMpan,
             meterSerialNumber = fakeMeterSerialNumber,
         )
-        assertEquals(GetConsumptionSampleData.dto, result)
+        assertEquals(expected = GetConsumptionSampleData.dto, actual = result)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/samples/GetConsumptionSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/samples/GetConsumptionSampleData.kt
@@ -9,12 +9,13 @@ package com.rwmobi.kunigami.data.source.network.samples
 
 import com.rwmobi.kunigami.data.source.network.dto.consumption.ConsumptionApiResponse
 import com.rwmobi.kunigami.data.source.network.dto.consumption.ConsumptionDto
+import com.rwmobi.kunigami.domain.model.consumption.Consumption
 import kotlinx.datetime.Instant
 
 object GetConsumptionSampleData {
     val json = """{
-  "count": 768,
-  "next": "https://api.octopus.energy/v1/electricity-meter-points/1100000111111/meters/11L1111111/consumption/?page=2",
+  "count": 5,
+  "next": null,
   "previous": null,
   "results": [
     {
@@ -47,8 +48,8 @@ object GetConsumptionSampleData {
     """.trimIndent()
 
     val dto = ConsumptionApiResponse(
-        count = 768,
-        next = "https://api.octopus.energy/v1/electricity-meter-points/1100000111111/meters/11L1111111/consumption/?page=2",
+        count = 5,
+        next = null,
         previous = null,
         results = listOf(
             ConsumptionDto(
@@ -76,6 +77,29 @@ object GetConsumptionSampleData {
                 intervalStart = Instant.parse("2024-05-06T21:30:00Z"),
                 intervalEnd = Instant.parse("2024-05-06T22:00:00Z"),
             ),
+        ),
+    )
+
+    val consumption = listOf(
+        Consumption(
+            kWhConsumed = 0.11,
+            interval = Instant.parse("2024-05-06T23:30:00Z")..Instant.parse("2024-05-07T00:00:00Z"),
+        ),
+        Consumption(
+            kWhConsumed = 0.58,
+            interval = Instant.parse("2024-05-06T23:00:00Z")..Instant.parse("2024-05-06T23:30:00Z"),
+        ),
+        Consumption(
+            kWhConsumed = 0.2,
+            interval = Instant.parse("2024-05-06T22:30:00Z")..Instant.parse("2024-05-06T23:00:00Z"),
+        ),
+        Consumption(
+            kWhConsumed = 0.45,
+            interval = Instant.parse("2024-05-06T22:00:00Z")..Instant.parse("2024-05-06T22:30:00Z"),
+        ),
+        Consumption(
+            kWhConsumed = 0.51,
+            interval = Instant.parse("2024-05-06T21:30:00Z")..Instant.parse("2024-05-06T22:00:00Z"),
         ),
     )
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensionsKtTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensionsKtTest.kt
@@ -7,6 +7,7 @@
 
 package com.rwmobi.kunigami.domain.extensions
 
+import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
@@ -220,5 +221,20 @@ class InstantExtensionsKtTest {
         val actualEndOfDay = expectedEndOfDay.atEndOfDay()
 
         assertEquals(expectedEndOfDay, actualEndOfDay)
+    }
+
+    @Test
+    fun `getHalfHourlyTimeSlotCount should return correct slot count`() {
+        val oneHourRange = Instant.parse("2023-05-01T10:30:00Z")..Instant.parse("2023-05-01T11:30:00Z")
+        val oneHourRangeSlots = oneHourRange.getHalfHourlyTimeSlotCount()
+        assertEquals(expected = 2, actual = oneHourRangeSlots)
+
+        val fiftyMinutesRange = Instant.parse("2023-05-01T10:30:00Z")..Instant.parse("2023-05-01T11:20:00Z")
+        val fiftyMinutesRangeSlots = fiftyMinutesRange.getHalfHourlyTimeSlotCount()
+        assertEquals(expected = 2, actual = fiftyMinutesRangeSlots)
+
+        val oneDayRange = Instant.parse("2023-05-02T00:00:00Z")..Instant.parse("2023-05-02T23:59:59Z")
+        val oneDayRangeSlots = oneDayRange.getHalfHourlyTimeSlotCount()
+        assertEquals(expected = 48, actual = oneDayRangeSlots)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/repository/FakeRestApiRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/repository/FakeRestApiRepository.kt
@@ -48,6 +48,7 @@ class FakeRestApiRepository : RestApiRepository {
     var setStandingChargesResponse: Result<List<Rate>>? = null
     override suspend fun getStandingCharges(
         tariffCode: String,
+        period: ClosedRange<Instant>?,
         requestedPage: Int?,
     ): Result<List<Rate>> {
         return setStandingChargesResponse ?: throw RuntimeException("Fake result setStandingChargesResponse not defined")
@@ -56,6 +57,7 @@ class FakeRestApiRepository : RestApiRepository {
     var setDayUnitRatesResponse: Result<List<Rate>>? = null
     override suspend fun getDayUnitRates(
         tariffCode: String,
+        period: ClosedRange<Instant>?,
         requestedPage: Int?,
     ): Result<List<Rate>> {
         return setDayUnitRatesResponse ?: throw RuntimeException("Fake result setDayUnitRatesResponse not defined")
@@ -64,6 +66,7 @@ class FakeRestApiRepository : RestApiRepository {
     var setNightUnitRatesResponse: Result<List<Rate>>? = null
     override suspend fun getNightUnitRates(
         tariffCode: String,
+        period: ClosedRange<Instant>?,
         requestedPage: Int?,
     ): Result<List<Rate>> {
         return setNightUnitRatesResponse ?: throw RuntimeException("Fake result setNightUnitRatesResponse not defined")

--- a/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/di/PlatformModule.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/di/PlatformModule.ios.kt
@@ -16,15 +16,27 @@ import com.rwmobi.kunigami.data.source.local.preferences.provideSettings
 import composeapp.kunigami.BuildConfig
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.darwin.Darwin
+import kotlinx.cinterop.ExperimentalForeignApi
 import org.koin.dsl.module
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
 import platform.Foundation.NSHomeDirectory
+import platform.Foundation.NSUserDomainMask
 
+@OptIn(ExperimentalForeignApi::class)
 val platformModule = module {
     single<HttpClientEngine> { Darwin.create() }
     single<Settings> { provideSettings(serviceName = BuildConfig.PACKAGE_NAME) }
 
     single<RoomDatabase.Builder<OctometerDatabase>> {
-        val dbFilePath = NSHomeDirectory() + "/octometer_database.db"
+        val documentsDirectory = NSFileManager.defaultManager.URLForDirectory(
+            directory = NSDocumentDirectory,
+            inDomain = NSUserDomainMask,
+            appropriateForURL = null,
+            create = true,
+            error = null,
+        )?.path ?: NSHomeDirectory()
+        val dbFilePath = "$documentsDirectory/octometer_database.db"
         Room.databaseBuilder<OctometerDatabase>(
             name = dbFilePath,
             factory = { OctometerDatabase::class.instantiateImpl() },


### PR DESCRIPTION
Adding on top of the current repository method to detect cached half-hourly consumption data, and return directly the required data from RoomDB without calling remote APIs. 

Store the remote API data to RoomDB if it is half-hourly.

For views other than half-hourly, the cache will be bypassed.

This ticket contains actual working code to make Room DB really work on all platforms (debug mode).

Additional proguard rules needed for building desktop releases. This will be done in a separate ticket.

