### PR TITLE
UsageScreen: Add button to jump back to latest readings

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,10 @@ Every tiny piece matters. This App contains the icons contributed by:
 * [Material Design Icons](https://github.com/material-icons/material-icons)
 
 **CC BY 4.0 License:**
-* [Solar Icons Set](https://www.figma.com/community/file/1166831539721848736)
-* [Font Awesome](https://github.com/FortAwesome/Font-Awesome)
 * [Basil Icons](https://www.figma.com/community/file/931906394678748246/basil-icons)
+* [Font Awesome](https://github.com/FortAwesome/Font-Awesome)
+* [Solar Icons Set](https://www.figma.com/community/file/1166831539721848736)
+* [Streamline](http://streamlinehq.com)
 
 **ISC License:**
 * [Lucide](https://github.com/lucide-icons/lucide)

--- a/composeApp/src/commonMain/composeResources/drawable/countdown_clock.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/countdown_clock.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Streamline
+  - http://streamlinehq.com/
+  ~ License: CC BY 4.0
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="14"
+    android:viewportHeight="14">
+
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M7,13.5A6.5,6.5 0,1 1,13.5 7a7.23,7.23 0,0 1,-2 5"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+
+    <path
+        android:fillColor="#00000000"
+        android:pathData="m13.5,11.5l-2,0.5l-0.5,-2M9,9L7,6.5H4"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+
+</vector>

--- a/composeApp/src/commonMain/composeResources/drawable/countdown_clock.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/countdown_clock.xml
@@ -13,7 +13,7 @@
         android:fillColor="#00000000"
         android:pathData="M7,13.5A6.5,6.5 0,1 1,13.5 7a7.23,7.23 0,0 1,-2 5"
         android:strokeWidth="1"
-        android:strokeColor="#00000000"
+        android:strokeColor="#000000"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
 
@@ -21,7 +21,7 @@
         android:fillColor="#00000000"
         android:pathData="m13.5,11.5l-2,0.5l-0.5,-2M9,9L7,6.5H4"
         android:strokeWidth="1"
-        android:strokeColor="#00000000"
+        android:strokeColor="#000000"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
 

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -61,6 +61,7 @@
     <string name="usage_standing_charge">Standing Charge</string>
     <string name="usage_kwh_year">kWh / year</string>
     <string name="usage_kwh_month">( %1$s kWh / month )</string>
+    <string name="usage_latest">Latest</string>
 
     <!-- Agile -->
     <string name="agile_demo_introduction">Demo Mode: The Agile Tariff shown for Retail Region A may not be available to you.</string>

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/IconTextButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/IconTextButton.kt
@@ -19,6 +19,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -26,6 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
@@ -39,6 +42,10 @@ fun IconTextButton(
     modifier: Modifier = Modifier,
     icon: Painter,
     text: String,
+    colors: ButtonColors = ButtonDefaults.buttonColors().copy(
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+    ),
+    shape: Shape = ButtonDefaults.shape,
     onClick: () -> Unit,
 ) {
     val currentDensity = LocalDensity.current
@@ -49,6 +56,8 @@ fun IconTextButton(
 
         Button(
             modifier = modifier,
+            shape = shape,
+            colors = colors,
             onClick = onClick,
         ) {
             Row(
@@ -63,7 +72,7 @@ fun IconTextButton(
                         .fillMaxHeight()
                         .aspectRatio(ratio = 1f),
                     painter = icon,
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    tint = colors.contentColor,
                     contentDescription = null,
                 )
 
@@ -72,7 +81,7 @@ fun IconTextButton(
                 Text(
                     modifier = Modifier.wrapContentHeight(),
                     style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    color = colors.contentColor,
                     text = text,
                 )
             }
@@ -87,6 +96,20 @@ private fun Preview() {
         IconTextButton(
             icon = painterResource(resource = Res.drawable.coin),
             text = "Money Generator",
+            colors = ButtonDefaults.buttonColors().copy(
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            ),
+            onClick = {},
+        )
+
+        IconTextButton(
+            icon = painterResource(resource = Res.drawable.coin),
+            text = "Money Generator",
+            shape = MaterialTheme.shapes.large,
+            colors = ButtonDefaults.buttonColors().copy(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            ),
             onClick = {},
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -278,7 +278,7 @@ fun AgileScreen(
                 }
             }
 
-            uiState.isLoading -> {
+            uiState.isLoading && uiState.barChartData == null -> {
                 LoadingScreen(
                     modifier = Modifier.fillMaxSize(),
                 )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
@@ -45,6 +45,7 @@ import com.rwmobi.kunigami.ui.model.chart.RequestedChartLayout
 import com.rwmobi.kunigami.ui.model.consumption.ConsumptionGroupWithPartitions
 import com.rwmobi.kunigami.ui.model.consumption.ConsumptionQueryFilter
 import com.rwmobi.kunigami.ui.theme.getDimension
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.bolt
@@ -128,6 +129,19 @@ fun UsageScreen(
                         NavigationOptionsBar(
                             modifier = Modifier.fillMaxWidth(),
                             selectedMpan = uiState.userProfile?.selectedMpan,
+                            onNavigateToLatest = {
+                                uiEvent.onSwitchPresentationStyle(
+                                    ConsumptionQueryFilter(
+                                        presentationStyle = uiState.consumptionQueryFilter.presentationStyle,
+                                        referencePoint = Clock.System.now(),
+                                        requestedPeriod = ConsumptionQueryFilter.calculateQueryPeriod(
+                                            referencePoint = Clock.System.now(),
+                                            presentationStyle = uiState.consumptionQueryFilter.presentationStyle,
+                                        ),
+                                    ),
+                                    uiState.consumptionQueryFilter.presentationStyle,
+                                )
+                            },
                         )
                     }
 

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/NavigationOptionsBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/NavigationOptionsBar.kt
@@ -29,7 +29,6 @@ import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.components.IconTextButton
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
-import kunigami.composeapp.generated.resources.account_mpan
 import kunigami.composeapp.generated.resources.countdown_clock
 import kunigami.composeapp.generated.resources.dashboard
 import kunigami.composeapp.generated.resources.usage_latest
@@ -62,7 +61,7 @@ internal fun NavigationOptionsBar(
                 )
                 Text(
                     style = MaterialTheme.typography.bodyMedium,
-                    text = stringResource(resource = Res.string.account_mpan, mpan),
+                    text = mpan,
                 )
             }
 

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/NavigationOptionsBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/NavigationOptionsBar.kt
@@ -11,10 +11,12 @@ import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -24,10 +26,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.components.IconTextButton
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.account_mpan
+import kunigami.composeapp.generated.resources.countdown_clock
 import kunigami.composeapp.generated.resources.dashboard
+import kunigami.composeapp.generated.resources.usage_latest
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -35,6 +40,7 @@ import org.jetbrains.compose.resources.stringResource
 internal fun NavigationOptionsBar(
     modifier: Modifier = Modifier,
     selectedMpan: String?,
+    onNavigateToLatest: () -> Unit,
 ) {
     val dimension = LocalDensity.current.getDimension()
     Column(modifier = modifier) {
@@ -59,6 +65,19 @@ internal fun NavigationOptionsBar(
                     text = stringResource(resource = Res.string.account_mpan, mpan),
                 )
             }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            IconTextButton(
+                icon = painterResource(resource = Res.drawable.countdown_clock),
+                text = stringResource(resource = Res.string.usage_latest),
+                shape = MaterialTheme.shapes.large,
+                colors = ButtonDefaults.buttonColors().copy(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                ),
+                onClick = onNavigateToLatest,
+            )
         }
 
         HorizontalDivider(
@@ -75,6 +94,7 @@ private fun Preview() {
         NavigationOptionsBar(
             modifier = Modifier.fillMaxWidth(),
             selectedMpan = "1200000123456",
+            onNavigateToLatest = {},
         )
     }
 }


### PR DESCRIPTION
Added a new button on the navigationOptionsBar, so we can jump back instantly to the latest readings under the current selected presentation style.

also added an experimental feature by hiding loading screen on AgileScreen when we already have something to show, so that the transition animations are not wasted.