### PR TITLE
App: fix Android Navigation stack

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/AppBottomNavigationBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/AppBottomNavigationBar.kt
@@ -4,9 +4,6 @@
  * Sponsored by RW MobiMedia UK Limited
  *
  */
-
-@file:OptIn(ExperimentalResourceApi::class)
-
 package com.rwmobi.kunigami.ui.components
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
@@ -32,7 +29,6 @@ import com.rwmobi.kunigami.ui.navigation.AppDestination
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.content_description_navigation_bar
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -46,9 +42,7 @@ fun AppBottomNavigationBar(
 
     val navigationBarContentDescription = stringResource(Res.string.content_description_navigation_bar)
     NavigationBar(
-        modifier = modifier.semantics {
-            contentDescription = navigationBarContentDescription
-        },
+        modifier = modifier.semantics { contentDescription = navigationBarContentDescription },
         tonalElevation = 0.dp,
         containerColor = MaterialTheme.colorScheme.background,
     ) {
@@ -65,11 +59,7 @@ fun AppBottomNavigationBar(
                 onClick = {
                     if (!selected) {
                         navController.navigate(item.name) {
-                            navController.graph.startDestinationRoute?.let {
-                                popUpTo(it) {
-                                    inclusive = true
-                                }
-                            }
+                            popUpTo(route = AppDestination.getStartDestination().name)
                             launchSingleTop = true
                         }
                     } else {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/AppNavigationRail.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/AppNavigationRail.kt
@@ -4,9 +4,6 @@
  * Sponsored by RW MobiMedia UK Limited
  *
  */
-
-@file:OptIn(ExperimentalResourceApi::class)
-
 package com.rwmobi.kunigami.ui.components
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
@@ -33,7 +30,6 @@ import com.rwmobi.kunigami.ui.navigation.AppDestination
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.content_description_navigation_rail
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -45,9 +41,7 @@ fun AppNavigationRail(
 ) {
     val navigationRailContentDescription = stringResource(Res.string.content_description_navigation_rail)
     NavigationRail(
-        modifier = modifier.semantics {
-            contentDescription = navigationRailContentDescription
-        },
+        modifier = modifier.semantics { contentDescription = navigationRailContentDescription },
         containerColor = MaterialTheme.colorScheme.background,
     ) {
         val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -68,11 +62,7 @@ fun AppNavigationRail(
                 onClick = {
                     if (!selected) {
                         navController.navigate(item.name) {
-                            navController.graph.startDestinationRoute?.let {
-                                popUpTo(it) {
-                                    inclusive = true
-                                }
-                            }
+                            popUpTo(route = AppDestination.getStartDestination().name)
                             launchSingleTop = true
                         }
                     } else {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/navigation/AppDestination.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/navigation/AppDestination.kt
@@ -28,5 +28,6 @@ enum class AppDestination(val titleResId: StringResource, val iconResId: Drawabl
 
     companion object {
         fun getNavBarDestinations(): List<AppDestination> = listOf(AGILE, USAGE, TARIFFS, ACCOUNT)
+        fun getStartDestination() = AGILE
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/navigation/AppNavigationHost.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/navigation/AppNavigationHost.kt
@@ -57,7 +57,7 @@ fun AppNavigationHost(
     NavHost(
         modifier = modifier,
         navController = navController,
-        startDestination = AppDestination.AGILE.name,
+        startDestination = AppDestination.getStartDestination().name,
     ) {
         composable(route = AppDestination.USAGE.name) {
             // Workaround: passing through parameters not working on iOS, so we do it here


### PR DESCRIPTION
The way we clear the navigation stack does not work as expected.
If users keep on navigating using the navigation bar/rail, the navigation stack will currently keep all these transactions, so when clicking back, it will replay this long navigation history.

Now, we always clear the stack and set the back behaviour to return to the start destination before exiting the screen.
