### PR TITLE
(#344) agile screen: blink cheapest timeslots

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/IndicatorTextValueGridItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/IndicatorTextValueGridItem.kt
@@ -15,6 +15,7 @@
 
 package com.rwmobi.kunigami.ui.components
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -29,8 +30,14 @@ import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -40,6 +47,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
+import kotlinx.coroutines.delay
 
 @Composable
 fun IndicatorTextValueGridItem(
@@ -47,10 +55,26 @@ fun IndicatorTextValueGridItem(
     indicatorColor: Color,
     label: String,
     value: String,
+    shouldBlinkValue: Boolean = false,
 ) {
     val dimension = getScreenSizeInfo().getDimension()
+    var isBlinkingTextVisible by remember { mutableStateOf(true) }
+    val blinkingAlpha by animateFloatAsState(if (isBlinkingTextVisible) 1f else 0f)
+    LaunchedEffect(shouldBlinkValue) {
+        if (shouldBlinkValue) {
+            while (true) {
+                isBlinkingTextVisible = !isBlinkingTextVisible
+                delay(if (isBlinkingTextVisible) 1000 else 500)
+            }
+        } else {
+            // Clean up
+            isBlinkingTextVisible = true
+        }
+    }
+
     Row(
         modifier = modifier.fillMaxWidth()
+            .alpha(blinkingAlpha)
             .drawBehind {
                 val width = dimension.grid_1.toPx()
                 drawRect(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -228,6 +228,7 @@ fun AgileScreen(
                                         partitionedItems = rateGroupsWithPartitions.partitionedItems,
                                         shouldHideLastColumn = shouldHideLastRateGroupColumn,
                                         rateRange = uiState.rateRange,
+                                        minimumVatInclusivePrice = uiState.minimumVatInclusivePrice,
                                         rowIndex = rowIndex,
                                     )
                                 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileUIState.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileUIState.kt
@@ -51,6 +51,7 @@ data class AgileUIState(
     val latestFixedTariff: Tariff? = null,
     val latestFlexibleTariff: Tariff? = null,
     val rateGroupedCells: List<RateGroup> = emptyList(),
+    val minimumVatInclusivePrice: Double = 0.0,
     val rateRange: ClosedFloatingPointRange<Double> = 0.0..0.0,
     val barChartData: BarChartData? = null,
     val requestScrollToTop: Boolean = false,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/AgileTariffCardAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/AgileTariffCardAdaptive.kt
@@ -106,12 +106,10 @@ internal fun AgileTariffCardAdaptive(
         null
     }
 
-    val isCurrentRateOverpriced: Boolean = vatInclusivePrice?.let {
-        it >= minOf(
-            latestFixedTariff?.vatInclusiveStandardUnitRate ?: Double.MAX_VALUE,
-            latestFlexibleTariff?.vatInclusiveStandardUnitRate ?: Double.MAX_VALUE,
-        )
-    } ?: false
+    val isCurrentRateOverpriced: Boolean = vatInclusivePrice >= minOf(
+        latestFixedTariff?.vatInclusiveStandardUnitRate ?: Double.MAX_VALUE,
+        latestFlexibleTariff?.vatInclusiveStandardUnitRate ?: Double.MAX_VALUE,
+    )
 
     when (requestedAdaptiveLayout) {
         WindowWidthSizeClass.Compact,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/CurrentRateTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/CurrentRateTile.kt
@@ -123,17 +123,16 @@ internal fun CurrentRateTile(
             }
         }
 
-        // Launch a coroutine to toggle visibility
-        var isVisible by remember { mutableStateOf(isCurrentRateOverpriced) }
-        LaunchedEffect(Unit) {
+        var isOverpricedTagVisible by remember { mutableStateOf(isCurrentRateOverpriced) }
+        LaunchedEffect(isCurrentRateOverpriced) {
             if (isCurrentRateOverpriced) {
                 while (true) {
-                    isVisible = !isVisible // Toggle visibility
-                    delay(500) // Blink duration
+                    isOverpricedTagVisible = !isOverpricedTagVisible
+                    delay(500)
                 }
             } else {
                 // Clean up if we move on to a cheaper slot
-                isVisible = false
+                isOverpricedTagVisible = false
             }
         }
         Row(
@@ -148,7 +147,7 @@ internal fun CurrentRateTile(
             )
 
             AnimatedVisibility(
-                visible = isVisible,
+                visible = isOverpricedTagVisible,
                 enter = fadeIn(),
                 exit = fadeOut(),
             ) {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupCells.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupCells.kt
@@ -37,6 +37,7 @@ internal fun RateGroupCells(
     rowIndex: Int,
     shouldHideLastColumn: Boolean,
     rateRange: ClosedFloatingPointRange<Double>,
+    minimumVatInclusivePrice: Double,
 ) {
     val dimension = getScreenSizeInfo().getDimension()
     Row(
@@ -52,6 +53,9 @@ internal fun RateGroupCells(
         for (columnIndex in columnRangeToRender) {
             val item = partitionedItems.getOrNull(columnIndex)?.getOrNull(rowIndex)
             if (item != null) {
+                val value = item.vatInclusivePrice.roundToTwoDecimalPlaces().toString(precision = 2)
+                val shouldBlinkValue = item.vatInclusivePrice == minimumVatInclusivePrice
+
                 IndicatorTextValueGridItem(
                     modifier = Modifier.weight(1f),
                     indicatorColor = RatePalette.lookupColorFromRange(
@@ -60,8 +64,8 @@ internal fun RateGroupCells(
                         shouldUseDarkTheme = shouldUseDarkTheme(),
                     ),
                     label = item.validity.start.getLocalHHMMString(),
-                    value = item.vatInclusivePrice.roundToTwoDecimalPlaces()
-                        .toString(precision = 2),
+                    value = value,
+                    shouldBlinkValue = shouldBlinkValue,
                 )
             } else {
                 Spacer(modifier = Modifier.weight(1f))

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
@@ -174,10 +174,12 @@ class AgileViewModel(
                 }
 
                 val rateGroupedCells = groupChartCells(rates = rates)
+                val minimumVatInclusivePrice = getMinimumVatInclusivePrice(rateGroupedCells)
                 _uiState.update { currentUiState ->
                     currentUiState.copy(
                         requestedScreenType = AgileScreenType.Chart,
                         rateGroupedCells = rateGroupedCells,
+                        minimumVatInclusivePrice = minimumVatInclusivePrice,
                         rateRange = rateRange,
                         barChartData = BarChartData.fromRates(
                             rates = rates,
@@ -298,6 +300,13 @@ class AgileViewModel(
                 }
             },
         )
+    }
+
+    private fun getMinimumVatInclusivePrice(rateGroupedCells: List<RateGroup>): Double {
+        return rateGroupedCells
+            .flatMap { it.rates }
+            .map { it.vatInclusivePrice }
+            .minOrNull() ?: 0.0
     }
 
     override fun onCleared() {


### PR DESCRIPTION
- Fix the previous overpricing tag state
- Set the cheapest agile timeslots to blink