### PR TITLE
AccountScreen: fix to correctly display a variable rate tariff

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/TariffLayout.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/TariffLayout.kt
@@ -124,9 +124,9 @@ internal fun TariffLayout(
         }
 
         when {
+            tariff.isVariable -> showVariableRate()
             tariff.isSingleRate() -> showSingleRate(tariff = tariff)
             tariff.hasDualRates() -> showDualRates(tariff = tariff)
-            tariff.isVariable -> showVariableRate()
         }
 
         if (showDivider) {


### PR DESCRIPTION
We made the `when` sequence incorrect so that a tariff with a variable rate could never be detected and shown using the correct layout.

A quick fix to rearrange the sequence so the variable rate will be checked first.