### PR TITLE
Agile Screen: Showing unit rates up to 23:00 the next day

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.kt
@@ -14,6 +14,7 @@ import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.atTime
 import kotlinx.datetime.format
 import kotlinx.datetime.format.DayOfWeekNames
 import kotlinx.datetime.format.MonthNames
@@ -75,6 +76,24 @@ fun Instant.atEndOfDay(): Instant {
         .plus(period = DatePeriod(days = 1))
         .atStartOfDayIn(timeZone = TimeZone.currentSystemDefault())
         .minus(value = 1, unit = DateTimeUnit.NANOSECOND)
+}
+
+/***
+ * Agile Unit Rates up to 23:00 the next day are published around 16:00 every day.
+ * It is no use requesting anything we know it's not available.
+ */
+fun Instant.getAgileClosingTime(): Instant {
+    val londonTimeZone = TimeZone.of("Europe/London")
+    val londonDateTime = this.toLocalDateTime(londonTimeZone)
+    val fifteenOClockToday = londonDateTime.date.atTime(hour = 15, minute = 0)
+    val closingTimeToday = londonDateTime.date.atTime(hour = 23, minute = 0)
+
+    if (londonDateTime < fifteenOClockToday) {
+        return closingTimeToday.toInstant(londonTimeZone)
+    }
+
+    val closingTimeTomorrow = (londonDateTime.date + DatePeriod(days = 1)).atTime(23, 0)
+    return closingTimeTomorrow.toInstant(londonTimeZone)
 }
 
 fun Instant.getDayRange(): ClosedRange<Instant> = atStartOfDay()..atEndOfDay()

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import com.rwmobi.kunigami.domain.exceptions.IncompleteCredentialsException
 import com.rwmobi.kunigami.domain.extensions.atStartOfHour
+import com.rwmobi.kunigami.domain.extensions.getAgileClosingTime
 import com.rwmobi.kunigami.domain.extensions.getLocalDateString
 import com.rwmobi.kunigami.domain.model.account.UserProfile
 import com.rwmobi.kunigami.domain.model.product.Tariff
@@ -38,7 +39,6 @@ import kotlinx.datetime.Clock
 import kotlin.math.ceil
 import kotlin.math.floor
 import kotlin.math.min
-import kotlin.time.Duration
 
 class AgileViewModel(
     private val getLatestProductByKeywordUseCase: GetLatestProductByKeywordUseCase,
@@ -147,7 +147,7 @@ class AgileViewModel(
         region: RetailRegion,
     ) {
         val currentTime = Clock.System.now().atStartOfHour()
-        val periodTo = currentTime.plus(duration = Duration.parse("1d"))
+        val periodTo = currentTime.getAgileClosingTime()
 
         getStandardUnitRateUseCase(
             tariffCode = "E-1R-$productCode-${region.code}",

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
@@ -56,6 +56,9 @@ class AgileViewModel(
     private val fallBackFlexibleProductCode = "VAR-22-11-01"
     private val demoRetailRegion = RetailRegion.EASTERN_ENGLAND
 
+    private var cachedFixedProductCode: String? = null
+    private var cachedFlexibleProductCode: String? = null
+
     fun errorShown(errorId: Long) {
         _uiState.update { currentUiState ->
             val errorMessages = currentUiState.errorMessages.filterNot { it.id == errorId }
@@ -233,7 +236,8 @@ class AgileViewModel(
      * Best effort to fetch reference tariffs for comparison. No harm if it fails, so it won't stop loading.
      */
     private suspend fun fetchReferenceTariffs(region: RetailRegion) {
-        val fixedProductCode = getLatestProductByKeywordUseCase(keyword = "OE-FIX-12M") ?: fallBackFixedProductCode
+        cachedFixedProductCode = cachedFixedProductCode ?: getLatestProductByKeywordUseCase(keyword = "OE-FIX-12M")
+        val fixedProductCode = cachedFixedProductCode ?: fallBackFixedProductCode
         getTariffRatesUseCase(
             tariffCode = "E-1R-$fixedProductCode-${region.code}",
         ).fold(
@@ -254,7 +258,8 @@ class AgileViewModel(
             },
         )
 
-        val flexibleProductCode = getLatestProductByKeywordUseCase(keyword = "VAR-") ?: fallBackFlexibleProductCode
+        cachedFlexibleProductCode = cachedFlexibleProductCode ?: getLatestProductByKeywordUseCase(keyword = "VAR-")
+        val flexibleProductCode = cachedFlexibleProductCode ?: fallBackFlexibleProductCode
         getTariffRatesUseCase(
             tariffCode = "E-1R-$flexibleProductCode-${region.code}",
         ).fold(

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensionsKtTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensionsKtTest.kt
@@ -237,4 +237,56 @@ class InstantExtensionsKtTest {
         val oneDayRangeSlots = oneDayRange.getHalfHourlyTimeSlotCount()
         assertEquals(expected = 48, actual = oneDayRangeSlots)
     }
+
+    @Test
+    fun `getAgileClosingTime should return 23_00 today when current time is before 15_00`() {
+        // Current time is 2024-08-30T10:00:00 in London time
+        val currentTime = LocalDateTime(2024, 8, 30, 10, 0, 0).toInstant(londonZone)
+
+        // Expected result is 2024-08-30T23:00:00 in London time
+        val expectedClosingTime = LocalDateTime(2024, 8, 30, 23, 0, 0).toInstant(londonZone)
+
+        val actualClosingTime = currentTime.getAgileClosingTime()
+
+        assertEquals(expectedClosingTime, actualClosingTime)
+    }
+
+    @Test
+    fun `getAgileClosingTime should return 23_00 tomorrow when current time is after 15_00`() {
+        // Current time is 2024-08-30T16:00:00 in London time
+        val currentTime = LocalDateTime(2024, 8, 30, 16, 0, 0).toInstant(londonZone)
+
+        // Expected result is 2024-08-31T23:00:00 in London time
+        val expectedClosingTime = LocalDateTime(2024, 8, 31, 23, 0, 0).toInstant(londonZone)
+
+        val actualClosingTime = currentTime.getAgileClosingTime()
+
+        assertEquals(expectedClosingTime, actualClosingTime)
+    }
+
+    @Test
+    fun `getAgileClosingTime should handle the transition from GMT to BST correctly`() {
+        // Current time is 2024-03-30T14:00:00 in London time (before BST starts)
+        val currentTime = LocalDateTime(2024, 3, 30, 14, 0, 0).toInstant(londonZone)
+
+        // Expected result is 2024-03-30T23:00:00 in London time (still GMT)
+        val expectedClosingTime = LocalDateTime(2024, 3, 30, 23, 0, 0).toInstant(londonZone)
+
+        val actualClosingTime = currentTime.getAgileClosingTime()
+
+        assertEquals(expectedClosingTime, actualClosingTime)
+    }
+
+    @Test
+    fun `getAgileClosingTime should return correct time on the day after BST starts`() {
+        // Current time is 2024-03-31T16:00:00 in London time (after BST starts)
+        val currentTime = LocalDateTime(2024, 3, 31, 16, 0, 0).toInstant(londonZone)
+
+        // Expected result is 2024-04-01T23:00:00 in London time (BST)
+        val expectedClosingTime = LocalDateTime(2024, 4, 1, 23, 0, 0).toInstant(londonZone)
+
+        val actualClosingTime = currentTime.getAgileClosingTime()
+
+        assertEquals(expectedClosingTime, actualClosingTime)
+    }
 }


### PR DESCRIPTION
- Implemented a temporary solution to cache the fixed and variable tariff code and rates to reduce API calls. This will be further improved to handle at repository level to enforce the single source of truth.
- Improved the Agile unit rate request date range, so that we request and show the rates up to 23:00 the next day if available.

Checked on iPhone SE2 (small screen) and confirmed KoalaPlot can properly render a packed graph.

![PHOTO-2024-08-30-17-44-55](https://github.com/user-attachments/assets/124ab312-865b-4231-b521-39a1c915a980)
