### PR TITLE
Minor UI retouch

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/MeterSerialNumberEntry.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/MeterSerialNumberEntry.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Density
 import com.rwmobi.kunigami.domain.extensions.getLocalDateString
-import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.domain.model.account.ElectricityMeter
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.theme.getDimension
@@ -115,7 +114,7 @@ internal fun MeterSerialNumberEntry(
                         Text(
                             modifier = Modifier.fillMaxWidth(),
                             style = MaterialTheme.typography.bodySmall,
-                            text = "$readingSource: ${value.roundToTwoDecimalPlaces()} (${readAt.getLocalDateString()})",
+                            text = "$readingSource: ${value.toInt()} (${readAt.getLocalDateString()})",
                         )
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/AgileTariffCardAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/AgileTariffCardAdaptive.kt
@@ -211,7 +211,9 @@ private fun AgileTariffCardCompact(
             )
 
             LatestTariffsCard(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = dimension.grid_1),
                 latestFlexibleTariff = latestFlexibleTariff,
                 latestFixedTariff = latestFixedTariff,
                 latestFlexibleTariffColor = cyanish,
@@ -284,7 +286,8 @@ private fun AgileTariffCardExpanded(
                 LatestTariffsCard(
                     modifier = Modifier
                         .weight(1f)
-                        .fillMaxHeight(),
+                        .fillMaxHeight()
+                        .padding(horizontal = dimension.grid_1),
                     latestFlexibleTariff = latestFlexibleTariff,
                     latestFixedTariff = latestFixedTariff,
                     latestFlexibleTariffColor = cyanish,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/LatestTariffsCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/LatestTariffsCard.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.text.font.FontWeight
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.domain.model.product.Tariff
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
-import com.rwmobi.kunigami.ui.components.WidgetCard
 import com.rwmobi.kunigami.ui.previewsampledata.TariffSamples
 import com.rwmobi.kunigami.ui.theme.cyanish
 import com.rwmobi.kunigami.ui.theme.getDimension
@@ -48,42 +47,42 @@ internal fun LatestTariffsCard(
 ) {
     val dimension = LocalDensity.current.getDimension()
 
-    WidgetCard(
+    Column(
         modifier = modifier,
-        contents = {
-            FlowRow(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_1),
-                verticalArrangement = Arrangement.spacedBy(space = dimension.grid_1),
-            ) {
-                latestFlexibleTariff?.let { tariff ->
-                    tariff.vatInclusiveStandardUnitRate?.let { unitRate ->
-                        TariffEntry(
-                            modifier = Modifier
-                                .widthIn(min = dimension.windowWidthCompactOneThird)
-                                .weight(1f),
-                            tariff = tariff,
-                            unitRate = unitRate,
-                            indicatorColor = latestFlexibleTariffColor,
-                        )
-                    }
-                }
-
-                latestFixedTariff?.let { tariff ->
-                    tariff.vatInclusiveStandardUnitRate?.let { unitRate ->
-                        TariffEntry(
-                            modifier = Modifier
-                                .widthIn(min = dimension.windowWidthCompactOneThird)
-                                .weight(1f),
-                            tariff = tariff,
-                            unitRate = unitRate,
-                            indicatorColor = latestFixedTariffColor,
-                        )
-                    }
+        verticalArrangement = Arrangement.Center,
+    ) {
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_1),
+            verticalArrangement = Arrangement.spacedBy(space = dimension.grid_1),
+        ) {
+            latestFlexibleTariff?.let { tariff ->
+                tariff.vatInclusiveStandardUnitRate?.let { unitRate ->
+                    TariffEntry(
+                        modifier = Modifier
+                            .widthIn(min = dimension.windowWidthCompactOneThird)
+                            .weight(1f),
+                        tariff = tariff,
+                        unitRate = unitRate,
+                        indicatorColor = latestFlexibleTariffColor,
+                    )
                 }
             }
-        },
-    )
+
+            latestFixedTariff?.let { tariff ->
+                tariff.vatInclusiveStandardUnitRate?.let { unitRate ->
+                    TariffEntry(
+                        modifier = Modifier
+                            .widthIn(min = dimension.windowWidthCompactOneThird)
+                            .weight(1f),
+                        tariff = tariff,
+                        unitRate = unitRate,
+                        indicatorColor = latestFixedTariffColor,
+                    )
+                }
+            }
+        }
+    }
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/LatestTariffsCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/LatestTariffsCard.kt
@@ -21,7 +21,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
@@ -98,9 +98,10 @@ private fun TariffEntry(
             .fillMaxWidth()
             .drawBehind {
                 val width = dimension.grid_2.toPx()
-                drawRect(
+                drawCircle(
                     color = indicatorColor,
-                    size = Size(width, size.height),
+                    radius = width / 2f,
+                    center = Offset(x = width / 2f, y = size.height / 2f),
                 )
             }
             .padding(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/NavigationOptionsBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/NavigationOptionsBar.kt
@@ -46,19 +46,19 @@ internal fun NavigationOptionsBar(
             modifier = Modifier
                 .background(color = MaterialTheme.colorScheme.surfaceContainerLow)
                 .fillMaxWidth()
-                .height(height = dimension.minListItemHeight)
-                .padding(horizontal = dimension.grid_2),
+                .height(height = dimension.minListItemHeight),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             selectedMpan?.let { mpan ->
                 Icon(
                     modifier = Modifier
                         .size(size = dimension.grid_4)
-                        .padding(end = dimension.grid_1),
+                        .padding(start = dimension.grid_2),
                     painter = painterResource(resource = Res.drawable.dashboard),
                     contentDescription = null,
                 )
                 Text(
+                    modifier = Modifier.padding(start = dimension.grid_1),
                     style = MaterialTheme.typography.bodyMedium,
                     text = mpan,
                 )


### PR DESCRIPTION
Polishing the UI for the upcoming release.
- Updated spacing of tariffs card on Agile Screen, Navigation options bar on Usage Screen
- Changed to show meter reading in integer without decimal
- Replaced rectangular colour blocks with dots for AgileScreen tariff legends

Note that the current dependency versions are in a strange state that the project can't properly run on Desktop. Android is fine. However, it is not in the scope of this ticket to fix them.