### PR TITLE
CI: apply workaround for Windows installer workflow

### DIFF
--- a/.github/workflows/tag_create_release.yml
+++ b/.github/workflows/tag_create_release.yml
@@ -131,6 +131,11 @@ jobs:
           java-version: '17'
           cache: gradle
 
+      - name: Prepare RoomDB actual declaration
+        run: .\gradlew :composeApp:kspCommonMainKotlinMetadata
+        env:
+          KEYSTORE_LOCATION: ${{ steps.decode_keystore.outputs.filePath }}
+
       - name: Build and Package Project
         run: .\gradlew packageReleaseDistributionForCurrentOS
         env:


### PR DESCRIPTION
A gradle workaround is needed to workaround a suspected ksp bug that affects the generation of actual functions