### PR TITLE
Minor UI layout update: Agile and Usage screen widget row

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/WidgetCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/WidgetCard.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
-import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -33,37 +32,33 @@ fun WidgetCard(
 ) {
     val dimension = LocalDensity.current.getDimension()
 
-    Card(
+    Column(
         modifier = modifier
             .sizeIn(
                 minWidth = dimension.windowWidthMedium / 2,
                 maxWidth = dimension.windowWidthCompact,
-            ),
+            )
+            .fillMaxSize()
+            .padding(all = dimension.grid_2),
+        verticalArrangement = Arrangement.spacedBy(space = dimension.grid_1),
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(all = dimension.grid_2),
-            verticalArrangement = Arrangement.spacedBy(space = dimension.grid_1),
-        ) {
-            heading?.let { headingText ->
-                Text(
-                    modifier = Modifier.fillMaxWidth(),
-                    style = MaterialTheme.typography.labelMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    textAlign = TextAlign.Center,
-                    text = headingText,
-                )
-            }
-
-            Spacer(modifier = Modifier.weight(weight = 1f))
-
-            contents()
-
-            Spacer(modifier = Modifier.weight(weight = 1f))
-
-            footer?.let { it() }
+        heading?.let { headingText ->
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                text = headingText,
+            )
         }
+
+        Spacer(modifier = Modifier.weight(weight = 1f))
+
+        contents()
+
+        Spacer(modifier = Modifier.weight(weight = 1f))
+
+        footer?.let { it() }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
@@ -166,11 +167,11 @@ fun AgileScreen(
                             item(key = "tariffDetails") {
                                 AgileTariffCardAdaptive(
                                     modifier = Modifier
+                                        .background(color = CardDefaults.cardColors().containerColor)
                                         .fillMaxWidth()
                                         .padding(
-                                            start = dimension.grid_3,
-                                            end = dimension.grid_3,
-                                            top = dimension.grid_1,
+                                            horizontal = dimension.grid_3,
+                                            vertical = dimension.grid_1,
                                         ),
                                     latestFixedTariff = uiState.latestFixedTariff,
                                     latestFlexibleTariff = uiState.latestFlexibleTariff,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/AgileTariffCardAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/AgileTariffCardAdaptive.kt
@@ -13,14 +13,15 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -32,6 +33,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import com.rwmobi.kunigami.domain.extensions.getNextHalfHourCountdownMillis
 import com.rwmobi.kunigami.domain.model.product.Tariff
 import com.rwmobi.kunigami.domain.model.rate.PaymentMethod
@@ -203,6 +205,11 @@ private fun AgileTariffCardCompact(
         }
 
         if (latestFixedTariff != null || latestFlexibleTariff != null) {
+            HorizontalDivider(
+                modifier = Modifier.height(height = dimension.grid_1),
+                thickness = Dp.Hairline,
+            )
+
             LatestTariffsCard(
                 modifier = Modifier.fillMaxWidth(),
                 latestFlexibleTariff = latestFlexibleTariff,
@@ -254,7 +261,10 @@ private fun AgileTariffCardExpanded(
                 ),
             )
 
-            Spacer(modifier = Modifier.width(width = dimension.grid_1))
+            VerticalDivider(
+                modifier = Modifier.width(width = dimension.grid_1),
+                thickness = Dp.Hairline,
+            )
 
             RateGaugeCountdownCard(
                 modifier = Modifier
@@ -266,7 +276,11 @@ private fun AgileTariffCardExpanded(
             )
 
             if (shouldShowLatestTariff) {
-                Spacer(modifier = Modifier.width(width = dimension.grid_1))
+                VerticalDivider(
+                    modifier = Modifier.width(width = dimension.grid_1),
+                    thickness = Dp.Hairline,
+                )
+
                 LatestTariffsCard(
                     modifier = Modifier
                         .weight(1f)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
@@ -194,6 +195,7 @@ fun UsageScreen(
                                 item(key = "tariffAndProjections") {
                                     TariffProjectionsCardAdaptive(
                                         modifier = Modifier
+                                            .background(color = CardDefaults.cardColors().containerColor)
                                             .fillMaxWidth()
                                             .padding(
                                                 horizontal = dimension.grid_3,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TariffProjectionsCardAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TariffProjectionsCardAdaptive.kt
@@ -13,18 +13,20 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.domain.model.product.Tariff
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
@@ -86,9 +88,19 @@ private fun TariffProjectionsCardLinear(
         }
 
         insights?.let { insights ->
+            HorizontalDivider(
+                modifier = Modifier.height(height = dimension.grid_1),
+                thickness = Dp.Hairline,
+            )
+
             InsightsCard(
                 modifier = Modifier.fillMaxWidth(),
                 insights = insights,
+            )
+
+            HorizontalDivider(
+                modifier = Modifier.height(height = dimension.grid_1),
+                thickness = Dp.Hairline,
             )
 
             ProjectedConsumptionCard(
@@ -130,7 +142,10 @@ private fun TariffProjectionsCardThreeColumns(
             }
 
             insights?.let { insights ->
-                Spacer(modifier = Modifier.width(width = dimension.grid_1))
+                VerticalDivider(
+                    modifier = Modifier.width(width = dimension.grid_1),
+                    thickness = Dp.Hairline,
+                )
 
                 InsightsCard(
                     modifier = Modifier
@@ -139,7 +154,10 @@ private fun TariffProjectionsCardThreeColumns(
                     insights = insights,
                 )
 
-                Spacer(modifier = Modifier.width(width = dimension.grid_1))
+                VerticalDivider(
+                    modifier = Modifier.width(width = dimension.grid_1),
+                    thickness = Dp.Hairline,
+                )
 
                 ProjectedConsumptionCard(
                     modifier = Modifier


### PR DESCRIPTION
This is a very small UI retouch:
- Removed `Card()` that wraps individual widgets
- Applied a global background colour to the widget row
- Added horizontal/vertical divider between widgets as a separator

This can make the widget less awkward on extra wide screens.
There is a newer UI design for this, but I am unsure if I have the time to implement it, so this change is better than none for now.