### PR TITLE
(#198) AgileScreen: Show latest fixed and flexible tariffs for comparison

### DIFF
--- a/composeApp/composeApp.podspec
+++ b/composeApp/composeApp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'composeApp'
-    spec.version                  = '1.2.0'
+    spec.version                  = '1.3.0'
     spec.homepage                 = 'https://github.com/ryanw-mobile/OctoMeter/'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/UseCaseModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/UseCaseModule.kt
@@ -10,7 +10,7 @@ package com.rwmobi.kunigami.di
 import com.rwmobi.kunigami.domain.usecase.ClearCacheUseCase
 import com.rwmobi.kunigami.domain.usecase.GetConsumptionAndCostUseCase
 import com.rwmobi.kunigami.domain.usecase.GetFilteredProductsUseCase
-import com.rwmobi.kunigami.domain.usecase.GetLatestAgileProductUseCase
+import com.rwmobi.kunigami.domain.usecase.GetLatestProductByKeywordUseCase
 import com.rwmobi.kunigami.domain.usecase.GetStandardUnitRateUseCase
 import com.rwmobi.kunigami.domain.usecase.GetTariffRatesUseCase
 import com.rwmobi.kunigami.domain.usecase.GetTariffUseCase
@@ -82,7 +82,7 @@ val userCaseModule = module {
     }
 
     factory {
-        GetLatestAgileProductUseCase(
+        GetLatestProductByKeywordUseCase(
             restApiRepository = get(),
             dispatcher = get(named("DefaultDispatcher")),
         )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/ViewModelModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/ViewModelModule.kt
@@ -28,7 +28,7 @@ val viewModelModule = module {
 
     factory {
         AgileViewModel(
-            getLatestAgileProductUseCase = get(),
+            getLatestProductByKeywordUseCase = get(),
             getTariffUseCase = get(),
             syncUserProfileUseCase = get(),
             getTariffRatesUseCase = get(),

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/Tariff.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/Tariff.kt
@@ -64,6 +64,8 @@ data class Tariff(
         fun isSingleRate(tariffCode: String): Boolean {
             return tariffCode.toCharArray().getOrNull(2)?.equals('1') == true
         }
+
+        fun isAgileProduct(tariffCode: String) = extractProductCode(tariffCode = tariffCode)?.contains("AGILE") == true
     }
 
     fun extractProductCode(): String? = extractProductCode(tariffCode = tariffCode)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/GetLatestProductByKeywordUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/GetLatestProductByKeywordUseCase.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-class GetLatestAgileProductUseCase(
+class GetLatestProductByKeywordUseCase(
     private val restApiRepository: RestApiRepository,
     private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
@@ -30,7 +30,7 @@ class GetLatestAgileProductUseCase(
                     productCode
                 },
                 onFailure = {
-                    Logger.e("GetLatestAgileProductUseCase", throwable = it)
+                    Logger.e("GetLatestProductByKeywordUseCase", throwable = it)
                     null
                 },
             )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/GetLatestProductByKeywordUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/GetLatestProductByKeywordUseCase.kt
@@ -17,7 +17,7 @@ class GetLatestProductByKeywordUseCase(
     private val restApiRepository: RestApiRepository,
     private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
-    suspend operator fun invoke(): String? {
+    suspend operator fun invoke(keyword: String): String? {
         return withContext(dispatcher) {
             val getProductsResult = restApiRepository.getProducts()
             getProductsResult.fold(
@@ -25,7 +25,7 @@ class GetLatestProductByKeywordUseCase(
                     val productCode = products.sortedByDescending {
                         it.availability.start
                     }.firstOrNull {
-                        it.code.contains("AGILE")
+                        it.code.contains(keyword)
                     }?.code
                     productCode
                 },

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/GetLatestProductByKeywordUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/GetLatestProductByKeywordUseCase.kt
@@ -25,7 +25,8 @@ class GetLatestProductByKeywordUseCase(
                     val productCode = products.sortedByDescending {
                         it.availability.start
                     }.firstOrNull {
-                        it.code.contains(keyword)
+                        it.code.contains(keyword) &&
+                            it.brand == "OCTOPUS_ENERGY"
                     }?.code
                     productCode
                 },

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -176,7 +176,8 @@ fun AgileScreen(
                                             end = dimension.grid_3,
                                             top = dimension.grid_1,
                                         ),
-                                    secondaryTariff = uiState.latestFixedTariff,
+                                    latestFixedTariff = uiState.latestFixedTariff,
+                                    latestFlexibleTariff = uiState.latestFlexibleTariff,
                                     rateRange = uiState.rateRange,
                                     rateGroupedCells = uiState.rateGroupedCells,
                                     requestedAdaptiveLayout = uiState.requestedAdaptiveLayout,
@@ -302,7 +303,7 @@ private fun LazyListScope.renderChart(
                     barChartData.tooltips[index]
                 },
                 backgroundPlot = { graphScope ->
-                    uiState.latestFixedTariff?.resolveUnitRate()?.let { fixedUnitRate ->
+                    uiState.latestFixedTariff?.vatInclusiveStandardUnitRate?.let { fixedUnitRate ->
                         graphScope.HorizontalLineAnnotation(
                             location = fixedUnitRate,
                             lineStyle = LineStyle(
@@ -316,7 +317,7 @@ private fun LazyListScope.renderChart(
                         )
                     }
 
-                    uiState.latestFlexibleTariff?.resolveUnitRate()?.let { flexibleUnitRate ->
+                    uiState.latestFlexibleTariff?.vatInclusiveStandardUnitRate?.let { flexibleUnitRate ->
                         graphScope.HorizontalLineAnnotation(
                             location = flexibleUnitRate,
                             lineStyle = LineStyle(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -47,7 +47,9 @@ import com.rwmobi.kunigami.ui.model.SpecialErrorScreen
 import com.rwmobi.kunigami.ui.model.chart.BarChartData
 import com.rwmobi.kunigami.ui.model.chart.RequestedChartLayout
 import com.rwmobi.kunigami.ui.model.rate.RateGroupWithPartitions
+import com.rwmobi.kunigami.ui.theme.cyanish
 import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.purpleish
 import io.github.koalaplot.core.style.LineStyle
 import io.github.koalaplot.core.xygraph.HorizontalLineAnnotation
 import kotlinx.coroutines.delay
@@ -304,10 +306,10 @@ private fun LazyListScope.renderChart(
                         graphScope.HorizontalLineAnnotation(
                             location = fixedUnitRate,
                             lineStyle = LineStyle(
-                                brush = SolidColor(MaterialTheme.colorScheme.error),
-                                strokeWidth = dimension.grid_0_5,
-                                pathEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 4f), 0f),
-                                alpha = 0.5f,
+                                brush = SolidColor(purpleish),
+                                strokeWidth = dimension.grid_0_25,
+                                pathEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 16f), 0f),
+                                alpha = 0.8f,
                                 colorFilter = null, // No color filter
                                 blendMode = DrawScope.DefaultBlendMode,
                             ),
@@ -318,10 +320,10 @@ private fun LazyListScope.renderChart(
                         graphScope.HorizontalLineAnnotation(
                             location = flexibleUnitRate,
                             lineStyle = LineStyle(
-                                brush = SolidColor(MaterialTheme.colorScheme.error),
-                                strokeWidth = dimension.grid_0_5,
-                                pathEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 4f), 0f),
-                                alpha = 0.5f,
+                                brush = SolidColor(cyanish),
+                                strokeWidth = dimension.grid_0_25,
+                                pathEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 16f), 0f),
+                                alpha = 0.8f,
                                 colorFilter = null, // No color filter
                                 blendMode = DrawScope.DefaultBlendMode,
                             ),

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileUIState.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileUIState.kt
@@ -39,8 +39,9 @@ data class AgileUIState(
     val requestedRateColumns: Int = 1,
     val requestedAdaptiveLayout: WindowWidthSizeClass = WindowWidthSizeClass.Compact,
     val userProfile: UserProfile? = null,
-    val activeTariff: Tariff? = null,
     val agileTariff: Tariff? = null,
+    val latestFixedTariff: Tariff? = null,
+    val latestFlexibleTariff: Tariff? = null,
     val rateGroupedCells: List<RateGroup> = emptyList(),
     val rateRange: ClosedFloatingPointRange<Double> = 0.0..0.0,
     val barChartData: BarChartData? = null,
@@ -67,12 +68,6 @@ data class AgileUIState(
             requestedAdaptiveLayout = windowSizeClass.widthSizeClass,
         )
     }
-
-    fun isOnDifferentTariff() = (
-        false == isDemoMode &&
-            activeTariff != null &&
-            activeTariff.tariffCode != agileTariff?.tariffCode
-        )
 
     suspend fun filterErrorAndStopLoading(throwable: Throwable): AgileUIState {
         return when (val translatedThrowable = throwable.mapFromPlatform()) {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/LatestTariffsCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/LatestTariffsCard.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.kunigami.ui.destinations.agile.components
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
+import com.rwmobi.kunigami.domain.model.product.Tariff
+import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.components.WidgetCard
+import com.rwmobi.kunigami.ui.previewsampledata.TariffSamples
+import com.rwmobi.kunigami.ui.theme.cyanish
+import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.purpleish
+import kunigami.composeapp.generated.resources.Res
+import kunigami.composeapp.generated.resources.agile_tariff_standard_unit_rate
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun LatestTariffsCard(
+    modifier: Modifier = Modifier,
+    latestFixedTariff: Tariff?,
+    latestFlexibleTariff: Tariff?,
+    latestFixedTariffColor: Color,
+    latestFlexibleTariffColor: Color,
+) {
+    WidgetCard(
+        modifier = modifier,
+        contents = {
+            latestFlexibleTariff?.let { tariff ->
+                tariff.vatInclusiveStandardUnitRate?.let { unitRate ->
+                    TariffEntry(
+                        tariff = tariff,
+                        unitRate = unitRate,
+                        indicatorColor = latestFlexibleTariffColor,
+                    )
+                }
+            }
+
+            latestFixedTariff?.let { tariff ->
+                tariff.vatInclusiveStandardUnitRate?.let { unitRate ->
+                    TariffEntry(
+                        tariff = tariff,
+                        unitRate = unitRate,
+                        indicatorColor = latestFixedTariffColor,
+                    )
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun TariffEntry(
+    tariff: Tariff,
+    unitRate: Double,
+    indicatorColor: Color,
+) {
+    val dimension = LocalDensity.current.getDimension()
+    Column(
+        modifier = Modifier.fillMaxWidth()
+            .drawBehind {
+                val width = dimension.grid_2.toPx()
+                drawRect(
+                    color = indicatorColor,
+                    size = Size(width, size.height),
+                )
+            }
+            .padding(
+                vertical = dimension.grid_0_25,
+                horizontal = dimension.grid_4,
+            ),
+    ) {
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.Bold,
+            text = tariff.displayName,
+        )
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            style = MaterialTheme.typography.bodySmall,
+            text = stringResource(
+                resource = Res.string.agile_tariff_standard_unit_rate,
+                unitRate.roundToTwoDecimalPlaces().toString(),
+            ),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun Preview() {
+    CommonPreviewSetup {
+        LatestTariffsCard(
+            modifier = Modifier.wrapContentSize(),
+            latestFlexibleTariff = TariffSamples.agileFlex221125,
+            latestFixedTariff = TariffSamples.fix12M240411,
+            latestFlexibleTariffColor = cyanish,
+            latestFixedTariffColor = purpleish,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/Color.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/Color.kt
@@ -73,3 +73,6 @@ val surfaceContainerLowDarkMediumContrast = Color(0xFF292A2A)
 val surfaceContainerDarkMediumContrast = Color(0xFF313233)
 val surfaceContainerHighDarkMediumContrast = Color(0xFF383939)
 val surfaceContainerHighestDarkMediumContrast = Color(0xFF3F4040)
+
+val cyanish = Color(0xFF00ACC1) // Cyan-ish
+val purpleish = Color(0xFF8E24AA) // Purple-ish

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/Color.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/Color.kt
@@ -75,4 +75,4 @@ val surfaceContainerHighDarkMediumContrast = Color(0xFF383939)
 val surfaceContainerHighestDarkMediumContrast = Color(0xFF3F4040)
 
 val cyanish = Color(0xFF00ACC1) // Cyan-ish
-val purpleish = Color(0xFF8E24AA) // Purple-ish
+val purpleish = Color(0xFFAB47BC) // Purple-ish

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
@@ -265,7 +265,7 @@ class AgileViewModel(
     }
 
     private suspend fun getLatestAgileProductCode(): String {
-        return getLatestProductByKeywordUseCase() ?: fallBackAgileProductCode
+        return getLatestProductByKeywordUseCase(keyword = "AGILE") ?: fallBackAgileProductCode
     }
 
     override fun onCleared() {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
@@ -16,8 +16,9 @@ import com.rwmobi.kunigami.domain.extensions.atStartOfHour
 import com.rwmobi.kunigami.domain.extensions.getLocalDateString
 import com.rwmobi.kunigami.domain.extensions.getLocalHHMMString
 import com.rwmobi.kunigami.domain.model.account.UserProfile
+import com.rwmobi.kunigami.domain.model.product.Tariff
 import com.rwmobi.kunigami.domain.model.rate.Rate
-import com.rwmobi.kunigami.domain.usecase.GetLatestAgileProductUseCase
+import com.rwmobi.kunigami.domain.usecase.GetLatestProductByKeywordUseCase
 import com.rwmobi.kunigami.domain.usecase.GetStandardUnitRateUseCase
 import com.rwmobi.kunigami.domain.usecase.GetTariffRatesUseCase
 import com.rwmobi.kunigami.domain.usecase.GetTariffUseCase
@@ -264,7 +265,7 @@ class AgileViewModel(
     }
 
     private suspend fun getLatestAgileProductCode(): String {
-        return getLatestAgileProductUseCase() ?: fallBackAgileProductCode
+        return getLatestProductByKeywordUseCase() ?: fallBackAgileProductCode
     }
 
     override fun onCleared() {

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/product/TariffTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/product/TariffTest.kt
@@ -142,12 +142,18 @@ class TariffTest {
     fun `isAgileProduct should return true when product code contains AGILE`() {
         val tariff = TariffSampleData.agileFlex221125
         assertTrue(tariff.isAgileProduct())
+
+        val tariffCodeResult = Tariff.isAgileProduct(tariffCode = TariffSampleData.agileFlex221125.tariffCode)
+        assertTrue(tariffCodeResult)
     }
 
     @Test
     fun `isAgileProduct should return false when product code does not contain AGILE`() {
         val tariff = TariffSampleData.var221101
         assertFalse(tariff.isAgileProduct())
+
+        val tariffCodeResult = Tariff.isAgileProduct(tariffCode = TariffSampleData.var221101.tariffCode)
+        assertFalse(tariffCodeResult)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/GetLatestProductByKeywordUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/GetLatestProductByKeywordUseCaseTest.kt
@@ -14,22 +14,22 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class GetLatestAgileProductUseCaseTest {
+class GetLatestProductByKeywordUseCaseTest {
 
-    private lateinit var getLatestAgileProductUseCase: GetLatestAgileProductUseCase
+    private lateinit var getLatestProductByKeywordUseCase: GetLatestProductByKeywordUseCase
     private lateinit var fakeRestApiRepository: FakeRestApiRepository
 
     @BeforeTest
     fun setupUseCase() {
         fakeRestApiRepository = FakeRestApiRepository()
-        getLatestAgileProductUseCase = GetLatestAgileProductUseCase(
+        getLatestProductByKeywordUseCase = GetLatestProductByKeywordUseCase(
             restApiRepository = fakeRestApiRepository,
             dispatcher = UnconfinedTestDispatcher(),
         )
     }
 
     @Test
-    fun `GetLatestAgileProductUseCase should return tariff code successfully`() = runTest {
+    fun `GetLatestProductByKeywordUseCase should return tariff code successfully`() = runTest {
         val productSummaries = listOf(
             ProductSummary(
                 code = "GO-VAR-22-10-14",
@@ -68,7 +68,7 @@ class GetLatestAgileProductUseCaseTest {
 
         fakeRestApiRepository.setProductsResponse = Result.success(productSummaries)
 
-        val result = getLatestAgileProductUseCase()
+        val result = getLatestProductByKeywordUseCase()
 
         assertEquals(
             expected = "AGILE-24-04-03",
@@ -77,7 +77,7 @@ class GetLatestAgileProductUseCaseTest {
     }
 
     @Test
-    fun `GetLatestAgileProductUseCase should return latest tariff code if more than one Agile products exist`() = runTest {
+    fun `GetLatestProductByKeywordUseCase should return latest tariff code if more than one Agile products exist`() = runTest {
         val productSummaries = listOf(
             ProductSummary(
                 code = "AGILE-FLEX-22-11-25",
@@ -105,7 +105,7 @@ class GetLatestAgileProductUseCaseTest {
 
         fakeRestApiRepository.setProductsResponse = Result.success(productSummaries)
 
-        val result = getLatestAgileProductUseCase()
+        val result = getLatestProductByKeywordUseCase()
 
         assertEquals(
             expected = "AGILE-24-04-03",
@@ -114,17 +114,17 @@ class GetLatestAgileProductUseCaseTest {
     }
 
     @Test
-    fun `GetLatestAgileProductUseCase should return null when repository call fails`() = runTest {
+    fun `GetLatestProductByKeywordUseCase should return null when repository call fails`() = runTest {
         val errorMessage = "API Error"
         fakeRestApiRepository.setProductsResponse = Result.failure(RuntimeException(errorMessage))
 
-        val result = getLatestAgileProductUseCase()
+        val result = getLatestProductByKeywordUseCase()
 
         assertNull(result)
     }
 
     @Test
-    fun `GetLatestAgileProductUseCase should return null when no products match criteria`() = runTest {
+    fun `GetLatestProductByKeywordUseCase should return null when no products match criteria`() = runTest {
         val productSummaries = listOf(
             ProductSummary(
                 code = "1",
@@ -140,7 +140,7 @@ class GetLatestAgileProductUseCaseTest {
         )
         fakeRestApiRepository.setProductsResponse = Result.success(productSummaries)
 
-        val result = getLatestAgileProductUseCase()
+        val result = getLatestProductByKeywordUseCase()
 
         assertNull(result)
     }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/GetLatestProductByKeywordUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/GetLatestProductByKeywordUseCaseTest.kt
@@ -18,6 +18,7 @@ class GetLatestProductByKeywordUseCaseTest {
 
     private lateinit var getLatestProductByKeywordUseCase: GetLatestProductByKeywordUseCase
     private lateinit var fakeRestApiRepository: FakeRestApiRepository
+    private val keyword = "AGILE"
 
     @BeforeTest
     fun setupUseCase() {
@@ -68,7 +69,7 @@ class GetLatestProductByKeywordUseCaseTest {
 
         fakeRestApiRepository.setProductsResponse = Result.success(productSummaries)
 
-        val result = getLatestProductByKeywordUseCase()
+        val result = getLatestProductByKeywordUseCase(keyword = keyword)
 
         assertEquals(
             expected = "AGILE-24-04-03",
@@ -105,7 +106,7 @@ class GetLatestProductByKeywordUseCaseTest {
 
         fakeRestApiRepository.setProductsResponse = Result.success(productSummaries)
 
-        val result = getLatestProductByKeywordUseCase()
+        val result = getLatestProductByKeywordUseCase(keyword = keyword)
 
         assertEquals(
             expected = "AGILE-24-04-03",
@@ -118,7 +119,7 @@ class GetLatestProductByKeywordUseCaseTest {
         val errorMessage = "API Error"
         fakeRestApiRepository.setProductsResponse = Result.failure(RuntimeException(errorMessage))
 
-        val result = getLatestProductByKeywordUseCase()
+        val result = getLatestProductByKeywordUseCase(keyword = keyword)
 
         assertNull(result)
     }
@@ -140,7 +141,7 @@ class GetLatestProductByKeywordUseCaseTest {
         )
         fakeRestApiRepository.setProductsResponse = Result.success(productSummaries)
 
-        val result = getLatestProductByKeywordUseCase()
+        val result = getLatestProductByKeywordUseCase(keyword = keyword)
 
         assertNull(result)
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,8 +38,8 @@ sqlite = "2.5.0-alpha04"
 slf4j = "2.0.13"
 
 # App configurations, not dependencies
-versionCode = "7"
-versionName = "1.2.0"
+versionCode = "8"
+versionName = "1.3.0"
 android-minSdk = "26"
 android-targetSdk = "34"
 android-compileSdk = "34"

--- a/iosApp/OctoMeter.xcodeproj/project.pbxproj
+++ b/iosApp/OctoMeter.xcodeproj/project.pbxproj
@@ -362,7 +362,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = V8M4R7N63C;
 				ENABLE_PREVIEWS = YES;
@@ -379,7 +379,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.3.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
@@ -400,7 +400,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = V8M4R7N63C;
 				ENABLE_PREVIEWS = YES;
@@ -417,7 +417,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.3.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",

--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - composeApp (1.2.0)
+  - composeApp (1.3.0)
 
 DEPENDENCIES:
   - composeApp (from `../composeApp/`)

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
The Agile Screen chart is updated to show the latest fixed and flexible tariff unit rates (as line graphs) to highlight when the agile tariff is generally cheaper than both of these tariffs.

A new widget is added as the legend. 

This ticket concludes version 1.3.0 (build 8)