### PR TITLE
(#240) Create local cache data source

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/cache/InMemoryCacheDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/cache/InMemoryCacheDataSource.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.kunigami.data.source.local.cache
+
+import com.rwmobi.kunigami.domain.extensions.toSystemDefaultLocalDate
+import com.rwmobi.kunigami.domain.model.account.Account
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+class InMemoryCacheDataSource {
+    private var cachedProfile: Pair<Account, Instant>? = null
+
+    fun cacheProfile(account: Account, createdAt: Instant) {
+        cachedProfile = Pair(account, createdAt)
+    }
+
+    /***
+     * Return cached profile, if there is an instance kept on the same day
+     */
+    fun getProfile(accountNumber: String): Account? {
+        return cachedProfile?.first?.let { account ->
+            if (account.accountNumber == accountNumber &&
+                Clock.System.now().toSystemDefaultLocalDate() == cachedProfile?.second?.toSystemDefaultLocalDate()
+            ) {
+                account
+            } else {
+                cachedProfile = null // clear the cache
+                null
+            }
+        }
+    }
+
+    fun clear() {
+        cachedProfile = null
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/DataSourceModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/DataSourceModule.kt
@@ -9,6 +9,7 @@ package com.rwmobi.kunigami.di
 
 import androidx.room.RoomDatabase
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import com.rwmobi.kunigami.data.source.local.cache.InMemoryCacheDataSource
 import com.rwmobi.kunigami.data.source.local.database.OctometerDatabase
 import com.rwmobi.kunigami.data.source.local.database.RoomDatabaseDataSource
 import com.rwmobi.kunigami.data.source.local.database.interfaces.DatabaseDataSource
@@ -40,5 +41,9 @@ val dataSourceModule = module {
             .fallbackToDestructiveMigration(dropAllTables = true)
             .setDriver(BundledSQLiteDriver())
             .build()
+    }
+
+    single<InMemoryCacheDataSource> {
+        InMemoryCacheDataSource()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/RepositoryModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/RepositoryModule.kt
@@ -21,6 +21,7 @@ val repositoryModule = module {
             productsEndpoint = get(),
             electricityMeterPointsEndpoint = get(),
             accountEndpoint = get(),
+            inMemoryCacheDataSource = get(),
             databaseDataSource = get(),
             dispatcher = get(named("DefaultDispatcher")),
         )

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/repository/OctopusRestApiRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/repository/OctopusRestApiRepositoryTest.kt
@@ -7,6 +7,7 @@
 
 package com.rwmobi.kunigami.data.repository
 
+import com.rwmobi.kunigami.data.source.local.cache.InMemoryCacheDataSource
 import com.rwmobi.kunigami.data.source.local.database.FakeDataBaseDataSource
 import com.rwmobi.kunigami.data.source.local.database.entity.ConsumptionEntity
 import com.rwmobi.kunigami.data.source.network.AccountEndpoint
@@ -142,6 +143,7 @@ class OctopusRestApiRepositoryTest {
                 httpClient = client,
                 dispatcher = UnconfinedTestDispatcher(),
             ),
+            inMemoryCacheDataSource = InMemoryCacheDataSource(),
             databaseDataSource = fakeDataBaseDataSource,
             dispatcher = UnconfinedTestDispatcher(),
         )

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/cache/InMemoryCacheDataSourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/cache/InMemoryCacheDataSourceTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.kunigami.data.source.local.cache
+
+import com.rwmobi.kunigami.ui.previewsampledata.AccountSamples
+import kotlinx.datetime.Clock
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration
+
+class InMemoryCacheDataSourceTest {
+
+    private lateinit var cacheDataSource: InMemoryCacheDataSource
+
+    @BeforeTest
+    fun setup() {
+        cacheDataSource = InMemoryCacheDataSource()
+    }
+
+    @AfterTest
+    fun teardown() {
+        cacheDataSource.clear()
+    }
+
+    @Test
+    fun `cacheProfile should cache the profile`() {
+        val account = AccountSamples.account928
+        cacheDataSource.cacheProfile(account, Clock.System.now())
+
+        val cachedAccount = cacheDataSource.getProfile(accountNumber = AccountSamples.account928.accountNumber)
+        assertEquals(expected = account, actual = cachedAccount)
+    }
+
+    @Test
+    fun `getProfile should return null if account number does not match`() {
+        val account = AccountSamples.account928
+        cacheDataSource.cacheProfile(account, Clock.System.now())
+
+        val cachedAccount = cacheDataSource.getProfile("another-account-number")
+        assertNull(cachedAccount)
+    }
+
+    @Test
+    fun `getProfile should return null if cached date is not the same day`() {
+        val account = AccountSamples.account928
+        val yesterday = Clock.System.now() - Duration.parse("2d")
+        cacheDataSource.cacheProfile(account, yesterday)
+
+        val cachedAccount = cacheDataSource.getProfile(accountNumber = AccountSamples.account928.accountNumber)
+        assertNull(cachedAccount)
+    }
+
+    @Test
+    fun `clear should clear the cache`() {
+        val account = AccountSamples.account928
+        cacheDataSource.cacheProfile(account, Clock.System.now())
+
+        cacheDataSource.clear()
+        val cachedAccount = cacheDataSource.getProfile(accountNumber = AccountSamples.account928.accountNumber)
+        assertNull(cachedAccount)
+    }
+}


### PR DESCRIPTION
ChatGPT believes we violates the Clean Architecture if we keep in-memory cache variables in repository rather than data source, therefore this is a quick refactoring to move the variable to the data source.