### PR TITLE
(#281) AgileScreen: cache API results to minimise refreshes

### DIFF
--- a/composeApp/composeApp.podspec
+++ b/composeApp/composeApp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'composeApp'
-    spec.version                  = '2.0.0'
+    spec.version                  = '2.1.0'
     spec.homepage                 = 'https://github.com/ryanw-mobile/OctoMeter/'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/cache/InMemoryCacheDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/cache/InMemoryCacheDataSource.kt
@@ -19,12 +19,14 @@ import com.rwmobi.kunigami.data.source.network.dto.auth.Token
 import com.rwmobi.kunigami.data.source.network.dto.auth.TokenState
 import com.rwmobi.kunigami.domain.extensions.toSystemDefaultLocalDate
 import com.rwmobi.kunigami.domain.model.account.Account
+import com.rwmobi.kunigami.domain.model.product.ProductSummary
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
 class InMemoryCacheDataSource {
     private var cachedProfile: Pair<Account, Instant>? = null
     private var cachedToken: Pair<String, Token>? = null
+    private var cachedProductSummary: Pair<String, List<ProductSummary>>? = null
 
     fun cacheProfile(account: Account, createdAt: Instant) {
         cachedProfile = Pair(account, createdAt)
@@ -32,6 +34,10 @@ class InMemoryCacheDataSource {
 
     fun cacheToken(apiKey: String, token: Token) {
         cachedToken = Pair(apiKey, token)
+    }
+
+    fun cacheProductSummary(postcode: String, productSummaries: List<ProductSummary>) {
+        cachedProductSummary = Pair(postcode, productSummaries)
     }
 
     /***
@@ -59,6 +65,18 @@ class InMemoryCacheDataSource {
                 null
             } else {
                 this.second
+            }
+        }
+    }
+
+    fun getProductSummary(postcode: String): List<ProductSummary>? {
+        return cachedProductSummary?.let {
+            if (it.first == postcode) {
+                it.second
+            } else {
+                // invalidate the cache to prevent the cached result staying for too long
+                cachedProductSummary = null
+                null
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/cache/InMemoryCacheDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/cache/InMemoryCacheDataSource.kt
@@ -19,6 +19,7 @@ import com.rwmobi.kunigami.data.source.network.dto.auth.Token
 import com.rwmobi.kunigami.data.source.network.dto.auth.TokenState
 import com.rwmobi.kunigami.domain.extensions.toSystemDefaultLocalDate
 import com.rwmobi.kunigami.domain.model.account.Account
+import com.rwmobi.kunigami.domain.model.product.ProductDetails
 import com.rwmobi.kunigami.domain.model.product.ProductSummary
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -27,6 +28,7 @@ class InMemoryCacheDataSource {
     private var profileCache: Pair<Account, Instant>? = null
     private var tokenCache: Pair<String, Token>? = null
     private var productSummaryCache: Pair<String, List<ProductSummary>>? = null
+    private var productDetailsCache: MutableMap<Pair<String, String>, ProductDetails> = mutableMapOf()
 
     fun cacheProfile(account: Account, createdAt: Instant) {
         profileCache = Pair(account, createdAt)
@@ -38,6 +40,11 @@ class InMemoryCacheDataSource {
 
     fun cacheProductSummary(postcode: String, productSummaries: List<ProductSummary>) {
         productSummaryCache = Pair(postcode, productSummaries)
+    }
+
+    fun cacheProductDetails(postcode: String, productCode: String, productDetails: ProductDetails) {
+        val key = Pair(postcode, productCode)
+        productDetailsCache[key] = productDetails
     }
 
     /***
@@ -81,9 +88,15 @@ class InMemoryCacheDataSource {
         }
     }
 
+    fun getProductDetails(postcode: String, productCode: String): ProductDetails? {
+        val key = Pair(postcode, productCode)
+        return productDetailsCache[key]
+    }
+
     fun clear() {
         profileCache = null
         tokenCache = null
         productSummaryCache = null
+        productDetailsCache.clear()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/cache/InMemoryCacheDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/cache/InMemoryCacheDataSource.kt
@@ -24,40 +24,40 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
 class InMemoryCacheDataSource {
-    private var cachedProfile: Pair<Account, Instant>? = null
-    private var cachedToken: Pair<String, Token>? = null
-    private var cachedProductSummary: Pair<String, List<ProductSummary>>? = null
+    private var profileCache: Pair<Account, Instant>? = null
+    private var tokenCache: Pair<String, Token>? = null
+    private var productSummaryCache: Pair<String, List<ProductSummary>>? = null
 
     fun cacheProfile(account: Account, createdAt: Instant) {
-        cachedProfile = Pair(account, createdAt)
+        profileCache = Pair(account, createdAt)
     }
 
     fun cacheToken(apiKey: String, token: Token) {
-        cachedToken = Pair(apiKey, token)
+        tokenCache = Pair(apiKey, token)
     }
 
     fun cacheProductSummary(postcode: String, productSummaries: List<ProductSummary>) {
-        cachedProductSummary = Pair(postcode, productSummaries)
+        productSummaryCache = Pair(postcode, productSummaries)
     }
 
     /***
      * Return cached profile, if there is an instance kept on the same day
      */
     fun getProfile(accountNumber: String): Account? {
-        return cachedProfile?.first?.let { account ->
+        return profileCache?.first?.let { account ->
             if (account.accountNumber == accountNumber &&
-                Clock.System.now().toSystemDefaultLocalDate() == cachedProfile?.second?.toSystemDefaultLocalDate()
+                Clock.System.now().toSystemDefaultLocalDate() == profileCache?.second?.toSystemDefaultLocalDate()
             ) {
                 account
             } else {
-                cachedProfile = null // clear the cache
+                profileCache = null // clear the cache
                 null
             }
         }
     }
 
     fun getToken(apiKey: String): Token? {
-        with(cachedToken) {
+        with(tokenCache) {
             return if (this == null ||
                 first != apiKey ||
                 second.getTokenState() == TokenState.EXPIRED
@@ -70,19 +70,20 @@ class InMemoryCacheDataSource {
     }
 
     fun getProductSummary(postcode: String): List<ProductSummary>? {
-        return cachedProductSummary?.let {
+        return productSummaryCache?.let {
             if (it.first == postcode) {
                 it.second
             } else {
                 // invalidate the cache to prevent the cached result staying for too long
-                cachedProductSummary = null
+                productSummaryCache = null
                 null
             }
         }
     }
 
     fun clear() {
-        cachedProfile = null
-        cachedToken = null
+        profileCache = null
+        tokenCache = null
+        productSummaryCache = null
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/cache/InMemoryCacheDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/local/cache/InMemoryCacheDataSource.kt
@@ -21,6 +21,7 @@ import com.rwmobi.kunigami.domain.extensions.toSystemDefaultLocalDate
 import com.rwmobi.kunigami.domain.model.account.Account
 import com.rwmobi.kunigami.domain.model.product.ProductDetails
 import com.rwmobi.kunigami.domain.model.product.ProductSummary
+import com.rwmobi.kunigami.domain.model.product.Tariff
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
@@ -29,6 +30,7 @@ class InMemoryCacheDataSource {
     private var tokenCache: Pair<String, Token>? = null
     private var productSummaryCache: Pair<String, List<ProductSummary>>? = null
     private var productDetailsCache: MutableMap<Pair<String, String>, ProductDetails> = mutableMapOf()
+    private var tariffCache: MutableMap<String, Tariff> = mutableMapOf()
 
     fun cacheProfile(account: Account, createdAt: Instant) {
         profileCache = Pair(account, createdAt)
@@ -45,6 +47,10 @@ class InMemoryCacheDataSource {
     fun cacheProductDetails(postcode: String, productCode: String, productDetails: ProductDetails) {
         val key = Pair(postcode, productCode)
         productDetailsCache[key] = productDetails
+    }
+
+    fun cacheTariff(tariffCode: String, tariff: Tariff) {
+        tariffCache[tariffCode] = tariff
     }
 
     /***
@@ -93,10 +99,15 @@ class InMemoryCacheDataSource {
         return productDetailsCache[key]
     }
 
+    fun getTariff(tariffCode: String): Tariff? {
+        return tariffCache[tariffCode]
+    }
+
     fun clear() {
         profileCache = null
         tokenCache = null
         productSummaryCache = null
+        tariffCache.clear()
         productDetailsCache.clear()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetLatestProductByKeywordUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetLatestProductByKeywordUseCase.kt
@@ -25,9 +25,9 @@ class GetLatestProductByKeywordUseCase(
     private val octopusApiRepository: OctopusApiRepository,
     private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
-    suspend operator fun invoke(keyword: String): String? {
+    suspend operator fun invoke(keyword: String, postcode: String): String? {
         return withContext(dispatcher) {
-            val getProductsResult = octopusApiRepository.getProducts(postcode = "WC1X 0ND")
+            val getProductsResult = octopusApiRepository.getProducts(postcode = postcode)
             getProductsResult.fold(
                 onSuccess = { products ->
                     val productCode = products.sortedByDescending {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
@@ -67,9 +67,6 @@ class AgileViewModel(
     private val fallBackFlexibleProductCode = "VAR-22-11-01"
     private val demoRetailRegion = RetailRegion.EASTERN_ENGLAND
 
-    private var cachedFixedProductCode: String? = null
-    private var cachedFlexibleProductCode: String? = null
-
     fun errorShown(errorId: Long) {
         _uiState.update { currentUiState ->
             val errorMessages = currentUiState.errorMessages.filterNot { it.id == errorId }
@@ -252,8 +249,11 @@ class AgileViewModel(
      * Best effort to fetch reference tariffs for comparison. No harm if it fails, so it won't stop loading.
      */
     private suspend fun fetchReferenceTariffs(region: RetailRegion, postcode: String) {
-        cachedFixedProductCode = cachedFixedProductCode ?: getLatestProductByKeywordUseCase(keyword = fixedTariffKeyword, postcode = postcode)
-        val fixedProductCode = cachedFixedProductCode ?: fallBackFixedProductCode
+        val fixedProductCode = getLatestProductByKeywordUseCase(
+            keyword = fixedTariffKeyword,
+            postcode = postcode,
+        ) ?: fallBackFixedProductCode
+
         getTariffRatesUseCase(
             tariffCode = "E-1R-$fixedProductCode-${region.code}",
         ).fold(
@@ -274,8 +274,11 @@ class AgileViewModel(
             },
         )
 
-        cachedFlexibleProductCode = cachedFlexibleProductCode ?: getLatestProductByKeywordUseCase(keyword = variableTariffKeyword, postcode = postcode)
-        val flexibleProductCode = cachedFlexibleProductCode ?: fallBackFlexibleProductCode
+        val flexibleProductCode = getLatestProductByKeywordUseCase(
+            keyword = variableTariffKeyword,
+            postcode = postcode,
+        ) ?: fallBackFlexibleProductCode
+
         getTariffRatesUseCase(
             tariffCode = "E-1R-$flexibleProductCode-${region.code}",
         ).fold(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
@@ -59,6 +59,9 @@ class AgileViewModel(
     private val _uiState: MutableStateFlow<AgileUIState> = MutableStateFlow(AgileUIState(isLoading = true))
     val uiState = _uiState.asStateFlow()
 
+    private val agileTariffKeyword = "AGILE"
+    private val variableTariffKeyword = "VAR-"
+    private val fixedTariffKeyword = "OE-FIX-12M"
     private val fallBackAgileProductCode = "AGILE-24-04-03"
     private val fallBackFixedProductCode = "OE-FIX-12M-24-06-28"
     private val fallBackFlexibleProductCode = "VAR-22-11-01"
@@ -86,7 +89,10 @@ class AgileViewModel(
                 val region = currentAgreement?.tariffCode?.let { Tariff.getRetailRegion(tariffCode = it) } ?: demoRetailRegion
                 val productCode = getAgileProductCode(currentTariffCode = currentAgreement?.tariffCode)
 
-                fetchReferenceTariffs(region = region)
+                fetchReferenceTariffs(
+                    region = region,
+                    postcode = region.postcode,
+                )
 
                 getAgileRates(
                     productCode = productCode,
@@ -147,7 +153,9 @@ class AgileViewModel(
             currentProductCode?.let { return it }
         }
 
-        return getLatestAgileProductCode()
+        val postcode = currentTariffCode?.let { Tariff.getRetailRegion(it)?.postcode }
+            ?: demoRetailRegion.postcode
+        return getLatestAgileProductCode(postcode = postcode)
     }
 
     private suspend fun getAgileRates(
@@ -236,15 +244,15 @@ class AgileViewModel(
             .map { (date, items) -> RateGroup(title = date, rates = items) }
     }
 
-    private suspend fun getLatestAgileProductCode(): String {
-        return getLatestProductByKeywordUseCase(keyword = "AGILE") ?: fallBackAgileProductCode
+    private suspend fun getLatestAgileProductCode(postcode: String): String {
+        return getLatestProductByKeywordUseCase(keyword = agileTariffKeyword, postcode = postcode) ?: fallBackAgileProductCode
     }
 
     /**
      * Best effort to fetch reference tariffs for comparison. No harm if it fails, so it won't stop loading.
      */
-    private suspend fun fetchReferenceTariffs(region: RetailRegion) {
-        cachedFixedProductCode = cachedFixedProductCode ?: getLatestProductByKeywordUseCase(keyword = "OE-FIX-12M")
+    private suspend fun fetchReferenceTariffs(region: RetailRegion, postcode: String) {
+        cachedFixedProductCode = cachedFixedProductCode ?: getLatestProductByKeywordUseCase(keyword = fixedTariffKeyword, postcode = postcode)
         val fixedProductCode = cachedFixedProductCode ?: fallBackFixedProductCode
         getTariffRatesUseCase(
             tariffCode = "E-1R-$fixedProductCode-${region.code}",
@@ -266,7 +274,7 @@ class AgileViewModel(
             },
         )
 
-        cachedFlexibleProductCode = cachedFlexibleProductCode ?: getLatestProductByKeywordUseCase(keyword = "VAR-")
+        cachedFlexibleProductCode = cachedFlexibleProductCode ?: getLatestProductByKeywordUseCase(keyword = variableTariffKeyword, postcode = postcode)
         val flexibleProductCode = cachedFlexibleProductCode ?: fallBackFlexibleProductCode
         getTariffRatesUseCase(
             tariffCode = "E-1R-$flexibleProductCode-${region.code}",

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetLatestProductByKeywordUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/usecase/product/GetLatestProductByKeywordUseCaseTest.kt
@@ -33,7 +33,8 @@ class GetLatestProductByKeywordUseCaseTest {
 
     private lateinit var getLatestProductByKeywordUseCase: GetLatestProductByKeywordUseCase
     private lateinit var fakeRestApiRepository: FakeOctopusApiRepository
-    private val keyword = "AGILE"
+    private val agileTariffKeyword = "AGILE"
+    private val samplePostcode = "WC1X 0ND"
 
     @BeforeTest
     fun setupUseCase() {
@@ -84,7 +85,10 @@ class GetLatestProductByKeywordUseCaseTest {
 
         fakeRestApiRepository.setProductsResponse = Result.success(productSummaries)
 
-        val result = getLatestProductByKeywordUseCase(keyword = keyword)
+        val result = getLatestProductByKeywordUseCase(
+            keyword = agileTariffKeyword,
+            postcode = samplePostcode,
+        )
 
         assertEquals(
             expected = "AGILE-24-04-03",
@@ -121,7 +125,10 @@ class GetLatestProductByKeywordUseCaseTest {
 
         fakeRestApiRepository.setProductsResponse = Result.success(productSummaries)
 
-        val result = getLatestProductByKeywordUseCase(keyword = keyword)
+        val result = getLatestProductByKeywordUseCase(
+            keyword = agileTariffKeyword,
+            postcode = samplePostcode,
+        )
 
         assertEquals(
             expected = "AGILE-24-04-03",
@@ -134,7 +141,10 @@ class GetLatestProductByKeywordUseCaseTest {
         val errorMessage = "API Error"
         fakeRestApiRepository.setProductsResponse = Result.failure(RuntimeException(errorMessage))
 
-        val result = getLatestProductByKeywordUseCase(keyword = keyword)
+        val result = getLatestProductByKeywordUseCase(
+            keyword = agileTariffKeyword,
+            postcode = samplePostcode,
+        )
 
         assertNull(result)
     }
@@ -156,7 +166,10 @@ class GetLatestProductByKeywordUseCaseTest {
         )
         fakeRestApiRepository.setProductsResponse = Result.success(productSummaries)
 
-        val result = getLatestProductByKeywordUseCase(keyword = keyword)
+        val result = getLatestProductByKeywordUseCase(
+            keyword = agileTariffKeyword,
+            postcode = samplePostcode,
+        )
 
         assertNull(result)
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,8 +42,8 @@ apollographqlMockServer = "0.0.3"
 testRules = "1.6.1"
 
 # App configurations, not dependencies
-versionCode = "11"
-versionName = "2.0.0"
+versionCode = "12"
+versionName = "2.1.0"
 android-minSdk = "26"
 android-targetSdk = "34"
 android-compileSdk = "34"

--- a/iosApp/OctoMeter.xcodeproj/project.pbxproj
+++ b/iosApp/OctoMeter.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = V8M4R7N63C;
 				ENABLE_PREVIEWS = YES;
@@ -401,7 +401,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
@@ -422,7 +422,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = V8M4R7N63C;
 				ENABLE_PREVIEWS = YES;
@@ -439,7 +439,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",

--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - composeApp (2.0.0)
+  - composeApp (2.1.0)
 
 DEPENDENCIES:
   - composeApp (from `../composeApp/`)

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>11</string>
+	<string>12</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
The AgileScreen is designed to run for 24/7. Given normally the Agile rates refresh once a day, we now have implemented in-memory cache to store most of API results for the screen as possible - such that the screen can refresh without triggering an error screen when the network is unavailable. 

Also, we fixed to take the correct postcode when querying for available products properly.

This release marks a milestone version 2.1.0 build 12 that is good enough for personal use.
