### PR TITLE
Update Proguard rules for Apollo GraphQL

### DIFF
--- a/composeApp/compose-desktop.pro
+++ b/composeApp/compose-desktop.pro
@@ -11,7 +11,19 @@
 
 # Keep all DTO classes in the package
 -keep class com.rwmobi.kunigami.data.source.network.dto.** { *; }
+-dontnote com.rwmobi.kunigami.data.source.network.dto.**
 -keep class com.rwmobi.kunigami.domain.model.** { *; }
+-dontnote com.rwmobi.kunigami.domain.model.**
+
+# Apollo workarounds
+-dontnote okio.**
+# -keep class com.rwmobi.kunigami.graphql.** { *; }
+-keep class com.apollographql.apollo.** { *; }
+-dontnote com.apollographql.**
+-keep class okhttp3.** { *; }
+-keep class org.bouncycastle.** { *; }
+-dontwarn okhttp3.internal.platform.**
+-dontnote okhttp3.**
 
 # Keep the class and fields of kotlinx.datetime.Instant
 -keep class kotlinx.datetime.Instant { *; }
@@ -92,6 +104,7 @@
 # Room persistence library
 -keep class androidx.room.** { *; }
 -dontwarn androidx.room.**
+-dontnote androidx.room.**
 -keep class androidx.sqlite.db.** { *; }
 -dontwarn androidx.sqlite.db.**
 -keep class androidx.sqlite.** { *; }
@@ -108,3 +121,4 @@
 # Keep the DAO classes
 -keep interface * extends androidx.room.RoomDatabase { *; }
 -keep class com.rwmobi.kunigami.data.source.local.database.dao.** { *; }
+-dontnote com.rwmobi.kunigami.data.source.local.database.dao.**

--- a/composeApp/compose-desktop.pro
+++ b/composeApp/compose-desktop.pro
@@ -6,7 +6,6 @@
 
 # Keep Ktor classes
 -keep class io.ktor.** { *; }
--dontwarn io.ktor.**
 -dontnote io.ktor.**
 
 # Keep all DTO classes in the package
@@ -17,16 +16,16 @@
 
 # Apollo workarounds
 -dontnote okio.**
-# -keep class com.rwmobi.kunigami.graphql.** { *; }
 -keep class com.apollographql.apollo.** { *; }
 -dontnote com.apollographql.**
 -keep class okhttp3.** { *; }
 -keep class org.bouncycastle.** { *; }
+-dontnote okhttp3.internal.platform.**
 -dontwarn okhttp3.internal.platform.**
--dontnote okhttp3.**
 
 # Keep the class and fields of kotlinx.datetime.Instant
 -keep class kotlinx.datetime.Instant { *; }
+-dontnote kotlinx.datetime.Instant
 
 # Kotlinx Serialization
 -keep class kotlinx.serialization.** { *; }
@@ -55,6 +54,7 @@
 
 # OSHI classes
 -keep class oshi.** { *; }
+-dontnote oshi.**
 
 # Keep the entire MacOSThemeDetector class and its nested classes
 -keep class com.jthemedetecor.** { *; }
@@ -103,11 +103,10 @@
 # RoomDB
 # Room persistence library
 -keep class androidx.room.** { *; }
--dontwarn androidx.room.**
 -dontnote androidx.room.**
 -keep class androidx.sqlite.db.** { *; }
--dontwarn androidx.sqlite.db.**
 -keep class androidx.sqlite.** { *; }
+-dontnote androidx.sqlite.db.**
 
 # Keep generated Room classes
 -keepclassmembers class * {


### PR DESCRIPTION
JetBrains' worst undiscussable KMP issue.
Updated Proguard to make desktop release work.