### PR TITLE
Dimension: change to extend from ScreenSizeInfo rather than Density

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/AppBottomNavigationBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/AppBottomNavigationBar.kt
@@ -26,13 +26,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.navigation.AppDestination
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
@@ -46,7 +46,7 @@ fun AppBottomNavigationBar(
     navController: NavController,
     onCurrentRouteSecondTapped: (item: AppDestination) -> Unit,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     val navigationBarContentDescription = stringResource(Res.string.content_description_navigation_bar)
     NavigationBar(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/AppNavigationRail.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/AppNavigationRail.kt
@@ -27,13 +27,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.navigation.AppDestination
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
@@ -54,7 +54,7 @@ fun AppNavigationRail(
     ) {
         val navBackStackEntry by navController.currentBackStackEntryAsState()
         val currentRoute = navBackStackEntry?.destination?.route
-        val dimension = LocalDensity.current.getDimension()
+        val dimension = getScreenSizeInfo().getDimension()
 
         Spacer(Modifier.weight(1f))
 

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/CommonPreviewSetup.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/CommonPreviewSetup.kt
@@ -27,8 +27,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Fill
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.AppTheme
 import com.rwmobi.kunigami.ui.theme.Dimension
 import com.rwmobi.kunigami.ui.theme.getDimension
@@ -38,7 +38,7 @@ internal fun CommonPreviewSetup(
     modifier: Modifier = Modifier,
     content: @Composable (dimension: Dimension) -> Unit = {},
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Column(
         modifier = modifier

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/DemoModeCtaAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/DemoModeCtaAdaptive.kt
@@ -30,7 +30,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalDensity
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.agile_demo_introduction
@@ -72,7 +72,7 @@ private fun DemoModeCTACompact(
     ctaButtonLabel: String,
     onCtaButtonClicked: () -> Unit,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Column(
         modifier = modifier
@@ -117,7 +117,7 @@ private fun DemoModeCTAWide(
     ctaButtonLabel: String,
     onCtaButtonClicked: () -> Unit,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Column(
         modifier = modifier

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/DualTitleBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/DualTitleBar.kt
@@ -28,11 +28,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 
 @Composable
@@ -41,7 +41,7 @@ internal fun DualTitleBar(
     title: String,
     subtitle: String? = null,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     Surface {
         Column(
             modifier = modifier.padding(horizontal = dimension.grid_3),

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/IconTextButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/IconTextButton.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.coin
@@ -60,8 +61,7 @@ fun IconTextButton(
     CompositionLocalProvider(
         LocalDensity provides Density(currentDensity.density, fontScale = 1f),
     ) {
-        val dimension = currentDensity.getDimension()
-
+        val dimension = getScreenSizeInfo().getDimension()
         Button(
             modifier = modifier,
             shape = shape,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/IndicatorTextValueGridItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/IndicatorTextValueGridItem.kt
@@ -35,10 +35,10 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 
 @Composable
@@ -48,7 +48,7 @@ fun IndicatorTextValueGridItem(
     label: String,
     value: String,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     Row(
         modifier = modifier.fillMaxWidth()
             .drawBehind {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/LabelValueRow.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/LabelValueRow.kt
@@ -21,9 +21,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 
 @Composable
@@ -33,7 +33,7 @@ internal fun LabelValueRow(
     label: String?,
     value: String?,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_1),

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/LargeTitleWithIcon.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/LargeTitleWithIcon.kt
@@ -25,7 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.platform.LocalDensity
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 
 @Composable
@@ -34,7 +34,7 @@ fun LargeTitleWithIcon(
     icon: Painter,
     label: String,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/LoadingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/LoadingScreen.kt
@@ -31,8 +31,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -44,7 +44,7 @@ import org.jetbrains.compose.resources.painterResource
 fun LoadingScreen(
     modifier: Modifier = Modifier,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Box(
         modifier = modifier

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/MessageActionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/MessageActionScreen.kt
@@ -34,9 +34,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.wallet
@@ -54,7 +54,7 @@ fun MessageActionScreen(
     secondaryButtonLabel: String? = null,
     onSecondaryButtonClicked: (() -> Unit)? = null,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Column(
         modifier = modifier.fillMaxSize(),

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/SquareButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/SquareButton.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.coin
@@ -61,8 +62,7 @@ internal fun SquareButton(
     CompositionLocalProvider(
         LocalDensity provides Density(currentDensity.density, fontScale = 1f),
     ) {
-        val dimension = currentDensity.getDimension()
-
+        val dimension = getScreenSizeInfo().getDimension()
         Column(
             modifier = modifier
                 .wrapContentHeight()

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TagWithIcon.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TagWithIcon.kt
@@ -26,9 +26,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.domain.model.product.ProductFeature
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -39,7 +39,7 @@ fun TagWithIcon(
     icon: Painter,
     text: String,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Row(
         modifier = modifier

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TariffSummaryTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TariffSummaryTile.kt
@@ -34,9 +34,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import com.rwmobi.kunigami.domain.model.product.Tariff
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.previewsampledata.TariffSamples
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
@@ -53,7 +53,7 @@ internal fun TariffSummaryTile(
     modifier: Modifier = Modifier,
     tariff: Tariff,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     Column(
         modifier = modifier
             .clip(shape = MaterialTheme.shapes.large)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/WidgetCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/WidgetCard.kt
@@ -26,9 +26,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 
 @Composable
@@ -38,7 +38,7 @@ fun WidgetCard(
     contents: @Composable () -> Unit,
     footer: @Composable (() -> Unit)? = null,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Column(
         modifier = modifier

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/VerticalBarChart.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/VerticalBarChart.kt
@@ -39,10 +39,10 @@ import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.composehelper.palette.RatePalette
 import com.rwmobi.kunigami.ui.composehelper.shouldUseDarkTheme
 import com.rwmobi.kunigami.ui.theme.getDimension
@@ -74,7 +74,7 @@ fun VerticalBarChart(
     yAxisTitle: String? = null,
     backgroundPlot: @Composable ((scope: XYGraphScope<Int, Double>) -> Unit)? = null,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Box {
         var showTooltipIndex: Int? by remember { mutableStateOf(null) }
@@ -230,7 +230,7 @@ private fun HoverElement(
     modifier: Modifier = Modifier,
     text: String,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Text(
         modifier = modifier

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountInformationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountInformationScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.domain.extensions.getLocalDateString
@@ -47,6 +46,7 @@ import com.rwmobi.kunigami.domain.model.account.UserProfile
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.components.MessageActionScreen
 import com.rwmobi.kunigami.ui.components.SquareButton
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.destinations.account.components.AppInfoFooter
 import com.rwmobi.kunigami.ui.destinations.account.components.ClearCredentialSectionAdaptive
 import com.rwmobi.kunigami.ui.destinations.account.components.ElectricityMeterPointCard
@@ -79,7 +79,7 @@ internal fun AccountInformationScreen(
     uiState: AccountUIState,
     uiEvent: AccountUIEvent,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Column(
         modifier = modifier,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountScreen.kt
@@ -32,12 +32,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import com.rwmobi.kunigami.ui.components.DualTitleBar
 import com.rwmobi.kunigami.ui.components.ErrorScreenHandler
 import com.rwmobi.kunigami.ui.components.LoadingScreen
 import com.rwmobi.kunigami.ui.components.ScrollbarMultiplatform
 import com.rwmobi.kunigami.ui.composehelper.conditionalBlur
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.SpecialErrorScreen
 import com.rwmobi.kunigami.ui.previewsampledata.FakeDemoUserProfile
 import com.rwmobi.kunigami.ui.theme.AppTheme
@@ -62,7 +62,7 @@ fun AccountScreen(
         }
     }
 
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     val lazyListState = rememberLazyListState()
 
     Box(modifier = modifier) {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/OnboardingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/OnboardingScreen.kt
@@ -33,10 +33,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.destinations.account.components.AppInfoFooter
 import com.rwmobi.kunigami.ui.destinations.account.components.CredentialsInputForm
 import com.rwmobi.kunigami.ui.theme.AppTheme
@@ -59,7 +59,7 @@ internal fun OnboardingScreen(
     uiState: AccountUIState,
     uiEvent: AccountUIEvent,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     val focusManager = LocalFocusManager.current
 
     Column(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/AppInfoFooter.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/AppInfoFooter.kt
@@ -25,9 +25,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 import composeapp.kunigami.BuildConfig
 import kunigami.composeapp.generated.resources.Res
@@ -38,7 +38,7 @@ import org.jetbrains.compose.resources.stringResource
 internal fun AppInfoFooter(
     modifier: Modifier = Modifier,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Column(
         modifier = modifier,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/ClearCredentialSectionAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/ClearCredentialSectionAdaptive.kt
@@ -29,10 +29,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.components.IconTextButton
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.account_clear_credential_button_cta
@@ -66,7 +66,7 @@ private fun ClearCredentialSectionCompact(
     modifier: Modifier = Modifier,
     onClearCredentialButtonClicked: () -> Unit,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Column(
         modifier = modifier
@@ -105,7 +105,7 @@ private fun ClearCredentialSectionWide(
     modifier: Modifier = Modifier,
     onClearCredentialButtonClicked: () -> Unit,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Column(
         modifier = modifier

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/CredentialsInputForm.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/CredentialsInputForm.kt
@@ -38,12 +38,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.onboarding_button_connect
@@ -63,7 +63,7 @@ internal fun CredentialsInputForm(
     isSubmitButtonEnabled: Boolean,
     onSubmitCredentials: (apiKey: String, accountNumber: String, stringResolver: suspend (resId: StringResource) -> String) -> Unit,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Column(
         modifier = modifier

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/ElectricityMeterPointCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/ElectricityMeterPointCard.kt
@@ -29,9 +29,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import com.rwmobi.kunigami.domain.model.account.ElectricityMeterPoint
 import com.rwmobi.kunigami.ui.components.IconTextButton
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.destinations.account.AccountScreenLayoutStyle
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
@@ -53,7 +53,7 @@ internal fun ElectricityMeterPointCard(
     onReloadTariff: () -> Unit,
     onMeterSerialNumberSelected: (mpan: String, meterSerialNumber: String) -> Unit,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Card(modifier = modifier) {
         Column(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/MeterSerialNumberEntry.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/MeterSerialNumberEntry.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.Density
 import com.rwmobi.kunigami.domain.extensions.getLocalDateString
 import com.rwmobi.kunigami.domain.model.account.ElectricityMeter
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kotlinx.datetime.Instant
 import kunigami.composeapp.generated.resources.Res
@@ -61,7 +62,7 @@ internal fun MeterSerialNumberEntry(
     onMeterSerialNumberSelected: () -> Unit,
 ) {
     val currentDensity = LocalDensity.current
-    val dimension = currentDensity.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     CompositionLocalProvider(
         LocalDensity provides Density(currentDensity.density, fontScale = 1f),
     ) {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/SimpleTitleButtonCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/SimpleTitleButtonCard.kt
@@ -29,10 +29,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.components.IconTextButton
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.account_update_api_key
@@ -49,7 +49,7 @@ internal fun SimpleTitleButtonCard(
     buttonPainter: Painter,
     onButtonClicked: () -> Unit,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Row(
         modifier = modifier

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/TariffLayout.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/TariffLayout.kt
@@ -32,13 +32,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import com.rwmobi.kunigami.domain.extensions.getLocalDateString
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.domain.model.account.Agreement
 import com.rwmobi.kunigami.domain.model.product.Tariff
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kotlinx.datetime.Instant
 import kunigami.composeapp.generated.resources.Res
@@ -62,7 +62,7 @@ internal fun TariffLayout(
     agreement: Agreement,
     showDivider: Boolean = false,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Column(
         modifier = modifier,
@@ -160,7 +160,7 @@ private fun RateRow(
     label: String,
     rate: Double,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     Row(
         modifier = Modifier
             .fillMaxWidth()

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.drawscope.DrawScope
-import androidx.compose.ui.platform.LocalDensity
 import com.rwmobi.kunigami.domain.extensions.getNextHalfHourCountdownMillis
 import com.rwmobi.kunigami.ui.components.DemoModeCtaAdaptive
 import com.rwmobi.kunigami.ui.components.DualTitleBar
@@ -48,6 +47,7 @@ import com.rwmobi.kunigami.ui.components.LoadingScreen
 import com.rwmobi.kunigami.ui.components.ScrollbarMultiplatform
 import com.rwmobi.kunigami.ui.components.koalaplot.VerticalBarChart
 import com.rwmobi.kunigami.ui.composehelper.conditionalBlur
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.destinations.agile.components.AgileTariffCardAdaptive
 import com.rwmobi.kunigami.ui.destinations.agile.components.RateGroupCells
 import com.rwmobi.kunigami.ui.destinations.agile.components.RateGroupTitle
@@ -91,7 +91,7 @@ fun AgileScreen(
         }
     }
 
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     val lazyListState = rememberLazyListState()
 
     Box(modifier = modifier) {
@@ -275,7 +275,7 @@ private fun LazyListScope.renderChart(
     barChartData: BarChartData,
 ) {
     item(key = "chart") {
-        val dimension = LocalDensity.current.getDimension()
+        val dimension = getScreenSizeInfo().getDimension()
         Box(
             modifier = Modifier.padding(top = dimension.grid_1),
         ) {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/AgileTariffCardAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/AgileTariffCardAdaptive.kt
@@ -36,12 +36,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalDensity
 import com.rwmobi.kunigami.domain.extensions.getNextHalfHourCountdownMillis
 import com.rwmobi.kunigami.domain.model.product.Tariff
 import com.rwmobi.kunigami.domain.model.rate.PaymentMethod
 import com.rwmobi.kunigami.domain.model.rate.Rate
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.composehelper.palette.RatePalette
 import com.rwmobi.kunigami.ui.composehelper.shouldUseDarkTheme
 import com.rwmobi.kunigami.ui.model.rate.RateGroup
@@ -171,7 +171,7 @@ private fun AgileTariffCardCompact(
     latestFixedTariff: Tariff? = null,
     latestFlexibleTariff: Tariff? = null,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(dimension.grid_1),
@@ -248,7 +248,7 @@ private fun AgileTariffCardExpanded(
     latestFixedTariff: Tariff? = null,
     latestFlexibleTariff: Tariff? = null,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     FlowRow(
         modifier = modifier.fillMaxSize(),
         horizontalArrangement = Arrangement.Center,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/CurrentRateTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/CurrentRateTile.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -44,6 +43,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.components.HorizontalAnimatedTintedPainterResource
 import com.rwmobi.kunigami.ui.components.VerticalAnimatedTintedPainterResource
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.rate.RateTrend
 import com.rwmobi.kunigami.ui.theme.getDimension
 import io.github.koalaplot.core.util.toString
@@ -60,7 +60,7 @@ internal fun CurrentRateTile(
     rateTrend: RateTrend?,
     rateTrendIconTint: Color? = null,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     Column(
         modifier = modifier
             .clip(shape = MaterialTheme.shapes.large)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGaugeCountdownTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGaugeCountdownTile.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalDensity
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 
 @Composable
@@ -37,7 +37,7 @@ internal fun RateGaugeCountdownTile(
     targetPercentage: Float,
     colorPalette: List<Color>,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     Column(
         modifier = modifier
             .clip(shape = MaterialTheme.shapes.large)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupCells.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupCells.kt
@@ -20,11 +20,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import com.rwmobi.kunigami.domain.extensions.getLocalHHMMString
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.domain.model.rate.Rate
 import com.rwmobi.kunigami.ui.components.IndicatorTextValueGridItem
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.composehelper.palette.RatePalette
 import com.rwmobi.kunigami.ui.composehelper.shouldUseDarkTheme
 import com.rwmobi.kunigami.ui.theme.getDimension
@@ -38,7 +38,7 @@ internal fun RateGroupCells(
     shouldHideLastColumn: Boolean,
     rateRange: ClosedFloatingPointRange<Double>,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_3),

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/ReferenceTariffTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/ReferenceTariffTile.kt
@@ -30,11 +30,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.domain.model.product.Tariff
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.previewsampledata.TariffSamples
 import com.rwmobi.kunigami.ui.theme.cyanish
 import com.rwmobi.kunigami.ui.theme.getDimension
@@ -48,7 +48,7 @@ internal fun ReferenceTariffTile(
     tariff: Tariff,
     indicatorColor: Color,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     Column(
         modifier = modifier
             .clip(shape = MaterialTheme.shapes.large)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffsScreen.kt
@@ -39,12 +39,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import com.rwmobi.kunigami.ui.components.DualTitleBar
 import com.rwmobi.kunigami.ui.components.ErrorScreenHandler
 import com.rwmobi.kunigami.ui.components.LoadingScreen
 import com.rwmobi.kunigami.ui.components.ScrollbarMultiplatform
 import com.rwmobi.kunigami.ui.composehelper.conditionalBlur
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.destinations.tariffs.components.ButtonTitleBar
 import com.rwmobi.kunigami.ui.destinations.tariffs.components.PostcodeInputBar
 import com.rwmobi.kunigami.ui.destinations.tariffs.components.ProductBottomSheetWrapper
@@ -78,7 +78,7 @@ fun TariffsScreen(
         }
     }
 
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     val mainLazyListState = rememberLazyListState()
 
     Box(modifier = modifier) {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/PostcodeInputBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/PostcodeInputBar.kt
@@ -35,8 +35,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.content_description_edit_postcode
@@ -51,7 +51,7 @@ internal fun PostcodeInputBar(
     postcode: String,
     onUpdatePostcode: (String) -> Unit,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     var showEditPostcodeDialog by remember { mutableStateOf(false) }
 
     if (showEditPostcodeDialog) {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductBottomSheetWrapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductBottomSheetWrapper.kt
@@ -23,8 +23,8 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import com.rwmobi.kunigami.domain.model.product.ProductDetails
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -35,7 +35,7 @@ internal fun ProductBottomSheetWrapper(
     bottomSheetState: SheetState,
     onDismissRequest: () -> Unit,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     ModalBottomSheet(
         modifier = modifier,
         onDismissRequest = onDismissRequest,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductFacts.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductFacts.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.Density
 import com.rwmobi.kunigami.domain.extensions.getLocalDateString
 import com.rwmobi.kunigami.domain.model.product.ProductDetails
 import com.rwmobi.kunigami.ui.components.TagWithIcon
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kotlinx.datetime.Instant
 import kunigami.composeapp.generated.resources.Res
@@ -50,7 +51,7 @@ internal fun ProductFacts(
     modifier: Modifier = Modifier,
     productDetails: ProductDetails,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Column(
         modifier = modifier.padding(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductListItemAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductListItemAdaptive.kt
@@ -44,6 +44,7 @@ import com.rwmobi.kunigami.domain.model.product.ProductFeature
 import com.rwmobi.kunigami.domain.model.product.ProductSummary
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.components.TagWithIcon
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.Dimension
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kotlinx.datetime.Instant
@@ -76,7 +77,7 @@ private fun ProductListItemCompact(
     modifier: Modifier = Modifier,
     productSummary: ProductSummary,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Column(
         modifier = modifier.padding(
@@ -139,7 +140,7 @@ internal fun ProductListItemWide(
     modifier: Modifier = Modifier,
     productSummary: ProductSummary,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Row(
         modifier = modifier

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductPaneWrapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductPaneWrapper.kt
@@ -23,9 +23,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import com.rwmobi.kunigami.domain.model.product.ProductDetails
 import com.rwmobi.kunigami.ui.components.ScrollbarMultiplatform
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 
 @Composable
@@ -34,7 +34,7 @@ internal fun ProductPaneWrapper(
     productDetails: ProductDetails? = null,
     header: @Composable () -> Unit,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     val detailLazyListState = rememberLazyListState()
     ScrollbarMultiplatform(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductScreenLayout.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductScreenLayout.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import com.rwmobi.kunigami.domain.model.product.ExitFeesType
 import com.rwmobi.kunigami.domain.model.product.ProductDetails
 import com.rwmobi.kunigami.domain.model.product.ProductDirection
@@ -33,6 +32,7 @@ import com.rwmobi.kunigami.domain.model.product.ProductFeature
 import com.rwmobi.kunigami.domain.model.product.Tariff
 import com.rwmobi.kunigami.domain.model.product.TariffPaymentTerm
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kotlinx.datetime.Instant
 
@@ -41,7 +41,7 @@ internal fun LazyListScope.productScreenLayout(
     productDetails: ProductDetails,
 ) {
     item(key = "productFacts") {
-        val dimension = LocalDensity.current.getDimension()
+        val dimension = getScreenSizeInfo().getDimension()
         Column(
             modifier = modifier,
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductTariff.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductTariff.kt
@@ -27,7 +27,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
@@ -36,6 +35,7 @@ import com.rwmobi.kunigami.domain.model.product.Tariff
 import com.rwmobi.kunigami.domain.model.product.TariffPaymentTerm
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.components.LabelValueRow
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.previewsampledata.TariffSamples
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
@@ -58,8 +58,7 @@ internal fun RegionTariff(
     modifier: Modifier,
     tariff: Tariff,
 ) {
-    val localDensity = LocalDensity.current
-    val dimension = localDensity.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Column(
         modifier = modifier.wrapContentHeight(),

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import com.rwmobi.kunigami.ui.components.DemoModeCtaAdaptive
 import com.rwmobi.kunigami.ui.components.ErrorScreenHandler
 import com.rwmobi.kunigami.ui.components.LargeTitleWithIcon
@@ -43,6 +42,7 @@ import com.rwmobi.kunigami.ui.components.MessageActionScreen
 import com.rwmobi.kunigami.ui.components.ScrollbarMultiplatform
 import com.rwmobi.kunigami.ui.components.koalaplot.VerticalBarChart
 import com.rwmobi.kunigami.ui.composehelper.conditionalBlur
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.destinations.usage.components.ConsumptionGroupCells
 import com.rwmobi.kunigami.ui.destinations.usage.components.NavigationOptionsBar
 import com.rwmobi.kunigami.ui.destinations.usage.components.RateGroupTitle
@@ -84,7 +84,7 @@ fun UsageScreen(
         }
     }
 
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     val lazyListState = rememberLazyListState()
 
     Box(modifier = modifier) {
@@ -267,7 +267,7 @@ private fun LazyListScope.consumptionBarChart(
 ) {
     item(key = "chart") {
         Box {
-            val dimension = LocalDensity.current.getDimension()
+            val dimension = getScreenSizeInfo().getDimension()
             val constraintModifier = when (uiState.requestedChartLayout) {
                 is RequestedChartLayout.Portrait -> {
                     Modifier
@@ -307,7 +307,7 @@ private fun LazyListScope.consumptionBreakdown(
 ) {
     consumptionGroupsWithPartitions.forEach { consumptionGroupWithPartitions ->
         item(key = "${consumptionGroupWithPartitions.title}Title") {
-            val dimension = LocalDensity.current.getDimension()
+            val dimension = getScreenSizeInfo().getDimension()
             RateGroupTitle(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -321,7 +321,7 @@ private fun LazyListScope.consumptionBreakdown(
 
         val maxRows = consumptionGroupWithPartitions.partitionedItems.maxOf { it.size }
         items(maxRows) { rowIndex ->
-            val dimension = LocalDensity.current.getDimension()
+            val dimension = getScreenSizeInfo().getDimension()
             ConsumptionGroupCells(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/ConsumptionGroupCells.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/ConsumptionGroupCells.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import com.rwmobi.kunigami.domain.extensions.getLocalDayMonthString
 import com.rwmobi.kunigami.domain.extensions.getLocalDayOfMonth
 import com.rwmobi.kunigami.domain.extensions.getLocalDayOfWeekAndDayString
@@ -28,6 +27,7 @@ import com.rwmobi.kunigami.domain.extensions.getLocalHHMMString
 import com.rwmobi.kunigami.domain.extensions.getLocalMonthString
 import com.rwmobi.kunigami.domain.model.consumption.Consumption
 import com.rwmobi.kunigami.ui.components.IndicatorTextValueGridItem
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.composehelper.palette.RatePalette
 import com.rwmobi.kunigami.ui.composehelper.shouldUseDarkTheme
 import com.rwmobi.kunigami.ui.model.consumption.ConsumptionPresentationStyle
@@ -43,7 +43,7 @@ internal fun ConsumptionGroupCells(
     consumptionRange: ClosedFloatingPointRange<Double>,
     presentationStyle: ConsumptionPresentationStyle,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_3),

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/ConsumptionTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/ConsumptionTile.kt
@@ -29,9 +29,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.consumption.Insights
 import com.rwmobi.kunigami.ui.previewsampledata.InsightsSamples
 import com.rwmobi.kunigami.ui.theme.getDimension
@@ -46,7 +46,7 @@ internal fun ConsumptionTile(
     modifier: Modifier = Modifier,
     insights: Insights,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     Column(
         modifier = modifier
             .clip(shape = MaterialTheme.shapes.large)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/DailyAverageTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/DailyAverageTile.kt
@@ -34,10 +34,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.consumption.Insights
 import com.rwmobi.kunigami.ui.previewsampledata.InsightsSamples
 import com.rwmobi.kunigami.ui.theme.getDimension
@@ -52,7 +52,7 @@ internal fun DailyAverageTile(
     modifier: Modifier = Modifier,
     insights: Insights,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     Column(
         modifier = modifier
             .clip(shape = MaterialTheme.shapes.large)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/InsightsTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/InsightsTile.kt
@@ -30,10 +30,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.consumption.Insights
 import com.rwmobi.kunigami.ui.previewsampledata.InsightsSamples
 import com.rwmobi.kunigami.ui.theme.getDimension
@@ -50,7 +50,7 @@ internal fun InsightsTile(
     modifier: Modifier = Modifier,
     insights: Insights,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     Column(
         modifier = modifier

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/NavigationOptionsBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/NavigationOptionsBar.kt
@@ -32,8 +32,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.dashboard
@@ -48,7 +48,7 @@ internal fun NavigationOptionsBar(
     selectedMpan: String?,
     onNavigateToLatest: () -> Unit,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     Column(modifier = modifier) {
         Row(
             modifier = Modifier

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/PresentationStyleDropdownMenu.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/PresentationStyleDropdownMenu.kt
@@ -28,10 +28,10 @@ import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.consumption.ConsumptionPresentationStyle
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
@@ -49,7 +49,7 @@ internal fun PresentationStyleDropdownMenu(
     onDismiss: () -> Unit,
     onSwitchPresentationStyle: (consumptionPresentationStyle: ConsumptionPresentationStyle) -> Unit,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
 
     DropdownMenu(
         modifier = modifier,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/ProjectedConsumptionTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/ProjectedConsumptionTile.kt
@@ -34,10 +34,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.consumption.Insights
 import com.rwmobi.kunigami.ui.previewsampledata.InsightsSamples
 import com.rwmobi.kunigami.ui.theme.getDimension
@@ -53,7 +53,7 @@ internal fun ProjectedConsumptionTile(
     modifier: Modifier = Modifier,
     insights: Insights,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     Column(
         modifier = modifier
             .clip(shape = MaterialTheme.shapes.large)
@@ -93,7 +93,7 @@ private fun UsageBlock(
     usage: String,
     period: String,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(dimension.grid_1),

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TariffProjectionTilesAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TariffProjectionTilesAdaptive.kt
@@ -29,11 +29,11 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.domain.model.product.Tariff
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.components.TariffSummaryTile
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.consumption.Insights
 import com.rwmobi.kunigami.ui.previewsampledata.InsightsSamples
 import com.rwmobi.kunigami.ui.previewsampledata.TariffSamples
@@ -73,7 +73,7 @@ private fun TariffProjectionsTileFLinear(
     tariff: Tariff?,
     insights: Insights?,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     Column(
         modifier = modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -143,7 +143,7 @@ private fun TariffProjectionsTileFlowRow(
     tariff: Tariff?,
     insights: Insights?,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     val halfWidthModifier = Modifier
         .width(dimension.widgetWidthHalf)
         .height(dimension.widgetHeight)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TitleNavigationBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TitleNavigationBar.kt
@@ -40,10 +40,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.consumption.ConsumptionPresentationStyle
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
@@ -64,7 +64,7 @@ internal fun TitleNavigationBar(
     onNavigateForward: () -> Unit,
     onSwitchPresentationStyle: (consumptionPresentationStyle: ConsumptionPresentationStyle) -> Unit,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     var presentationStyleDropdownMenuExpanded by remember { mutableStateOf(false) }
 
     Surface {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/Dimension.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/Dimension.kt
@@ -16,10 +16,9 @@
 package com.rwmobi.kunigami.ui.theme
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
+import com.rwmobi.kunigami.ui.model.ScreenSizeInfo
 
 /**
  * Source: https://proandroiddev.com/supporting-different-screen-sizes-on-android-with-jetpack-compose-f215c13081bd
@@ -90,7 +89,6 @@ val sw360Dimension = Dimension(
 )
 
 @Composable
-fun Density.getDimension(): Dimension {
-    val screenSizeInfo = getScreenSizeInfo()
-    return if (screenSizeInfo.widthDp <= 360.dp) smallDimension else sw360Dimension
+fun ScreenSizeInfo.getDimension(): Dimension {
+    return if (widthDp <= 360.dp) smallDimension else sw360Dimension
 }

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/components/ScrollbarMultiplatform.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/components/ScrollbarMultiplatform.desktop.kt
@@ -45,6 +45,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.AppTheme
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kotlinx.coroutines.delay
@@ -101,7 +102,7 @@ private fun ScrollbarMultiplatform(
     scrollbarAdapter: ScrollbarAdapter,
     content: @Composable (contentModifier: Modifier) -> Unit,
 ) {
-    val dimension = LocalDensity.current.getDimension()
+    val dimension = getScreenSizeInfo().getDimension()
     val density = LocalDensity.current
 
     var isScrollbarVisible by remember { mutableStateOf(false) }


### PR DESCRIPTION
Some historical reasons we picked Density to extend to provide `dimensions`, but ended up we are not using any of its properties, so `ScreenSizeInfo` is more appropriate and we update its usage in the project.