### PR TITLE
(#246) AgileScreen: remove unwanted loading blur; code refactoring

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -79,6 +79,7 @@
     <string name="agile_tariff_standard_unit_rate">Unit Rate: %1$d p/kWh</string>
     <string name="agile_tariff_standing_charge">Standing Charge: %1$d p/day</string>
     <string name="agile_current_rate">Current Rate</string>
+    <string name="agile_chart_tooltip_range_p">%1$s\n%2$sp</string>
 
     <!-- Tariffs -->
     <string name="tariffs_retail_region">Retail Region</string>

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -114,11 +114,7 @@ fun AgileScreen(
                     }
                 }
 
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .conditionalBlur(enabled = uiState.isLoading && uiState.barChartData == null),
-                ) {
+                Column(modifier = Modifier.fillMaxSize()) {
                     val subtitle = uiState.agileTariff?.let { primaryTariff ->
                         val regionCode = primaryTariff.getRetailRegion()?.stringResource
                             ?.let { stringResource(it) }
@@ -142,7 +138,7 @@ fun AgileScreen(
                         lazyListState = lazyListState,
                     ) { contentModifier ->
                         LazyColumn(
-                            modifier = contentModifier.conditionalBlur(enabled = uiState.isLoading),
+                            modifier = contentModifier.conditionalBlur(enabled = uiState.isLoading && uiState.barChartData == null),
                             contentPadding = PaddingValues(bottom = dimension.grid_4),
                             state = lazyListState,
                         ) {
@@ -233,9 +229,7 @@ fun AgileScreen(
             }
 
             uiState.isLoading && uiState.barChartData == null -> {
-                LoadingScreen(
-                    modifier = Modifier.fillMaxSize(),
-                )
+                LoadingScreen(modifier = Modifier.fillMaxSize())
             }
 
             else -> {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/chart/BarChartData.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/chart/BarChartData.kt
@@ -8,11 +8,75 @@
 package com.rwmobi.kunigami.ui.model.chart
 
 import androidx.compose.runtime.Immutable
+import com.rwmobi.kunigami.domain.extensions.getLocalHHMMString
+import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
+import com.rwmobi.kunigami.domain.model.rate.Rate
+import io.github.koalaplot.core.bar.DefaultVerticalBarPlotEntry
+import io.github.koalaplot.core.bar.DefaultVerticalBarPosition
 import io.github.koalaplot.core.bar.VerticalBarPlotEntry
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kunigami.composeapp.generated.resources.Res
+import kunigami.composeapp.generated.resources.agile_chart_tooltip_range_p
+import org.jetbrains.compose.resources.getString
 
 @Immutable
 data class BarChartData(
     val verticalBarPlotEntries: List<VerticalBarPlotEntry<Int, Double>>,
     val labels: Map<Int, String>,
     val tooltips: List<String>,
-)
+) {
+    companion object {
+        suspend fun fromRates(rates: List<Rate>) = BarChartData(
+            verticalBarPlotEntries = getVerticalBarPlotEntries(rates = rates),
+            labels = generateChartLabels(rates = rates),
+            tooltips = generateChartToolTips(rates = rates),
+        )
+
+        private fun getVerticalBarPlotEntries(rates: List<Rate>): List<VerticalBarPlotEntry<Int, Double>> = buildList {
+            rates.forEachIndexed { index, rate ->
+                add(
+                    element = DefaultVerticalBarPlotEntry(
+                        x = index,
+                        y = if (rate.vatInclusivePrice >= 0) {
+                            DefaultVerticalBarPosition(yMin = 0.0, yMax = rate.vatInclusivePrice)
+                        } else {
+                            DefaultVerticalBarPosition(yMin = rate.vatInclusivePrice, yMax = 0.0)
+                        },
+                    ),
+                )
+            }
+        }
+
+        private fun generateChartLabels(rates: List<Rate>): Map<Int, String> {
+            return buildMap {
+                var lastRateValue: Int? = null
+                rates.forEachIndexed { index, rate ->
+                    val currentTime = rate.validity.start.toLocalDateTime(TimeZone.currentSystemDefault()).time.hour
+                    if (currentTime != lastRateValue) {
+                        put(key = index, value = currentTime.toString().padStart(length = 2, padChar = '0'))
+                        lastRateValue = currentTime
+                    }
+                }
+            }
+        }
+
+        private suspend fun generateChartToolTips(rates: List<Rate>): List<String> {
+            return rates.map { rate ->
+                val validToString = if (rate.validity.endInclusive != Instant.DISTANT_FUTURE) {
+                    " - ${rate.validity.endInclusive.getLocalHHMMString()}"
+                } else {
+                    ""
+                }
+                val timeRange = rate.validity.start.getLocalHHMMString() + validToString
+
+                getString(
+                    resource = Res.string.agile_chart_tooltip_range_p,
+                    timeRange,
+                    rate.vatInclusivePrice.roundToTwoDecimalPlaces(),
+                )
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/chart/BarChartData.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/chart/BarChartData.kt
@@ -8,18 +8,30 @@
 package com.rwmobi.kunigami.ui.model.chart
 
 import androidx.compose.runtime.Immutable
+import com.rwmobi.kunigami.domain.extensions.getLocalDateString
+import com.rwmobi.kunigami.domain.extensions.getLocalDayMonthString
+import com.rwmobi.kunigami.domain.extensions.getLocalDayOfMonth
+import com.rwmobi.kunigami.domain.extensions.getLocalEnglishAbbreviatedDayOfWeekName
 import com.rwmobi.kunigami.domain.extensions.getLocalHHMMString
+import com.rwmobi.kunigami.domain.extensions.getLocalMonthString
+import com.rwmobi.kunigami.domain.extensions.getLocalMonthYearString
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
+import com.rwmobi.kunigami.domain.model.consumption.Consumption
 import com.rwmobi.kunigami.domain.model.rate.Rate
+import com.rwmobi.kunigami.ui.model.consumption.ConsumptionPresentationStyle
 import io.github.koalaplot.core.bar.DefaultVerticalBarPlotEntry
 import io.github.koalaplot.core.bar.DefaultVerticalBarPosition
 import io.github.koalaplot.core.bar.VerticalBarPlotEntry
+import io.github.koalaplot.core.util.toString
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.agile_chart_tooltip_range_p
+import kunigami.composeapp.generated.resources.usage_chart_tooltip_range_kwh
+import kunigami.composeapp.generated.resources.usage_chart_tooltip_spot_kwh
 import org.jetbrains.compose.resources.getString
+import kotlin.time.Duration.Companion.nanoseconds
 
 @Immutable
 data class BarChartData(
@@ -29,12 +41,19 @@ data class BarChartData(
 ) {
     companion object {
         suspend fun fromRates(rates: List<Rate>) = BarChartData(
-            verticalBarPlotEntries = getVerticalBarPlotEntries(rates = rates),
-            labels = generateChartLabels(rates = rates),
-            tooltips = generateChartToolTips(rates = rates),
+            verticalBarPlotEntries = generateRateVerticalBarPlotEntries(rates = rates),
+            labels = generateRateLabels(rates = rates),
+            tooltips = generateRateToolTips(rates = rates),
         )
 
-        private fun getVerticalBarPlotEntries(rates: List<Rate>): List<VerticalBarPlotEntry<Int, Double>> = buildList {
+        suspend fun fromConsumptions(presentationStyle: ConsumptionPresentationStyle, consumptions: List<Consumption>) = BarChartData(
+            verticalBarPlotEntries = generateConsumptionVerticalBarPlotEntries(consumptions = consumptions),
+            labels = generateConsumptionLabels(presentationStyle = presentationStyle, consumptions = consumptions),
+            tooltips = generateConsumptionToolTips(presentationStyle = presentationStyle, consumptions = consumptions),
+        )
+
+        // Rate - Agile
+        private fun generateRateVerticalBarPlotEntries(rates: List<Rate>): List<VerticalBarPlotEntry<Int, Double>> = buildList {
             rates.forEachIndexed { index, rate ->
                 add(
                     element = DefaultVerticalBarPlotEntry(
@@ -49,7 +68,7 @@ data class BarChartData(
             }
         }
 
-        private fun generateChartLabels(rates: List<Rate>): Map<Int, String> {
+        private fun generateRateLabels(rates: List<Rate>): Map<Int, String> {
             return buildMap {
                 var lastRateValue: Int? = null
                 rates.forEachIndexed { index, rate ->
@@ -62,7 +81,7 @@ data class BarChartData(
             }
         }
 
-        private suspend fun generateChartToolTips(rates: List<Rate>): List<String> {
+        private suspend fun generateRateToolTips(rates: List<Rate>): List<String> {
             return rates.map { rate ->
                 val validToString = if (rate.validity.endInclusive != Instant.DISTANT_FUTURE) {
                     " - ${rate.validity.endInclusive.getLocalHHMMString()}"
@@ -76,6 +95,136 @@ data class BarChartData(
                     timeRange,
                     rate.vatInclusivePrice.roundToTwoDecimalPlaces(),
                 )
+            }
+        }
+
+        // Consumption - Usage
+        private fun generateConsumptionVerticalBarPlotEntries(consumptions: List<Consumption>): List<VerticalBarPlotEntry<Int, Double>> = buildList {
+            consumptions.forEachIndexed { index, consumption ->
+                add(
+                    element = DefaultVerticalBarPlotEntry(
+                        x = index,
+                        y = DefaultVerticalBarPosition(yMin = 0.0, yMax = consumption.kWhConsumed),
+                    ),
+                )
+            }
+        }
+
+        private fun generateConsumptionLabels(
+            presentationStyle: ConsumptionPresentationStyle,
+            consumptions: List<Consumption>,
+        ): Map<Int, String> {
+            return buildMap {
+                when (presentationStyle) {
+                    ConsumptionPresentationStyle.DAY_HALF_HOURLY -> {
+                        var lastRateValue: Int? = null
+                        consumptions.forEachIndexed { index, consumption ->
+                            val currentTime = consumption.interval.start.toLocalDateTime(TimeZone.currentSystemDefault()).time.hour
+                            if (currentTime != lastRateValue && currentTime % 2 == 0) {
+                                put(
+                                    key = index,
+                                    value = currentTime.toString().padStart(length = 2, padChar = '0'),
+                                )
+                            }
+                            lastRateValue = currentTime
+                        }
+                    }
+
+                    ConsumptionPresentationStyle.WEEK_SEVEN_DAYS -> {
+                        consumptions.forEachIndexed { index, consumption ->
+                            put(
+                                key = index,
+                                value = consumption.interval.start.getLocalEnglishAbbreviatedDayOfWeekName(),
+                            )
+                        }
+                    }
+
+                    ConsumptionPresentationStyle.MONTH_WEEKS -> {
+                        consumptions.forEachIndexed { index, consumption ->
+                            put(
+                                key = index,
+                                value = consumption.interval.start.getLocalDayMonthString(),
+                            )
+                        }
+                    }
+
+                    ConsumptionPresentationStyle.MONTH_THIRTY_DAYS -> {
+                        consumptions.forEachIndexed { index, consumption ->
+                            put(
+                                key = index,
+                                value = consumption.interval.start.getLocalDayOfMonth().toString(),
+                            )
+                        }
+                    }
+
+                    ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS -> {
+                        consumptions.forEachIndexed { index, consumption ->
+                            put(
+                                key = index,
+                                value = consumption.interval.start.getLocalMonthString(),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        private suspend fun generateConsumptionToolTips(
+            presentationStyle: ConsumptionPresentationStyle,
+            consumptions: List<Consumption>,
+        ): List<String> {
+            return when (presentationStyle) {
+                ConsumptionPresentationStyle.DAY_HALF_HOURLY -> {
+                    consumptions.map { consumption ->
+                        getString(
+                            resource = Res.string.usage_chart_tooltip_range_kwh,
+                            consumption.interval.start.getLocalHHMMString(),
+                            consumption.interval.endInclusive.getLocalHHMMString(),
+                            consumption.kWhConsumed.toString(precision = 2),
+                        )
+                    }
+                }
+
+                ConsumptionPresentationStyle.WEEK_SEVEN_DAYS -> {
+                    consumptions.map { consumption ->
+                        getString(
+                            resource = Res.string.usage_chart_tooltip_spot_kwh,
+                            consumption.interval.start.getLocalDateString(),
+                            consumption.kWhConsumed.toString(precision = 2),
+                        )
+                    }
+                }
+
+                ConsumptionPresentationStyle.MONTH_WEEKS -> {
+                    consumptions.map { consumption ->
+                        getString(
+                            resource = Res.string.usage_chart_tooltip_range_kwh,
+                            consumption.interval.start.getLocalDayMonthString(),
+                            (consumption.interval.endInclusive - 1.nanoseconds).getLocalDayMonthString(),
+                            consumption.kWhConsumed.toString(precision = 2),
+                        )
+                    }
+                }
+
+                ConsumptionPresentationStyle.MONTH_THIRTY_DAYS -> {
+                    consumptions.map { consumption ->
+                        getString(
+                            resource = Res.string.usage_chart_tooltip_spot_kwh,
+                            consumption.interval.start.getLocalDayMonthString(),
+                            consumption.kWhConsumed.toString(precision = 2),
+                        )
+                    }
+                }
+
+                ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS -> {
+                    consumptions.map { consumption ->
+                        getString(
+                            resource = Res.string.usage_chart_tooltip_spot_kwh,
+                            consumption.interval.start.getLocalMonthYearString(),
+                            consumption.kWhConsumed.toString(precision = 2),
+                        )
+                    }
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModel.kt
@@ -28,9 +28,6 @@ import com.rwmobi.kunigami.ui.model.chart.BarChartData
 import com.rwmobi.kunigami.ui.model.consumption.ConsumptionPresentationStyle
 import com.rwmobi.kunigami.ui.model.consumption.ConsumptionQueryFilter
 import com.rwmobi.kunigami.ui.previewsampledata.FakeDemoUserProfile
-import io.github.koalaplot.core.bar.DefaultVerticalBarPlotEntry
-import io.github.koalaplot.core.bar.DefaultVerticalBarPosition
-import io.github.koalaplot.core.bar.VerticalBarPlotEntry
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -298,20 +295,7 @@ class UsageViewModel(
     ) {
         val consumptions = consumptionWithCost.map { it.consumption }
         val consumptionRange = consumptions.getConsumptionRange()
-        val labels = consumptionQueryFilter.generateChartLabels(consumptions = consumptions)
         val consumptionGroupedCells = consumptionQueryFilter.groupChartCells(consumptions = consumptions)
-        val toolTips = consumptionQueryFilter.generateChartToolTips(consumptions = consumptions)
-        val verticalBarPlotEntries: List<VerticalBarPlotEntry<Int, Double>> = buildList {
-            consumptions.forEachIndexed { index, consumption ->
-                add(
-                    element = DefaultVerticalBarPlotEntry(
-                        x = index,
-                        y = DefaultVerticalBarPosition(yMin = 0.0, yMax = consumption.kWhConsumed),
-                    ),
-                )
-            }
-        }
-
         val insights = generateUsageInsightsUseCase(
             tariff = tariff,
             consumptionWithCost = consumptionWithCost,
@@ -322,10 +306,9 @@ class UsageViewModel(
                 consumptionQueryFilter = consumptionQueryFilter,
                 consumptionGroupedCells = consumptionGroupedCells,
                 consumptionRange = consumptionRange,
-                barChartData = BarChartData(
-                    verticalBarPlotEntries = verticalBarPlotEntries,
-                    labels = labels,
-                    tooltips = toolTips,
+                barChartData = BarChartData.fromConsumptions(
+                    consumptions = consumptions,
+                    presentationStyle = consumptionQueryFilter.presentationStyle,
                 ),
                 requestedScreenType = UsageScreenType.Chart,
                 insights = insights,

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/chart/BarChartDataTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/chart/BarChartDataTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.kunigami.ui.model.chart
+
+import com.rwmobi.kunigami.domain.model.rate.PaymentMethod
+import com.rwmobi.kunigami.domain.model.rate.Rate
+import io.github.koalaplot.core.bar.DefaultVerticalBarPlotEntry
+import io.github.koalaplot.core.bar.DefaultVerticalBarPosition
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BarChartDataTest {
+    // We intended to test BST in this case
+    private val sampleRateList = listOf(
+        Rate(
+            vatInclusivePrice = 10.0,
+            validity = Instant.parse("2024-07-04T10:00:00Z")..Instant.parse("2024-07-04T11:00:00Z"),
+            paymentMethod = PaymentMethod.DIRECT_DEBIT,
+        ),
+        Rate(
+            vatInclusivePrice = -5.0,
+            validity = Instant.parse("2024-07-04T11:00:00Z")..Instant.parse("2024-07-04T12:00:00Z"),
+            paymentMethod = PaymentMethod.DIRECT_DEBIT,
+        ),
+        Rate(
+            vatInclusivePrice = 15.0,
+            validity = Instant.parse("2024-07-04T12:00:00Z")..Instant.DISTANT_FUTURE,
+            paymentMethod = PaymentMethod.DIRECT_DEBIT,
+        ),
+    )
+
+    @Test
+    fun `fromRates should generate correct verticalBarPlotEntries`() = runBlocking {
+        val rates = sampleRateList
+        val expectedEntries = listOf(
+            DefaultVerticalBarPlotEntry(
+                x = 0,
+                y = DefaultVerticalBarPosition(yMin = 0.0, yMax = 10.0),
+            ),
+            DefaultVerticalBarPlotEntry(
+                x = 1,
+                y = DefaultVerticalBarPosition(yMin = -5.0, yMax = 0.0),
+            ),
+            DefaultVerticalBarPlotEntry(
+                x = 2,
+                y = DefaultVerticalBarPosition(yMin = 0.0, yMax = 15.0),
+            ),
+        )
+
+        val barChartData = BarChartData.fromRates(rates)
+
+        assertEquals(expected = expectedEntries, actual = barChartData.verticalBarPlotEntries)
+    }
+
+    @Test
+    fun `fromRates should generate correct labels`() = runBlocking {
+        val rates = sampleRateList
+        val expectedLabels = mapOf(
+            0 to "11",
+            1 to "12",
+            2 to "13",
+        )
+
+        val barChartData = BarChartData.fromRates(rates)
+
+        assertEquals(expected = expectedLabels, actual = barChartData.labels)
+    }
+
+    @Test
+    fun `fromRates should generate correct tooltips`() = runBlocking {
+        val rates = sampleRateList
+        val expectedTooltips = listOf(
+            "11:00 - 12:00\n10.0p",
+            "12:00 - 13:00\n-5.0p",
+            "13:00\n15.0p",
+        )
+
+        val barChartData = BarChartData.fromRates(rates)
+
+        assertEquals(expected = expectedTooltips, actual = barChartData.tooltips)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/chart/BarChartDataTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/chart/BarChartDataTest.kt
@@ -7,8 +7,10 @@
 
 package com.rwmobi.kunigami.ui.model.chart
 
+import com.rwmobi.kunigami.domain.model.consumption.Consumption
 import com.rwmobi.kunigami.domain.model.rate.PaymentMethod
 import com.rwmobi.kunigami.domain.model.rate.Rate
+import com.rwmobi.kunigami.ui.model.consumption.ConsumptionPresentationStyle
 import io.github.koalaplot.core.bar.DefaultVerticalBarPlotEntry
 import io.github.koalaplot.core.bar.DefaultVerticalBarPosition
 import kotlinx.coroutines.runBlocking
@@ -36,6 +38,7 @@ class BarChartDataTest {
         ),
     )
 
+    // 🗂 fromRates
     @Test
     fun `fromRates should generate correct verticalBarPlotEntries`() = runBlocking {
         val rates = sampleRateList
@@ -83,6 +86,170 @@ class BarChartDataTest {
         )
 
         val barChartData = BarChartData.fromRates(rates)
+
+        assertEquals(expected = expectedTooltips, actual = barChartData.tooltips)
+    }
+
+    // 🗂 fromConsumptions
+    // Helper function to create Consumption objects for testing
+    private fun createConsumption(kWhConsumed: Double, start: String, end: String): Consumption {
+        return Consumption(
+            kWhConsumed = kWhConsumed,
+            interval = Instant.parse(start)..Instant.parse(end),
+        )
+    }
+
+    @Test
+    fun `fromConsumptions should generate correct verticalBarPlotEntries`() = runBlocking {
+        val consumptions = listOf(
+            createConsumption(kWhConsumed = 5.0, start = "2024-07-04T10:00:00Z", end = "2024-07-04T10:30:00Z"),
+            createConsumption(kWhConsumed = 10.0, start = "2024-07-04T10:30:00Z", end = "2024-07-04T11:00:00Z"),
+            createConsumption(kWhConsumed = 15.0, start = "2024-07-04T11:00:00Z", end = "2024-07-04T11:30:00Z"),
+        )
+        val expectedEntries = listOf(
+            DefaultVerticalBarPlotEntry(
+                x = 0,
+                y = DefaultVerticalBarPosition(yMin = 0.0, yMax = 5.0),
+            ),
+            DefaultVerticalBarPlotEntry(
+                x = 1,
+                y = DefaultVerticalBarPosition(yMin = 0.0, yMax = 10.0),
+            ),
+            DefaultVerticalBarPlotEntry(
+                x = 2,
+                y = DefaultVerticalBarPosition(yMin = 0.0, yMax = 15.0),
+            ),
+        )
+
+        val barChartData = BarChartData.fromConsumptions(
+            presentationStyle = ConsumptionPresentationStyle.DAY_HALF_HOURLY,
+            consumptions = consumptions,
+        )
+
+        assertEquals(expectedEntries, barChartData.verticalBarPlotEntries)
+    }
+
+    @Test
+    fun `fromConsumptions should generate correct labels for DAY_HALF_HOURLY`() = runBlocking {
+        val consumptions = listOf(
+            createConsumption(kWhConsumed = 5.0, start = "2024-07-04T01:00:00Z", end = "2024-07-04T01:30:00Z"),
+            createConsumption(kWhConsumed = 10.0, start = "2024-07-04T01:30:00Z", end = "2024-07-04T02:00:00Z"),
+            createConsumption(kWhConsumed = 15.0, start = "2024-07-04T02:00:00Z", end = "2024-07-04T02:30:00Z"),
+            createConsumption(kWhConsumed = 20.0, start = "2024-07-04T02:30:00Z", end = "2024-07-04T03:00:00Z"),
+        )
+        val expectedLabels = mapOf(
+            0 to "02",
+        )
+
+        val barChartData = BarChartData.fromConsumptions(
+            presentationStyle = ConsumptionPresentationStyle.DAY_HALF_HOURLY,
+            consumptions = consumptions,
+        )
+
+        assertEquals(expected = expectedLabels, actual = barChartData.labels)
+    }
+
+    @Test
+    fun `fromConsumptions should generate correct tooltips for DAY_HALF_HOURLY`() = runBlocking {
+        val consumptions = listOf(
+            createConsumption(kWhConsumed = 5.0, start = "2024-07-04T10:00:00Z", end = "2024-07-04T10:30:00Z"),
+            createConsumption(kWhConsumed = 10.0, start = "2024-07-04T10:30:00Z", end = "2024-07-04T11:00:00Z"),
+            createConsumption(kWhConsumed = 15.0, start = "2024-07-04T11:00:00Z", end = "2024-07-04T11:30:00Z"),
+        )
+        val expectedTooltips = listOf(
+            "11:00 - 11:30\n5.00 kWh",
+            "11:30 - 12:00\n10.00 kWh",
+            "12:00 - 12:30\n15.00 kWh",
+        )
+
+        val barChartData = BarChartData.fromConsumptions(
+            presentationStyle = ConsumptionPresentationStyle.DAY_HALF_HOURLY,
+            consumptions = consumptions,
+        )
+
+        assertEquals(expected = expectedTooltips, actual = barChartData.tooltips)
+    }
+
+    @Test
+    fun `fromConsumptions should generate correct labels for WEEK_SEVEN_DAYS`() = runBlocking {
+        val consumptions = listOf(
+            createConsumption(kWhConsumed = 5.0, start = "2024-07-01T00:00:00Z", end = "2024-07-01T23:59:59Z"), // Monday
+            createConsumption(kWhConsumed = 10.0, start = "2024-07-02T00:00:00Z", end = "2024-07-02T23:59:59Z"), // Tuesday
+            createConsumption(kWhConsumed = 15.0, start = "2024-07-03T00:00:00Z", end = "2024-07-03T23:59:59Z"), // Wednesday
+        )
+        val expectedLabels = mapOf(
+            0 to "Mon",
+            1 to "Tue",
+            2 to "Wed",
+        )
+
+        val barChartData = BarChartData.fromConsumptions(
+            presentationStyle = ConsumptionPresentationStyle.WEEK_SEVEN_DAYS,
+            consumptions = consumptions,
+        )
+
+        assertEquals(expected = expectedLabels, actual = barChartData.labels)
+    }
+
+    @Test
+    fun `fromConsumptions should generate correct tooltips for WEEK_SEVEN_DAYS`() = runBlocking {
+        val consumptions = listOf(
+            createConsumption(kWhConsumed = 5.0, start = "2024-07-01T00:00:00Z", end = "2024-07-01T23:59:59Z"), // Monday
+            createConsumption(kWhConsumed = 10.0, start = "2024-07-02T00:00:00Z", end = "2024-07-02T23:59:59Z"), // Tuesday
+            createConsumption(kWhConsumed = 15.0, start = "2024-07-03T00:00:00Z", end = "2024-07-03T23:59:59Z"), // Wednesday
+        )
+        val expectedTooltips = listOf(
+            "1 Jul 2024\n5.00 kWh",
+            "2 Jul 2024\n10.00 kWh",
+            "3 Jul 2024\n15.00 kWh",
+        )
+
+        val barChartData = BarChartData.fromConsumptions(
+            presentationStyle = ConsumptionPresentationStyle.WEEK_SEVEN_DAYS,
+            consumptions = consumptions,
+        )
+
+        assertEquals(expected = expectedTooltips, actual = barChartData.tooltips)
+    }
+
+    @Test
+    fun `fromConsumptions should generate correct labels for YEAR_TWELVE_MONTHS`() = runBlocking {
+        val consumptions = listOf(
+            createConsumption(kWhConsumed = 5.0, start = "2024-01-01T00:00:00Z", end = "2024-01-31T23:59:59Z"), // January
+            createConsumption(kWhConsumed = 10.0, start = "2024-02-01T00:00:00Z", end = "2024-02-28T23:59:59Z"), // February
+            createConsumption(kWhConsumed = 15.0, start = "2024-03-01T00:00:00Z", end = "2024-03-31T23:59:59Z"), // March
+        )
+        val expectedLabels = mapOf(
+            0 to "Jan",
+            1 to "Feb",
+            2 to "Mar",
+        )
+
+        val barChartData = BarChartData.fromConsumptions(
+            presentationStyle = ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS,
+            consumptions = consumptions,
+        )
+
+        assertEquals(expected = expectedLabels, actual = barChartData.labels)
+    }
+
+    @Test
+    fun `fromConsumptions should generate correct tooltips for YEAR_TWELVE_MONTHS`() = runBlocking {
+        val consumptions = listOf(
+            createConsumption(kWhConsumed = 5.0, start = "2024-01-01T00:00:00Z", end = "2024-01-31T23:59:59Z"), // January
+            createConsumption(kWhConsumed = 10.0, start = "2024-02-01T00:00:00Z", end = "2024-02-28T23:59:59Z"), // February
+            createConsumption(kWhConsumed = 15.0, start = "2024-03-01T00:00:00Z", end = "2024-03-31T23:59:59Z"), // March
+        )
+        val expectedTooltips = listOf(
+            "Jan 2024\n5.00 kWh",
+            "Feb 2024\n10.00 kWh",
+            "Mar 2024\n15.00 kWh",
+        )
+
+        val barChartData = BarChartData.fromConsumptions(
+            presentationStyle = ConsumptionPresentationStyle.YEAR_TWELVE_MONTHS,
+            consumptions = consumptions,
+        )
 
         assertEquals(expected = expectedTooltips, actual = barChartData.tooltips)
     }

--- a/composeApp/src/desktopTest/kotlin/com/rwmobi/kunigami/ui/model/chart/BarChartDataTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/rwmobi/kunigami/ui/model/chart/BarChartDataTest.kt
@@ -18,6 +18,7 @@ import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@Suppress("TooManyFunctions")
 class BarChartDataTest {
     // We intended to test BST in this case
     private val sampleRateList = listOf(


### PR DESCRIPTION
This fix removes the duplicated loading blur effect, so it should not be triggered when the screen already has a chart shown during the refresh.

Also consolidates chart data generation functions with unit tests added.