### PR TITLE
Renovate: lift manual approval for Gradle updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,12 +30,6 @@
         "com.google.devtools.ksp"
       ],
       "groupName": "kotlin"
-    },
-    {
-      "matchManagers": ["gradle-wrapper"],
-      "groupName": "Gradle Wrapper",
-      "automerge": false,
-      "labels": ["requires-approval"]
     }
   ],
   "automerge": true,


### PR DESCRIPTION
The new gradle update fixed the iOS build issue, so we are good to let Renovate runs