### PR TITLE
(#310) update readme and copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,54 +1,86 @@
-Copyright 2024 Ryan Wong, RW MobiMedia UK Limited, and open-source contributors
+Copyright 2024 RW MobiMedia UK Limited, and open-source contributors
 
 Mozilla Public License Version 2.0 (MPL-2.0)
 
 1. Definitions
 
 1.1. "Contributor"
-    means each individual or legal entity that creates, contributes to the creation of, or owns Covered Software.
+    means each individual or legal entity that creates, contributes to the
+    creation of, or owns Covered Software.
 
 1.2. "Contributor Version"
-    means the combination of the Contributions of others (if any) used by a Contributor and that particular Contributor's Contribution.
+    means the combination of the Contributions of others (if any) used by
+    a Contributor and that particular Contributor's Contribution.
 
 1.3. "Contribution"
     means Covered Software of a particular Contributor.
 
 1.4. "Covered Software"
-    means Source Code Form to which the initial Contributor has attached the notice in Exhibit A, the Executable Form of such Source Code Form, and Modifications of such Source Code Form, in each case including portions thereof.
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code Form,
+    and Modifications of such Source Code Form, in each case including
+    portions thereof.
 
 1.5. "Executable Form"
     means any form of the work other than Source Code Form.
 
 1.6. "Non-Commercial Use"
-    means any use of the work that is not primarily intended for or directed towards commercial advantage or monetary compensation.
+    means any use of the work that is not primarily intended for or directed
+    towards commercial advantage or monetary compensation.
 
 1.7. "Source Code Form"
     means the form of the work preferred for making modifications.
 
 1.8. "You" (or "Your")
-    means an individual or a legal entity exercising rights under this License. For legal entities, "You" includes any entity that controls, is controlled by, or is under common control with You. For purposes of this definition, "control" means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of more than fifty percent (50%) of the outstanding shares or beneficial ownership of such entity.
+    means an individual or a legal entity exercising rights under this License.
+    For legal entities, "You" includes any entity that controls, is controlled
+    by, or is under common control with You. For purposes of this definition,
+    "control" means (a) the power, direct or indirect, to cause the direction
+    or management of such entity, whether by contract or otherwise, or (b)
+    ownership of more than fifty percent (50%) of the outstanding shares or
+    beneficial ownership of such entity.
 
 2. License Grants and Conditions
 
 2.1. Grants
 
-Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:
+Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive
+license:
 
-(a) under intellectual property rights (other than patent or trademark) Licensable by such Contributor to use, reproduce, make available, modify, display, perform, distribute, and otherwise exploit its Contributions, either on an unmodified basis, with Modifications, or as part of a Larger Work; and
+(a) under intellectual property rights (other than patent or trademark)
+Licensable by such Contributor to use, reproduce, make available, modify,
+display, perform, distribute, and otherwise exploit its Contributions, either
+on an unmodified basis, with Modifications, or as part of a Larger Work; and
 
-(b) under Patent Claims of such Contributor to make, use, sell, offer for sale, have made, import, and otherwise transfer either its Contributions or its Contributor Version.
+(b) under Patent Claims of such Contributor to make, use, sell, offer for
+sale, have made, import, and otherwise transfer either its Contributions or
+its Contributor Version.
 
 2.2. Non-Commercial Use
 
-You are not permitted to use the Covered Software for commercial purposes. This includes, but is not limited to, selling the software, incorporating the software into a product for sale, or offering services involving the software. You are also prohibited from uploading the software to the Apple App Store, Google Play Store, or any other commercial app marketplace.
+You are not permitted to use the Covered Software for commercial purposes
+without the prior written permission of RW MobiMedia UK Limited. This
+includes, but is not limited to, selling the software, incorporating the
+software into a product for sale, or offering services involving the
+software. Commercial distribution of the software or its derivatives is
+prohibited, including uploading the software to the Apple App Store, Google
+Play Store, or any other commercial app marketplace, unless authorised by RW
+MobiMedia UK Limited.
 
 2.3. Attribution
 
-You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+You must give appropriate credit to RW MobiMedia UK Limited and any open-source
+contributors, provide a link to the license, and indicate if changes were made.
+Attribution must be displayed in a prominent manner in any distributed or published
+form of the software, including but not limited to the about page of an application
+or documentation files. You may do so in any reasonable manner, but not in any way
+that suggests RW MobiMedia UK Limited or any contributors endorse you or your use.
 
 2.4. Modifications
 
-If You create Modifications, and such Modifications are not Covered Software, You agree to release the Modifications under this License or a Compatible License.
+If You create Modifications, and such Modifications are not Covered Software,
+You agree to release the Modifications under this License or a Compatible
+License.
 
 3. Compliance with Laws
 
@@ -56,16 +88,30 @@ You must comply with all applicable laws regarding use of the software.
 
 4. Disclaimer of Warranty
 
-Covered Software is provided under this License on an "as is" basis, without warranty of any kind, either expressed, implied, or statutory, including, without limitation, warranties that the Covered Software is free of defects, merchantable, fit for a particular purpose or non-infringing.
+Covered Software is provided under this License on an "as is" basis, without
+warranty of any kind, either expressed, implied, or statutory, including,
+without limitation, warranties that the Covered Software is free of defects,
+merchantable, fit for a particular purpose or non-infringing.
 
 5. Limitation of Liability
 
-To the extent permitted by applicable law, no Contributor will be liable to You for any damages, including direct, indirect, special, incidental, or consequential damages arising out of or related to this License or the use or inability to use the Covered Software (including but not limited to loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+To the extent permitted by applicable law, no Contributor will be liable to
+You for any damages, including direct, indirect, special, incidental, or
+consequential damages arising out of or related to this License or the use or
+inability to use the Covered Software (including but not limited to loss of
+goodwill, work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor has been
+advised of the possibility of such damages.
 
 6. Termination
 
-The rights granted under this License will terminate automatically if You fail to comply with any of its terms. Upon termination, You must cease all use of the Covered Software and destroy all copies of it.
+The rights granted under this License will terminate automatically if You
+fail to comply with any of its terms. Upon termination, You must cease all
+use of the Covered Software and destroy all copies of it.
 
 7. Miscellaneous
 
-This License represents the complete agreement concerning subject matter hereof. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable.
+This License represents the complete agreement concerning subject matter
+hereof. If any provision of this License is held to be unenforceable, such
+provision shall be reformed only to the extent necessary to make it
+enforceable.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## _[Project Kunigami](https://maps.app.goo.gl/cdZWxxSgx8jM5QZC7)_ / <br/>OctoMeter: Empowering Smart Electricity Usage<br/>[![Pull request](https://img.shields.io/badge/PRs-welcome-success?style=flat)](https://github.com/ryanw-mobile/OctoMeter/pulls) ![GitHub Repo stars](https://img.shields.io/github/stars/ryanw-mobile/OctoMeter?style=flat) ![Gradle Build](https://github.com/ryanw-mobile/OctoMeter/actions/workflows/main_build.yml/badge.svg) [![Codacy Coverage Badge](https://app.codacy.com/project/badge/Coverage/76861cc9ba88455d9c7eb1abd856b056)](https://app.codacy.com/gh/ryanw-mobile/OctoMeter/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage) [![Codacy Grade Badge](https://app.codacy.com/project/badge/Grade/76861cc9ba88455d9c7eb1abd856b056)](https://app.codacy.com/gh/ryanw-mobile/OctoMeter/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade) [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
+## OctoMeter: Empowering Smart Electricity Usage<br/>[![Pull request](https://img.shields.io/badge/PRs-welcome-success?style=flat)](https://github.com/ryanw-mobile/OctoMeter/pulls) ![GitHub Repo stars](https://img.shields.io/github/stars/ryanw-mobile/OctoMeter?style=flat) ![Gradle Build](https://github.com/ryanw-mobile/OctoMeter/actions/workflows/main_build.yml/badge.svg) [![Codacy Coverage Badge](https://app.codacy.com/project/badge/Coverage/76861cc9ba88455d9c7eb1abd856b056)](https://app.codacy.com/gh/ryanw-mobile/OctoMeter/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage) [![Codacy Grade Badge](https://app.codacy.com/project/badge/Grade/76861cc9ba88455d9c7eb1abd856b056)](https://app.codacy.com/gh/ryanw-mobile/OctoMeter/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade) [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
 
 ### Production-grade Kotlin Multiplatform App targeting Desktop, Android, iOS
 
@@ -25,8 +25,8 @@ The main purposes of this app are:
   refresh.
 * Browse available Octopus Energy tariffs.
 
-This is a fully functional app that I developed for myself. **I use it every day** to monitor energy
-consumption and save money. For this reason, the app was intentionally built to reach
+This is a fully functional app that I developed for myself. **I use it every day** and my energy
+expenses have reduced by more than 50%. For this reason, the app was intentionally built to reach
 production-level quality as much as possible.
 
 * While it should technically work for some other Octopus Energy customers, I do not have enough
@@ -55,15 +55,8 @@ or [on LinkedIn](https://www.linkedin.com/in/ryanwmobile/).
 
 ## Running the app
 
-I use Android Studio Koala to build the Android and Deskop apps. Xcode 15.4 for iOS.
-
-> [!TIP]
-> Octopus Energy/Kraken don't prefer UI-sharing. While this app is primarily designed for desktop
-> use, it leverages CMP to provide mobile versions as well. This decision does not reflect my
-> personal
-> preferences; it simply reflects the budgetary constraints that prevent me from developing in
-> SwiftUI
-> for this project.
+The project dependencies are maintained by Renovate. By default, the app builds on the latest Xcode 
+and Android Studio.
 
 All downloadables are provided under
 the [Release Section](https://github.com/ryanw-mobile/OctoMeter/releases).
@@ -85,10 +78,9 @@ the [Release Section](https://github.com/ryanw-mobile/OctoMeter/releases).
 Planned enhancements are logged as [issues](https://github.com/ryanw-mobile/OctoMeter/issues).
 
 > [!NOTE]
-> I am currently seeking my next Senior Android Developer role and maintaining this project at my
-> own expense with a limited budget. Octopus Energy and Kraken HR have my CV on file. If I end up
-> working with them, I plan to enhance this project to address a wider range of customer use cases.
-> Otherwise, it will transition to maintenance mode once I am no longer an Octopus Energy customer.
+> I am actively seeking my next full-time Senior Android Developer role. Due to budget constraints, 
+> major feature development may be delayed. If you know of any suitable opportunities in the UK, 
+> I would greatly appreciate your referral.
 
 ### RestAPI and GraphQL
 
@@ -120,9 +112,7 @@ at [https://octopus.energy/dashboard/new/accounts/personal-details/api-access](h
 This app never asks for your Octopus customer account password, and you can always generate a new
 API key to invalidate the old keys.
 
-This app stores your API key, account number, MPAN and meter serial number
-using `EncryptedSharedPreferences` on Android, or the Keychain on iOS. On desktop, these credentials
-are currently unencrypted, but expected to do so when the library we use supports it.
+This app does not have write access to any of your customer data kept at Octopus Energy's systems.
 
 <br /><br />
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -361,7 +361,7 @@ compose.desktop {
             packageName = productName
             packageVersion = libs.versions.versionName.get()
             description = "OctoMeter: Empowering Smart Electricity Usage"
-            copyright = "© 2024 Ryan Wong and open source contributors. All rights reserved."
+            copyright = "© 2024 RW MobiMedia UK Limited. All rights reserved."
             vendor = "RW MobiMedia UK Limited"
             licenseFile.set(project.file("../LICENSE"))
             includeAllModules = true

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 import com.android.build.api.dsl.ManagedVirtualDevice

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/rwmobi/kunigami/ui/MainActivityTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/rwmobi/kunigami/ui/MainActivityTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/rwmobi/kunigami/ui/MainActivityTestRobot.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/rwmobi/kunigami/ui/MainActivityTestRobot.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/rwmobi/kunigami/ui/components/IconTextButtonPreview.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/rwmobi/kunigami/ui/components/IconTextButtonPreview.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/rwmobi/kunigami/ui/components/IndicatorTextValueGridItemPreview.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/rwmobi/kunigami/ui/components/IndicatorTextValueGridItemPreview.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/rwmobi/kunigami/ui/components/SquareButtonPreview.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/rwmobi/kunigami/ui/components/SquareButtonPreview.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/rwmobi/kunigami/ui/test/ComposePagerTestRule.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/rwmobi/kunigami/ui/test/ComposePagerTestRule.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.test

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/rwmobi/kunigami/ui/test/SemanticsMatchers.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/rwmobi/kunigami/ui/test/SemanticsMatchers.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.test

--- a/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/KunigamiApplication.kt
+++ b/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/KunigamiApplication.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami

--- a/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/MainActivity.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024. RW MobiMedia UK Limited
+ *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
+ */
+
 package com.rwmobi.kunigami
 
 import android.app.Activity

--- a/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/data/source/local/preferences/ProvideSettings.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/data/source/local/preferences/ProvideSettings.android.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.preferences

--- a/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/di/PlatformModule.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/di/PlatformModule.android.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.di

--- a/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.android.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.extensions

--- a/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/components/ScrollbarMultiplatform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/components/ScrollbarMultiplatform.android.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/composehelper/CollectAsStateMultiplatform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/composehelper/CollectAsStateMultiplatform.android.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper

--- a/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/composehelper/GetScreenSizeInfo.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/composehelper/GetScreenSizeInfo.android.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper

--- a/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/composehelper/ShouldUseDarkTheme.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/composehelper/ShouldUseDarkTheme.android.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper

--- a/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/extensions/GenerateRandomLong.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/extensions/GenerateRandomLong.android.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.extensions

--- a/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.android.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.extensions

--- a/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/extensions/WindowSizeClassExtensions.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/extensions/WindowSizeClassExtensions.android.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.extensions

--- a/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/theme/ProvideBodyFontFamily.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/theme/ProvideBodyFontFamily.android.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.theme

--- a/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/theme/ProvideDisplayFontFamily.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/rwmobi/kunigami/ui/theme/ProvideDisplayFontFamily.android.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.theme

--- a/composeApp/src/androidMain/res/values-night/colors.xml
+++ b/composeApp/src/androidMain/res/values-night/colors.xml
@@ -1,8 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2024. Ryan Wong
-  ~ https://github.com/ryanw-mobile
-  ~ Sponsored by RW MobiMedia UK Limited
+  ~ Copyright (c) 2024. RW MobiMedia UK Limited
   ~
+  ~ Contributions made by other developers remain the property of their respective authors but are licensed
+  ~ to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+  ~ the LICENSE file.
+  ~
+  ~ RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+  ~ Reuse of this source code, with or without modifications, requires proper attribution to
+  ~ RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+  ~ permission from RW MobiMedia UK Limited is prohibited.
+  ~
+  ~ Please refer to the LICENSE file for the full terms and conditions.
   -->
 
 <resources>

--- a/composeApp/src/androidMain/res/values/colors.xml
+++ b/composeApp/src/androidMain/res/values/colors.xml
@@ -1,8 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2024. Ryan Wong
-  ~ https://github.com/ryanw-mobile
-  ~ Sponsored by RW MobiMedia UK Limited
+  ~ Copyright (c) 2024. RW MobiMedia UK Limited
   ~
+  ~ Contributions made by other developers remain the property of their respective authors but are licensed
+  ~ to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+  ~ the LICENSE file.
+  ~
+  ~ RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+  ~ Reuse of this source code, with or without modifications, requires proper attribution to
+  ~ RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+  ~ permission from RW MobiMedia UK Limited is prohibited.
+  ~
+  ~ Please refer to the LICENSE file for the full terms and conditions.
   -->
 
 <resources>

--- a/composeApp/src/androidMain/res/values/themes.xml
+++ b/composeApp/src/androidMain/res/values/themes.xml
@@ -1,8 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2024. Ryan Wong
-  ~ https://github.com/ryanw-mobile
-  ~ Sponsored by RW MobiMedia UK Limited
+  ~ Copyright (c) 2024. RW MobiMedia UK Limited
   ~
+  ~ Contributions made by other developers remain the property of their respective authors but are licensed
+  ~ to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+  ~ the LICENSE file.
+  ~
+  ~ RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+  ~ Reuse of this source code, with or without modifications, requires proper attribution to
+  ~ RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+  ~ permission from RW MobiMedia UK Limited is prohibited.
+  ~
+  ~ Please refer to the LICENSE file for the full terms and conditions.
   -->
 
 <resources xmlns:tools="http://schemas.android.com/tools">

--- a/composeApp/src/androidUnitTest/kotlin/com/rwmobi/kunigami/data/source/local/database/dao/ConsumptionDaoTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/rwmobi/kunigami/data/source/local/database/dao/ConsumptionDaoTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 package com.rwmobi.kunigami.data.source.local.database.dao
 

--- a/composeApp/src/androidUnitTest/kotlin/com/rwmobi/kunigami/data/source/local/database/dao/RateDaoTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/rwmobi/kunigami/data/source/local/database/dao/RateDaoTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 package com.rwmobi.kunigami.data.source.local.database.dao
 

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1,8 +1,16 @@
 <!--
-  ~ Copyright (c) 2024. Ryan Wong
-  ~ https://github.com/ryanw-mobile
-  ~ Sponsored by RW MobiMedia UK Limited
+  ~ Copyright (c) 2024. RW MobiMedia UK Limited
   ~
+  ~ Contributions made by other developers remain the property of their respective authors but are licensed
+  ~ to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+  ~ the LICENSE file.
+  ~
+  ~ RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+  ~ Reuse of this source code, with or without modifications, requires proper attribution to
+  ~ RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+  ~ permission from RW MobiMedia UK Limited is prohibited.
+  ~
+  ~ Please refer to the LICENSE file for the full terms and conditions.
   -->
 
 <resources>

--- a/composeApp/src/commonMain/kotlin/androidx/compose/desktop/ui/tooling/preview/Preview.kt
+++ b/composeApp/src/commonMain/kotlin/androidx/compose/desktop/ui/tooling/preview/Preview.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package androidx.compose.desktop.ui.tooling.preview

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/App.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/DemoOctopusApiRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/DemoOctopusApiRepository.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.repository

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/GraphQLTokenRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/GraphQLTokenRepository.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.repository

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/OctopusGraphQLRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/OctopusGraphQLRepository.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.repository

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/OctopusUserPreferencesRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/OctopusUserPreferencesRepository.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.repository

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/AccountMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/AccountMapper.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.repository.mapper

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/ConsumptionMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/ConsumptionMapper.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.repository.mapper

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/ProductMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/ProductMapper.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.repository.mapper

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/RateMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/RateMapper.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.repository.mapper

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/TariffMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/TariffMapper.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.repository.mapper

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/cache/InMemoryCacheDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/cache/InMemoryCacheDataSource.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.cache

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/DatabaseTypeConverters.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/DatabaseTypeConverters.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.database

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/OctometerDatabase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/OctometerDatabase.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.database

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/RoomDatabaseDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/RoomDatabaseDataSource.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.database

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/dao/ConsumptionDao.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/dao/ConsumptionDao.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.database.dao

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/dao/RateDao.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/dao/RateDao.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.database.dao

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/entity/ConsumptionEntity.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/entity/ConsumptionEntity.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.database.entity

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/entity/RateEntity.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/entity/RateEntity.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.database.entity

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/interfaces/DatabaseDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/interfaces/DatabaseDataSource.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.database.interfaces

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/model/RateType.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/database/model/RateType.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.database.model

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/preferences/MultiplatformPreferencesStore.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/preferences/MultiplatformPreferencesStore.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.preferences

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/preferences/interfaces/PreferencesStore.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/preferences/interfaces/PreferencesStore.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.preferences.interfaces

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/LinkDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/LinkDto.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/account/AccountApiResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/account/AccountApiResponse.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/account/AgreementDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/account/AgreementDto.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/account/ElectricityMeterPointDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/account/ElectricityMeterPointDto.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/account/GasMeterPointDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/account/GasMeterPointDto.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/account/MeterDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/account/MeterDto.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/account/PropertyDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/account/PropertyDto.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/account/RegisterDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/account/RegisterDto.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/auth/Token.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/auth/Token.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.auth

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/consumption/ConsumptionApiResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/consumption/ConsumptionApiResponse.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.consumption

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/consumption/ConsumptionDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/consumption/ConsumptionDto.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.consumption

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/prices/PricesApiResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/prices/PricesApiResponse.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.prices

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/prices/RateDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/prices/RateDto.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.prices

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/products/ProductDetailsDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/products/ProductDetailsDto.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.products

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/products/ProductsApiResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/products/ProductsApiResponse.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.products

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/ConsumptionDetailDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/ConsumptionDetailDto.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.singleproduct

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/DualFuelConsumptionDetailDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/DualFuelConsumptionDetailDto.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.singleproduct

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/DualRateConsumptionDetailDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/DualRateConsumptionDetailDto.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.singleproduct

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/ElectricityRateQuotesDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/ElectricityRateQuotesDto.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.singleproduct

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/ElectricityTariffDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/ElectricityTariffDto.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.singleproduct

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/QuotesDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/QuotesDto.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.singleproduct

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/SampleConsumptionDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/SampleConsumptionDto.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.singleproduct

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/SampleQuotesDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/SampleQuotesDto.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.singleproduct

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/SingleProductApiResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/SingleProductApiResponse.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.singleproduct

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/TariffDetailsDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/dto/singleproduct/TariffDetailsDto.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.singleproduct

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/extensions/StringExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/extensions/StringExtensions.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.extensions

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/graphql/ApolloGraphQLEndpoint.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/graphql/ApolloGraphQLEndpoint.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.graphql

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/graphql/AuthorisationInterceptor.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/graphql/AuthorisationInterceptor.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.graphql

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/graphql/interfaces/GraphQLEndpoint.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/graphql/interfaces/GraphQLEndpoint.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.graphql.interfaces

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/restapi/AccountEndpoint.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/restapi/AccountEndpoint.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.restapi

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/restapi/ElectricityMeterPointsEndpoint.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/restapi/ElectricityMeterPointsEndpoint.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.restapi

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/restapi/ProductsEndpoint.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/restapi/ProductsEndpoint.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.restapi

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/DataSourceModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/DataSourceModule.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.di

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/DispatcherModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/DispatcherModule.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.di

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/GraphQLModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/GraphQLModule.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.di

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/KtorModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/KtorModule.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.di

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/RepositoryModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/RepositoryModule.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.di

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/UseCaseModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/UseCaseModule.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.di

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/ViewModelModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/di/ViewModelModule.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.di

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/exceptions/HttpException.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/exceptions/HttpException.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.exceptions

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/exceptions/IncompleteCredentialsException.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/exceptions/IncompleteCredentialsException.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.exceptions

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/exceptions/NoValidMeterException.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/exceptions/NoValidMeterException.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.exceptions

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/exceptions/RunCatchingException.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/exceptions/RunCatchingException.kt
@@ -1,5 +1,16 @@
 /*
- * Copyright (c) 2022-2024. Ryan Wong (hello@ryanwebmail.com)
+ * Copyright (c) 2022-2024. RW MobiMedia UK Limited
+ *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.exceptions

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/exceptions/TariffNotFoundException.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/exceptions/TariffNotFoundException.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.exceptions

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/DoubleExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/DoubleExtensions.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.extensions

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 package com.rwmobi.kunigami.domain.extensions
 

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/LocalDateTimeExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/LocalDateTimeExtensions.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.extensions

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/account/Account.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/account/Account.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/account/Agreement.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/account/Agreement.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/account/ElectricityMeter.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/account/ElectricityMeter.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/account/ElectricityMeterPoint.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/account/ElectricityMeterPoint.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/account/UserProfile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/account/UserProfile.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/consumption/Consumption.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/consumption/Consumption.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.consumption

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/consumption/ConsumptionDataOrder.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/consumption/ConsumptionDataOrder.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.consumption

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/consumption/ConsumptionTimeFrame.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/consumption/ConsumptionTimeFrame.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.consumption

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/consumption/ConsumptionWithCost.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/consumption/ConsumptionWithCost.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.consumption

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/ElectricityTariffType.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/ElectricityTariffType.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.product

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/ExitFeesType.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/ExitFeesType.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.product

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/ProductDetails.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/ProductDetails.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.product

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/ProductDirection.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/ProductDirection.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.product

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/ProductFeature.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/ProductFeature.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 @file:OptIn(ExperimentalResourceApi::class)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/ProductSummary.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/ProductSummary.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.product

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/Tariff.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/Tariff.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.product

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/TariffPaymentTerm.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/TariffPaymentTerm.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.product

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/rate/PaymentMethod.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/rate/PaymentMethod.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.rate

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/rate/Rate.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/rate/Rate.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.rate

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/repository/OctopusApiRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/repository/OctopusApiRepository.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.repository

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/repository/TokenRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/repository/TokenRepository.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.repository

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/repository/UserPreferencesRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/repository/UserPreferencesRepository.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.repository

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/account/ClearCacheUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/account/ClearCacheUseCase.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/account/GetDefaultPostcodeUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/account/GetDefaultPostcodeUseCase.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/account/InitialiseAccountUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/account/InitialiseAccountUseCase.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/account/SyncUserProfileUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/account/SyncUserProfileUseCase.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/account/UpdateMeterPreferenceUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/account/UpdateMeterPreferenceUseCase.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/consumption/GenerateUsageInsightsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/consumption/GenerateUsageInsightsUseCase.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.consumption

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/consumption/GetConsumptionAndCostUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/consumption/GetConsumptionAndCostUseCase.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.consumption

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetFilteredProductsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetFilteredProductsUseCase.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.product

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetLatestProductByKeywordUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetLatestProductByKeywordUseCase.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.product

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetStandardUnitRateUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetStandardUnitRateUseCase.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.product

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetTariffRatesUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetTariffRatesUseCase.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.product

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetTariffUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetTariffUseCase.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.product

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/AppBottomNavigationBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/AppBottomNavigationBar.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 package com.rwmobi.kunigami.ui.components
 

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/AppNavigationRail.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/AppNavigationRail.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 package com.rwmobi.kunigami.ui.components
 

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/CommonPreviewSetup.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/CommonPreviewSetup.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/DemoModeCtaAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/DemoModeCtaAdaptive.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/DualTitleBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/DualTitleBar.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/ErrorScreenHandler.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/ErrorScreenHandler.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/HorizontalAnimatedTintedPainterResource.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/HorizontalAnimatedTintedPainterResource.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/IconTextButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/IconTextButton.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/IndicatorTextValueGridItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/IndicatorTextValueGridItem.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/LabelValueRow.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/LabelValueRow.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/LargeTitleWithIcon.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/LargeTitleWithIcon.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/LoadingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/LoadingScreen.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/MessageActionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/MessageActionScreen.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 @file:OptIn(ExperimentalResourceApi::class)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/ScrollbarMultiplatform.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/ScrollbarMultiplatform.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/SquareButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/SquareButton.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TagWithIcon.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TagWithIcon.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TariffSummaryCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TariffSummaryCard.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/VerticalAnimatedTintedPainterResource.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/VerticalAnimatedTintedPainterResource.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/WidgetCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/WidgetCard.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/WidthAdaptiveLayout.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/WidthAdaptiveLayout.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/AxisLabel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/AxisLabel.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components.koalaplot

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/ChartTitle.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/ChartTitle.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components.koalaplot

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/VerticalBarChart.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/VerticalBarChart.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components.koalaplot

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/XAxisTitle.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/XAxisTitle.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components.koalaplot

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/YAxisTitle.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/YAxisTitle.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components.koalaplot

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/CollectAsStateMultiplatform.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/CollectAsStateMultiplatform.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/ColorExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/ColorExtensions.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/ConditionalBlur.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/ConditionalBlur.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/DrawArcSegment.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/DrawArcSegment.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/DrawHalfCircleArcSegment.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/DrawHalfCircleArcSegment.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/DrawPlainColorArc.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/DrawPlainColorArc.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/GetScreenSizeInfo.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/GetScreenSizeInfo.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/ShouldUseDarkTheme.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/ShouldUseDarkTheme.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/palette/GenerateFreezingBlueSpectrum.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/palette/GenerateFreezingBlueSpectrum.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper.palette

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/palette/GenerateGYRHueSpectrum.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/palette/GenerateGYRHueSpectrum.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper.palette

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/palette/RatePalette.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/palette/RatePalette.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper.palette

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountInformationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountInformationScreen.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 @file:OptIn(ExperimentalResourceApi::class)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountScreen.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountScreenLayoutStyle.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountScreenLayoutStyle.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountScreenType.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountScreenType.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountUIEvent.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountUIEvent.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountUIState.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountUIState.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.account

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/OnboardingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/OnboardingScreen.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 @file:OptIn(ExperimentalResourceApi::class, ExperimentalResourceApi::class)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/AppInfoFooter.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/AppInfoFooter.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.account.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/ClearCredentialSectionAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/ClearCredentialSectionAdaptive.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.account.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/CredentialsInputForm.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/CredentialsInputForm.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 @file:OptIn(ExperimentalResourceApi::class)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/ElectricityMeterPointCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/ElectricityMeterPointCard.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 @file:OptIn(ExperimentalResourceApi::class)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/MeterSerialNumberEntry.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/MeterSerialNumberEntry.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.account.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/SimpleTitleButtonCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/SimpleTitleButtonCard.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.account.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/TariffLayout.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/TariffLayout.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 @file:OptIn(ExperimentalResourceApi::class)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/UpdateApiKeyDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/UpdateApiKeyDialog.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.account.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.agile

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreenType.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreenType.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.agile

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileUIEvent.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileUIEvent.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.agile

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileUIState.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileUIState.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.agile

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/AgileTariffCardAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/AgileTariffCardAdaptive.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.agile.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/CurrentRateCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/CurrentRateCard.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.agile.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/DashboardWidget.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/DashboardWidget.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.agile.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/LatestTariffsCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/LatestTariffsCard.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.agile.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGaugeCountdownCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGaugeCountdownCard.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.agile.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupCells.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupCells.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.agile.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupTitle.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupTitle.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.agile.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffScreenLayoutStyle.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffScreenLayoutStyle.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.tariffs

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffsScreen.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.tariffs

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffsScreenType.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffsScreenType.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.tariffs

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffsUIEvent.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffsUIEvent.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.tariffs

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffsUIState.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffsUIState.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.tariffs

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/CloseButtonBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/CloseButtonBar.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.tariffs.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/PostcodeEditDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/PostcodeEditDialog.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.tariffs.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/PostcodeInputBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/PostcodeInputBar.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.tariffs.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductBottomSheetWrapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductBottomSheetWrapper.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.tariffs.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductFacts.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductFacts.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.tariffs.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductListItemAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductListItemAdaptive.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 @file:OptIn(ExperimentalLayoutApi::class)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductPaneWrapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductPaneWrapper.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.tariffs.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductScreenLayout.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductScreenLayout.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.tariffs.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductTariff.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductTariff.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.tariffs.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.usage

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreenType.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreenType.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.usage

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageUIEvent.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageUIEvent.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.usage

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageUIState.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageUIState.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.usage

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/AnimatedRatioBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/AnimatedRatioBar.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.usage.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/ConsumptionGroupCells.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/ConsumptionGroupCells.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.usage.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/InsightsCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/InsightsCard.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.usage.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/NavigationOptionsBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/NavigationOptionsBar.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.usage.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/PresentationStyleDropdownMenu.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/PresentationStyleDropdownMenu.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.usage.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/ProjectedConsumptionCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/ProjectedConsumptionCard.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.usage.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/RateGroupTitle.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/RateGroupTitle.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.usage.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TariffProjectionsCardAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TariffProjectionsCardAdaptive.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.usage.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TitleNavigationBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TitleNavigationBar.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.destinations.usage.components

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/extensions/GenerateRandomLong.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/extensions/GenerateRandomLong.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.extensions

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/extensions/ListExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/extensions/ListExtensions.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.extensions

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/extensions/PostcodeStringExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/extensions/PostcodeStringExtensions.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.extensions

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.extensions

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/extensions/WindowSizeClassExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/extensions/WindowSizeClassExtensions.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.extensions

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/ErrorMessage.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/ErrorMessage.kt
@@ -1,6 +1,16 @@
 /*
- * Copyright (c) 2022-2024. Ryan Wong
- * https://github.com/ryanw-mobile
+ * Copyright (c) 2022-2024. RW MobiMedia UK Limited
+ *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.model

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/PlatformType.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/PlatformType.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.model

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/ScreenSizeInfo.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/ScreenSizeInfo.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.model

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/SpecialErrorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/SpecialErrorScreen.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.model

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/chart/BarChartData.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/chart/BarChartData.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.model.chart

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/chart/RequestedChartLayout.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/chart/RequestedChartLayout.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.model.chart

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionGroupWithPartitions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionGroupWithPartitions.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.model.consumption

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionGroupedCells.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionGroupedCells.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.model.consumption

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionPresentationStyle.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionPresentationStyle.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.model.consumption

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.model.consumption

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/Insights.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/Insights.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.model.consumption

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/product/RetailRegion.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/product/RetailRegion.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.model.product

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/rate/RateGroup.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/rate/RateGroup.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.model.rate

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/rate/RateGroupWithPartitions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/rate/RateGroupWithPartitions.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.model.rate

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/rate/RateTrend.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/rate/RateTrend.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.model.rate

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/navigation/AppDestination.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/navigation/AppDestination.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.navigation

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/navigation/AppNavigationHost.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/navigation/AppNavigationHost.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.navigation

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/previewsampledata/AccountSamples.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/previewsampledata/AccountSamples.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.previewsampledata

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/previewsampledata/FakeDemoUserProfile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/previewsampledata/FakeDemoUserProfile.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.previewsampledata

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/previewsampledata/InsightsSamples.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/previewsampledata/InsightsSamples.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.previewsampledata

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/previewsampledata/TariffSamples.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/previewsampledata/TariffSamples.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.previewsampledata

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/Color.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/Color.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024. RW MobiMedia UK Limited
+ *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
+ */
+
 package com.rwmobi.kunigami.ui.theme
 
 import androidx.compose.ui.graphics.Color

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/Dimension.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/Dimension.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.theme

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/ProvideBodyFontFamily.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/ProvideBodyFontFamily.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.theme

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/ProvideDisplayFontFamily.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/ProvideDisplayFontFamily.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.theme

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/Theme.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/Theme.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024. RW MobiMedia UK Limited
+ *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
+ */
+
 package com.rwmobi.kunigami.ui.theme
 
 import androidx.compose.material3.MaterialTheme

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/Type.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/Type.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024. RW MobiMedia UK Limited
+ *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
+ */
+
 package com.rwmobi.kunigami.ui.theme
 
 import androidx.compose.material3.Typography

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/tools/MultiplatformStringResourceProvider.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/tools/MultiplatformStringResourceProvider.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 package com.rwmobi.kunigami.ui.tools
 

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/tools/interfaces/StringResourceProvider.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/tools/interfaces/StringResourceProvider.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 // In the :presentation module under ui/model package
 package com.rwmobi.kunigami.ui.tools.interfaces

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AccountViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AccountViewModel.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.viewmodels

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.viewmodels

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/TariffsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/TariffsViewModel.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.viewmodels

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModel.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.viewmodels

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/repository/DemoRestApiRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/repository/DemoRestApiRepositoryTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.repository

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/repository/GraphQLTokenRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/repository/GraphQLTokenRepositoryTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024. RW MobiMedia UK Limited
+ *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
+ */
+
 package com.rwmobi.kunigami.data.repository
 
 import com.rwmobi.kunigami.data.source.local.cache.InMemoryCacheDataSource

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/repository/OctopusGraphQLRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/repository/OctopusGraphQLRepositoryTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.repository

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/repository/OctopusUserPreferencesRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/repository/OctopusUserPreferencesRepositoryTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024. RW MobiMedia UK Limited
+ *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
+ */
+
 package com.rwmobi.kunigami.data.repository
 
 import androidx.compose.ui.unit.DpSize

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/cache/InMemoryCacheDataSourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/cache/InMemoryCacheDataSourceTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.cache

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/database/FakeDataBaseDataSource.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/database/FakeDataBaseDataSource.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.database

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/database/RoomDatabaseDataSourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/database/RoomDatabaseDataSourceTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 package com.rwmobi.kunigami.data.source.local.database
 

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/database/dao/FakeConsumptionDao.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/database/dao/FakeConsumptionDao.kt
@@ -1,15 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
- */
-
-/*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
  *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.database.dao

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/database/dao/FakeRateDao.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/database/dao/FakeRateDao.kt
@@ -1,15 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
- */
-
-/*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
  *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.database.dao

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/database/entity/RateEntityKtTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/database/entity/RateEntityKtTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.database.entity

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/preferences/FakePreferencesStore.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/local/preferences/FakePreferencesStore.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.preferences

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/dto/auth/TokenTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/dto/auth/TokenTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.dto.auth

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/graphql/FakeGraphQLEndpoint.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/graphql/FakeGraphQLEndpoint.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.graphql

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/restapi/AccountEndpointTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/restapi/AccountEndpointTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.restapi

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/restapi/ElectricityMeterPointsEndpointTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/restapi/ElectricityMeterPointsEndpointTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.restapi

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/restapi/ProductsEndpointTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/data/source/network/restapi/ProductsEndpointTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.network.restapi

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/DoubleExtensionsKtTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/DoubleExtensionsKtTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 import com.rwmobi.kunigami.domain.extensions.roundToNearestEvenHundredth

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensionsKtTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensionsKtTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.extensions

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/RateTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/RateTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/account/AccountTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/account/AccountTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024. RW MobiMedia UK Limited
+ *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
+ */
+
 package com.rwmobi.kunigami.domain.model.account
 
 import com.rwmobi.kunigami.ui.previewsampledata.AccountSamples

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/account/ElectricityMeterPointTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/account/ElectricityMeterPointTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024. RW MobiMedia UK Limited
+ *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
+ */
+
 package com.rwmobi.kunigami.domain.model.account
 
 import kotlinx.datetime.Clock

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/consumption/ConsumptionTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/consumption/ConsumptionTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.consumption

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/product/ExitFeesTypeTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/product/ExitFeesTypeTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.product

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/product/ProductDirectionTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/product/ProductDirectionTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.product

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/product/ProductFeatureTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/product/ProductFeatureTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.product

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/product/TariffTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/product/TariffTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.product

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/rate/PaymentMethodTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/rate/PaymentMethodTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.model.rate

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/rate/RateTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/model/rate/RateTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024. RW MobiMedia UK Limited
+ *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
+ */
+
 package com.rwmobi.kunigami.domain.model.rate
 
 import kotlinx.datetime.Instant

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/repository/FakeOctopusApiRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/repository/FakeOctopusApiRepository.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.repository

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/repository/FakeUserPreferencesRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/repository/FakeUserPreferencesRepository.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.repository

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/account/ClearCacheUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/account/ClearCacheUseCaseTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.account

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/account/GetDefaultPostcodeUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/account/GetDefaultPostcodeUseCaseTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.account

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/account/InitialiseAccountUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/account/InitialiseAccountUseCaseTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.account

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/account/SyncUserProfileUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/account/SyncUserProfileUseCaseTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.account

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/account/UpdateMeterPreferenceUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/account/UpdateMeterPreferenceUseCaseTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.account

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/consumption/GenerateUsageInsightsUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/consumption/GenerateUsageInsightsUseCaseTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.consumption

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/consumption/GetConsumptionAndCostUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/consumption/GetConsumptionAndCostUseCaseTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.consumption

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetFilteredProductsUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetFilteredProductsUseCaseTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.product

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetLatestProductByKeywordUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetLatestProductByKeywordUseCaseTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.product

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetStandardUnitRateUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetStandardUnitRateUseCaseTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.product

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetTariffRatesUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetTariffRatesUseCaseTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.product

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetTariffSummaryUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetTariffSummaryUseCaseTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.usecase.product

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/AccountSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/AccountSampleData.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.test.samples

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/ConsumptionEntitySampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/ConsumptionEntitySampleData.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.test.samples

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/ConsumptionSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/ConsumptionSampleData.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024. RW MobiMedia UK Limited
+ *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
+ */
+
 import com.rwmobi.kunigami.domain.model.consumption.Consumption
 import kotlinx.datetime.Instant
 

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/ConsumptionSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/ConsumptionSampleData.kt
@@ -16,13 +16,6 @@
 import com.rwmobi.kunigami.domain.model.consumption.Consumption
 import kotlinx.datetime.Instant
 
-/*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
- *
- */
-
 object ConsumptionSampleData {
     val randomSample = listOf(
         Consumption(kWhConsumed = 0.165235958596004, interval = Instant.parse("2024-08-22T23:00:00Z")..Instant.parse("2024-08-22T23:30:00Z")),

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetAccountSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetAccountSampleData.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.test.samples

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetConsumptionSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetConsumptionSampleData.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.test.samples

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetDayUnitRatesSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetDayUnitRatesSampleData.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.test.samples

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetNightUnitRatesSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetNightUnitRatesSampleData.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.test.samples

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetProductSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetProductSampleData.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.test.samples

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetProductsSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetProductsSampleData.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.test.samples

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetStandardUnitRatesSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetStandardUnitRatesSampleData.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.test.samples

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetStandingChargesSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetStandingChargesSampleData.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.test.samples

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetTariffSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetTariffSampleData.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.test.samples

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/RateEntitySampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/RateEntitySampleData.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 package com.rwmobi.kunigami.test.samples
 

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/RateSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/RateSampleData.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.test.samples

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/TariffSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/TariffSampleData.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.test.samples

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/extensions/ListExtensionsKtTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/extensions/ListExtensionsKtTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.extensions

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/extensions/PostcodeStringExtensionsKtTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/extensions/PostcodeStringExtensionsKtTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.extensions

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/StubStringResourceProvider.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/StubStringResourceProvider.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 package com.rwmobi.kunigami.ui.model
 

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionGroupedCellsTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionGroupedCellsTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024. RW MobiMedia UK Limited
+ *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
+ */
+
 package com.rwmobi.kunigami.ui.model.consumption
 
 import com.rwmobi.kunigami.domain.model.consumption.Consumption

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionPresentationStyleTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionPresentationStyleTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.model.consumption

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilterTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 package com.rwmobi.kunigami.ui.model.consumption
 

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/product/RetailRegionTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/product/RetailRegionTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024. RW MobiMedia UK Limited
+ *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
+ */
+
 package com.rwmobi.kunigami.ui.model.product
 
 import kotlin.test.Test

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/rate/RateGroupTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/model/rate/RateGroupTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024. RW MobiMedia UK Limited
+ *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
+ */
+
 package com.rwmobi.kunigami.ui.model.rate
 
 import com.rwmobi.kunigami.domain.model.rate.PaymentMethod

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/viewmodels/AccountViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/viewmodels/AccountViewModelTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024. RW MobiMedia UK Limited
+ *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
+ */
+
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.ui.geometry.Size

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModelTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/viewmodels/TariffsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/viewmodels/TariffsViewModelTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModelTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.viewmodels

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/Main.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/data/source/local/preferences/ProvideSettings.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/data/source/local/preferences/ProvideSettings.desktop.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.preferences

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/di/PlatformModule.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/di/PlatformModule.desktop.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.di

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.desktop.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.extensions

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/components/ScrollbarMultiplatform.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/components/ScrollbarMultiplatform.desktop.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/composehelper/CollectAsStateMultiplatform.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/composehelper/CollectAsStateMultiplatform.desktop.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/composehelper/CustomizeMacOsAboutMenu.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/composehelper/CustomizeMacOsAboutMenu.desktop.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/composehelper/GetScreenSizeInfo.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/composehelper/GetScreenSizeInfo.desktop.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/composehelper/ShouldUseDarkTheme.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/composehelper/ShouldUseDarkTheme.desktop.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/extensions/GenerateRandomLong.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/extensions/GenerateRandomLong.desktop.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.extensions

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.desktop.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.extensions

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/extensions/WindowSizeClassExtensions.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/extensions/WindowSizeClassExtensions.desktop.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.extensions

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/theme/ProvideBodyFontFamily.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/theme/ProvideBodyFontFamily.desktop.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.theme

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/theme/ProvideDisplayFontFamily.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/theme/ProvideDisplayFontFamily.desktop.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.theme

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/PlatformMainViewModel.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/PlatformMainViewModel.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.viewmodels

--- a/composeApp/src/desktopTest/kotlin/com/rwmobi/kunigami/ui/model/chart/BarChartDataTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/rwmobi/kunigami/ui/model/chart/BarChartDataTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.model.chart

--- a/composeApp/src/desktopTest/kotlin/com/rwmobi/kunigami/ui/viewmodels/PlatformMainViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/rwmobi/kunigami/ui/viewmodels/PlatformMainViewModelTest.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.viewmodels

--- a/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/MainViewController.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami

--- a/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/data/source/local/preferences/ProvideSettings.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/data/source/local/preferences/ProvideSettings.ios.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.data.source.local.preferences

--- a/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/di/KoinHelper.kt
+++ b/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/di/KoinHelper.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 package com.rwmobi.kunigami.di
 

--- a/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/di/PlatformModule.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/di/PlatformModule.ios.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.di

--- a/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/domain/extensions/InstantExtensions.ios.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.domain.extensions

--- a/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/components/ScrollbarMultiplatform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/components/ScrollbarMultiplatform.ios.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.components

--- a/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/composehelper/CollectAsStateMultiplatform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/composehelper/CollectAsStateMultiplatform.ios.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper

--- a/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/composehelper/GetScreenSizeInfo.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/composehelper/GetScreenSizeInfo.ios.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper

--- a/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/composehelper/ShouldUseDarkTheme.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/composehelper/ShouldUseDarkTheme.ios.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.composehelper

--- a/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/extensions/GenerateRandomLong.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/extensions/GenerateRandomLong.ios.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.extensions

--- a/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/extensions/ThrowableExtensions.ios.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.extensions

--- a/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/extensions/WindowSizeClassExtensions.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/extensions/WindowSizeClassExtensions.ios.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.extensions

--- a/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/theme/ProvideBodyFontFamily.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/theme/ProvideBodyFontFamily.ios.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.theme

--- a/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/theme/ProvideDisplayFontFamily.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/rwmobi/kunigami/ui/theme/ProvideDisplayFontFamily.ios.kt
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2024. Ryan Wong
- * https://github.com/ryanw-mobile
- * Sponsored by RW MobiMedia UK Limited
+ * Copyright (c) 2024. RW MobiMedia UK Limited
  *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
  */
 
 package com.rwmobi.kunigami.ui.theme

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,16 @@
 #
-# Copyright (c) 2024. Ryan Wong
-# https://github.com/ryanw-mobile
-# Sponsored by RW MobiMedia UK Limited
+# Copyright (c) 2024. RW MobiMedia UK Limited
 #
+# Contributions made by other developers remain the property of their respective authors but are licensed
+# to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+# the LICENSE file.
+#
+# RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+# Reuse of this source code, with or without modifications, requires proper attribution to
+# RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+# permission from RW MobiMedia UK Limited is prohibited.
+#
+# Please refer to the LICENSE file for the full terms and conditions.
 #
 kotlin.code.style=official
 #Gradle


### PR DESCRIPTION
Transferred the copyright ownership to RW MobiMedia UK Limited. 
Clarified the license terms as RW MobiMedia owns the right to distribute the app.
Simplified the README 