### PR TITLE
AgileScreen: update CurrentRateTile to show overpriced tag

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -89,6 +89,7 @@
     <string name="agile_tariff_standing_charge">Standing Charge: %1$d p/day</string>
     <string name="agile_current_rate">Current Rate</string>
     <string name="agile_chart_tooltip_range_p">%1$s\n%2$sp</string>
+    <string name="overpriced">Overpriced</string>
 
     <!-- Tariffs -->
     <string name="tariffs_postcode">Postcode: %1$s</string>

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/AgileTariffCardAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/AgileTariffCardAdaptive.kt
@@ -106,6 +106,13 @@ internal fun AgileTariffCardAdaptive(
         null
     }
 
+    val isCurrentRateOverpriced: Boolean = vatInclusivePrice?.let {
+        it >= minOf(
+            latestFixedTariff?.vatInclusiveStandardUnitRate ?: Double.MAX_VALUE,
+            latestFlexibleTariff?.vatInclusiveStandardUnitRate ?: Double.MAX_VALUE,
+        )
+    } ?: false
+
     when (requestedAdaptiveLayout) {
         WindowWidthSizeClass.Compact,
         WindowWidthSizeClass.Medium,
@@ -119,6 +126,7 @@ internal fun AgileTariffCardAdaptive(
                 countDownText = countDownText,
                 latestFlexibleTariff = latestFlexibleTariff,
                 latestFixedTariff = latestFixedTariff,
+                isCurrentRateOverpriced = isCurrentRateOverpriced,
             )
         }
 
@@ -132,6 +140,7 @@ internal fun AgileTariffCardAdaptive(
                 countDownText = countDownText,
                 latestFlexibleTariff = latestFlexibleTariff,
                 latestFixedTariff = latestFixedTariff,
+                isCurrentRateOverpriced = isCurrentRateOverpriced,
             )
         }
     }
@@ -164,6 +173,7 @@ internal fun AgileTariffCardAdaptive(
 private fun AgileTariffCardCompact(
     modifier: Modifier = Modifier,
     targetPercentage: Float,
+    isCurrentRateOverpriced: Boolean,
     vatInclusivePrice: Double? = null,
     countDownText: String? = null,
     rateTrend: RateTrend? = null,
@@ -188,6 +198,7 @@ private fun AgileTariffCardCompact(
         ) {
             CurrentRateTile(
                 modifier = tileModifier,
+                isCurrentRateOverpriced = isCurrentRateOverpriced,
                 vatInclusivePrice = vatInclusivePrice,
                 rateTrend = rateTrend,
                 rateTrendIconTint = rateTrendIconTint,
@@ -241,6 +252,7 @@ private fun ReferenceTariffTiles(
 private fun AgileTariffCardExpanded(
     modifier: Modifier = Modifier,
     targetPercentage: Float,
+    isCurrentRateOverpriced: Boolean,
     vatInclusivePrice: Double? = null,
     countDownText: String? = null,
     rateTrend: RateTrend? = null,
@@ -261,6 +273,7 @@ private fun AgileTariffCardExpanded(
 
         CurrentRateTile(
             modifier = tileModifier,
+            isCurrentRateOverpriced = isCurrentRateOverpriced,
             vatInclusivePrice = vatInclusivePrice,
             rateTrend = rateTrend,
             rateTrendIconTint = rateTrendIconTint,


### PR DESCRIPTION
Solves the problem: How cheap is cheap for Agile?

<img width="302" alt="Screenshot 2024-10-26 at 22 21 57" src="https://github.com/user-attachments/assets/7f8880f2-33e0-4675-a832-a0bbad9f17f2">

Added an animated tag when the current agile unit rate is higher(or equal) than the reference fixed or flexible tariff.

So simply when seeing this tag flashing, it is not wise to consume energy unnecessarily.