### PR TITLE
(#245) UsageScreen: Bound navigation using first tariff start date instead of move-in date

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -62,6 +62,7 @@
     <string name="usage_kwh_year">kWh / year</string>
     <string name="usage_kwh_month">( %1$s kWh / month )</string>
     <string name="usage_latest">Latest</string>
+    <string name="usage_error_date_out_of_range">Requested date is outside of the allowed range.</string>
 
     <!-- Agile -->
     <string name="agile_demo_introduction">Demo Mode: The Agile Tariff shown for Retail Region A may not be available to you.</string>
@@ -189,4 +190,7 @@
     <string name="content_description_next_period">Navigate to the next period</string>
     <string name="content_description_dismiss_this_pane">Dismiss this pane</string>
     <string name="content_description_navigate_back">Navigate back</string>
+
+    <!-- Fallback Error message -->
+    <string name="fallback_error_no_consumptions">Error when retrieving consumptions</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/account/ElectricityMeterPoint.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/account/ElectricityMeterPoint.kt
@@ -46,8 +46,13 @@ data class ElectricityMeterPoint(
      * Returns null if the list is empty
      */
     fun getLatestAgreement(): Agreement? {
-        return agreements.maxByOrNull { agreement ->
-            agreement.period.endInclusive
-        }
+        return agreements.maxByOrNull { it.period.endInclusive }
+    }
+
+    /**
+     * Returns the start date of the first tariff for this MPAN
+     */
+    fun getFirstTariffStartDate(): Instant? {
+        return agreements.minByOrNull { it.period.start }?.period?.start
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
@@ -112,6 +112,9 @@ fun UsageScreen(
                 ) {
                     // We need to retain the navigation bar even for no data
                     uiState.consumptionQueryFilter?.let { consumptionQueryFilter ->
+                        val firstTariffStartDate = uiState.userProfile?.getSelectedElectricityMeterPoint()?.getFirstTariffStartDate()
+                            ?: Instant.DISTANT_FUTURE
+
                         TitleNavigationBar(
                             modifier = Modifier
                                 .background(color = MaterialTheme.colorScheme.secondary)
@@ -119,7 +122,7 @@ fun UsageScreen(
                                 .height(height = dimension.minListItemHeight),
                             currentPresentationStyle = consumptionQueryFilter.presentationStyle,
                             title = consumptionQueryFilter.getConsumptionPeriodString(),
-                            canNavigateBack = consumptionQueryFilter.canNavigateBackward(accountMoveInDate = uiState.userProfile?.account?.movedInAt ?: Instant.DISTANT_PAST),
+                            canNavigateBack = consumptionQueryFilter.canNavigateBackward(firstTariffStartDate = firstTariffStartDate),
                             canNavigateForward = consumptionQueryFilter.canNavigateForward(),
                             onNavigateBack = { uiEvent.onPreviousTimeFrame(consumptionQueryFilter) },
                             onNavigateForward = { uiEvent.onNextTimeFrame(consumptionQueryFilter) },

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
@@ -257,24 +257,24 @@ data class ConsumptionQueryFilter(
     }
 
     /**
-     * We assume no smart meter logs before the account move-in date.
-     * Although for accurate billing, we should take the tariff start date.
-     * We consider the end date for eligibility to make sure we show all available data.
+     * There can be a gap between move-in date and the first tariff becomes effective.
+     * We assume no smart meter logs before the first tariff start date.
+     * We also accept when the end date is after the start date to make sure we show all available data.
      */
-    fun canNavigateBackward(accountMoveInDate: Instant): Boolean {
+    fun canNavigateBackward(firstTariffStartDate: Instant): Boolean {
         val newReferencePoint = getBackwardReferencePoint()
         val newRequestPeriod = calculateQueryPeriod(
             referencePoint = newReferencePoint,
             presentationStyle = presentationStyle,
         )
-        return newRequestPeriod.endInclusive >= accountMoveInDate
+        return newRequestPeriod.endInclusive >= firstTariffStartDate
     }
 
     /**
      * Generate the ConsumptionQueryFilter for making an API request
      */
-    fun navigateBackward(accountMoveInDate: Instant): ConsumptionQueryFilter? {
-        if (!canNavigateBackward(accountMoveInDate = accountMoveInDate)) {
+    fun navigateBackward(firstTariffStartDate: Instant): ConsumptionQueryFilter? {
+        if (!canNavigateBackward(firstTariffStartDate = firstTariffStartDate)) {
             return null
         }
 

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModel.kt
@@ -41,6 +41,8 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.account_error_load_account
+import kunigami.composeapp.generated.resources.fallback_error_no_consumptions
+import kunigami.composeapp.generated.resources.usage_error_date_out_of_range
 import org.jetbrains.compose.resources.getString
 import kotlin.time.Duration
 
@@ -114,9 +116,10 @@ class UsageViewModel(
                             }
                         },
                         onFailure = { throwable ->
-                            Logger.e("UsageViewModel", throwable = throwable, message = { "Error when retrieving consumptions" })
+                            val fallbackErrorMessage = getString(resource = Res.string.fallback_error_no_consumptions)
+                            Logger.e("UsageViewModel", throwable = throwable, message = { fallbackErrorMessage })
                             _uiState.update { currentUiState ->
-                                currentUiState.filterErrorAndStopLoading(throwable = throwable, defaultMessage = "Error when retrieving consumptions")
+                                currentUiState.filterErrorAndStopLoading(throwable = throwable, defaultMessage = fallbackErrorMessage)
                             }
                             remainingRetryAttempt = 0 // API Error. Give up
                         },
@@ -164,12 +167,18 @@ class UsageViewModel(
                     )
                 },
                 onFailure = { throwable ->
-                    Logger.e("UsageViewModel", throwable = throwable, message = { "Error when retrieving consumptions" })
+                    val fallbackErrorMessage = getString(resource = Res.string.fallback_error_no_consumptions)
+                    Logger.e("UsageViewModel", throwable = throwable, message = { fallbackErrorMessage })
                     _uiState.update { currentUiState ->
-                        currentUiState.filterErrorAndStopLoading(throwable = throwable, defaultMessage = "Error when retrieving consumptions")
+                        currentUiState.filterErrorAndStopLoading(throwable = throwable, defaultMessage = getString(resource = Res.string.fallback_error_no_consumptions))
                     }
                 },
             )
+        } else {
+            _uiState.update { currentUiState ->
+                val errorMessage = getString(resource = Res.string.fallback_error_no_consumptions)
+                currentUiState.filterErrorAndStopLoading(throwable = IllegalStateException(errorMessage))
+            }
         }
     }
 
@@ -200,7 +209,7 @@ class UsageViewModel(
             if (newConsumptionQueryFilter == null) {
                 Logger.e("UsageViewModel", message = { "onNavigateForward request declined." })
                 _uiState.update { currentUiState ->
-                    currentUiState.filterErrorAndStopLoading(throwable = IllegalArgumentException("Requested date is outside of the allowed range."))
+                    currentUiState.filterErrorAndStopLoading(throwable = IllegalArgumentException(getString(resource = Res.string.usage_error_date_out_of_range)))
                 }
             } else {
                 refresh(consumptionQueryFilter = newConsumptionQueryFilter)
@@ -214,7 +223,7 @@ class UsageViewModel(
             if (newConsumptionQueryFilter == null) {
                 Logger.e("UsageViewModel", message = { "onNavigateForward request declined." })
                 _uiState.update { currentUiState ->
-                    currentUiState.filterErrorAndStopLoading(throwable = IllegalArgumentException("Requested date is outside of the allowed range."))
+                    currentUiState.filterErrorAndStopLoading(throwable = IllegalArgumentException(getString(resource = Res.string.usage_error_date_out_of_range)))
                 }
             } else {
                 refresh(consumptionQueryFilter = newConsumptionQueryFilter)

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/account/ElectricityMeterPointTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/account/ElectricityMeterPointTest.kt
@@ -69,4 +69,17 @@ class ElectricityMeterPointTest {
         val latestAgreement = emptyMeterPoint.getLatestAgreement()
         assertNull(latestAgreement)
     }
+
+    @Test
+    fun `getFirstTariffStartDate should return the date with the first validFrom date`() {
+        val firstTariffStartDate = meterPoint.getFirstTariffStartDate()
+        assertEquals(agreement1.period.start, firstTariffStartDate)
+    }
+
+    @Test
+    fun `getFirstTariffStartDate should return null if there are no agreements`() {
+        val emptyMeterPoint = ElectricityMeterPoint("MPAN1", listOf("METER1"), emptyList())
+        val firstTariffStartDate = emptyMeterPoint.getFirstTariffStartDate()
+        assertNull(firstTariffStartDate)
+    }
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilterTest.kt
@@ -179,7 +179,7 @@ class ConsumptionQueryFilterTest {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.DAY_HALF_HOURLY, referencePoint = reference)
         val expected = Instant.parse("2012-03-24T00:00:00Z")
 
-        val newFilter = filter.navigateBackward(accountMoveInDate = Instant.DISTANT_PAST)
+        val newFilter = filter.navigateBackward(firstTariffStartDate = Instant.DISTANT_PAST)
 
         assertEquals(expected, newFilter!!.referencePoint)
     }
@@ -190,7 +190,7 @@ class ConsumptionQueryFilterTest {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.WEEK_SEVEN_DAYS, referencePoint = reference)
         val expected = Instant.parse("2012-03-18T00:00:00Z")
 
-        val newFilter = filter.navigateBackward(accountMoveInDate = Instant.DISTANT_PAST)
+        val newFilter = filter.navigateBackward(firstTariffStartDate = Instant.DISTANT_PAST)
 
         assertEquals(expected, newFilter!!.referencePoint)
     }
@@ -201,7 +201,7 @@ class ConsumptionQueryFilterTest {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.MONTH_WEEKS, referencePoint = reference)
         val expected = Instant.parse("2012-03-01T00:00:00Z")
 
-        val newFilter = filter.navigateBackward(accountMoveInDate = Instant.DISTANT_PAST)
+        val newFilter = filter.navigateBackward(firstTariffStartDate = Instant.DISTANT_PAST)
 
         assertEquals(expected, newFilter!!.referencePoint)
     }
@@ -212,7 +212,7 @@ class ConsumptionQueryFilterTest {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.MONTH_THIRTY_DAYS, referencePoint = reference)
         val expected = Instant.parse("2012-03-01T00:00:00Z")
 
-        val newFilter = filter.navigateBackward(accountMoveInDate = Instant.DISTANT_PAST)
+        val newFilter = filter.navigateBackward(firstTariffStartDate = Instant.DISTANT_PAST)
 
         assertEquals(expected, newFilter!!.referencePoint)
     }
@@ -223,7 +223,7 @@ class ConsumptionQueryFilterTest {
         val filter = ConsumptionQueryFilter(presentationStyle = ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS, referencePoint = reference)
         val expected = Instant.parse("2011-12-31T00:00:00Z")
 
-        val newFilter = filter.navigateBackward(accountMoveInDate = Instant.DISTANT_PAST)
+        val newFilter = filter.navigateBackward(firstTariffStartDate = Instant.DISTANT_PAST)
 
         assertEquals(expected, newFilter!!.referencePoint)
     }

--- a/iosApp/OctoMeter.xcodeproj/project.pbxproj
+++ b/iosApp/OctoMeter.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 				7555FF77242A565900829871 /* Sources */,
 				B92378962B6B1156000C7307 /* Frameworks */,
 				7555FF79242A565900829871 /* Resources */,
+				4AD7A0029230F1B71E8D6C8E /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -177,6 +178,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		4AD7A0029230F1B71E8D6C8E /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OctoMeter/Pods-OctoMeter-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OctoMeter/Pods-OctoMeter-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OctoMeter/Pods-OctoMeter-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		6AECE37EC66E0570E7402658 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../composeApp/"
 
 SPEC CHECKSUMS:
-  composeApp: e31aeb78ae1e16cd7f7d81afc6157b3a562e1e1f
+  composeApp: 3dac210d1dd2810229d8ce57289c832bb64f29e2
 
 PODFILE CHECKSUM: 132f4b88956762bee62e7893fe00dca16e0d8114
 


### PR DESCRIPTION
It is a fact that the account move-in date does not mean the day we start to have meter readings and an effective tariff.
This is the same wrong assumption the official Octopus App made and caused the error.
We changed to use the first tariff on record to determine how early we allow users to navigate back to, because otherwise, even the API returns 0 meter readings, we still have no effective tariff to work out the billing.