### PR TITLE
(#351) Account Screen UI update

### DIFF
--- a/composeApp/composeApp.podspec
+++ b/composeApp/composeApp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'composeApp'
-    spec.version                  = '2.2.0'
+    spec.version                  = '2.3.0'
     spec.homepage                 = 'https://github.com/ryanw-mobile/OctoMeter/'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/composeApp/src/commonMain/graphql/com/rwmobi/kunigami/queries/PropertiesQuery.graphql
+++ b/composeApp/src/commonMain/graphql/com/rwmobi/kunigami/queries/PropertiesQuery.graphql
@@ -87,4 +87,9 @@ query PropertiesQuery($accountNumber: String!) {
             }
         }
     }
+    account(accountNumber: $accountNumber) {
+        users {
+          preferredName
+        }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/OctopusGraphQLRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/OctopusGraphQLRepository.kt
@@ -479,9 +479,14 @@ class OctopusGraphQLRepository(
                     accountNumber = accountNumber,
                 )
 
-                response.properties?.firstOrNull()?.toAccount(accountNumber = accountNumber)?.also {
-                    inMemoryCacheDataSource.cacheProfile(account = it, createdAt = Clock.System.now())
-                }
+                val preferredName = response.account?.users?.firstOrNull()?.preferredName
+                response.properties?.firstOrNull()?.toAccount(
+                    accountNumber = accountNumber,
+                    preferredName = preferredName,
+                )
+                    ?.also {
+                        inMemoryCacheDataSource.cacheProfile(account = it, createdAt = Clock.System.now())
+                    }
             }
         }.except<CancellationException, _>()
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/AccountMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/AccountMapper.kt
@@ -25,7 +25,7 @@ import kotlinx.datetime.Instant
 /***
  * Throws: IllegalArgumentException - if the timestamp return from API is not parsable
  */
-fun PropertiesQuery.Property.toAccount(accountNumber: String): Account {
+fun PropertiesQuery.Property.toAccount(accountNumber: String, preferredName: String?): Account {
     // We decided to take the latest occupancy. This has no other side-effects other than a date showing on the screen.
     val occupancyPeriod = occupancyPeriods?.maxByOrNull {
         it?.effectiveFrom?.let { effectiveFrom ->
@@ -35,6 +35,7 @@ fun PropertiesQuery.Property.toAccount(accountNumber: String): Account {
 
     return Account(
         accountNumber = accountNumber,
+        preferredName = preferredName,
         movedInAt = occupancyPeriod?.effectiveFrom?.let { Instant.parse(it.toString()) },
         movedOutAt = occupancyPeriod?.effectiveTo?.let { Instant.parse(it.toString()) },
         fullAddress = address,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/account/Account.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/account/Account.kt
@@ -22,6 +22,7 @@ import kotlinx.datetime.Instant
 @Immutable
 data class Account(
     val accountNumber: String,
+    val preferredName: String?,
     val fullAddress: String?,
     val postcode: String?,
     val movedInAt: Instant?,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountInformationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountInformationScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -34,6 +35,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.domain.extensions.getLocalDateString
@@ -86,39 +88,62 @@ internal fun AccountInformationScreen(
                 onSecondaryButtonClicked = uiEvent.onClearCredentialButtonClicked,
             )
         } else {
-            Spacer(modifier = Modifier.height(height = dimension.grid_2))
+            Spacer(modifier = Modifier.height(height = dimension.grid_1))
 
-            Text(
-                style = MaterialTheme.typography.headlineMedium,
-                fontWeight = FontWeight.Bold,
-                maxLines = 1,
-                text = stringResource(resource = Res.string.account_number, uiState.userProfile.account.accountNumber),
-            )
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(dimension.grid_2),
+                    verticalArrangement = Arrangement.spacedBy(dimension.grid_2),
+                ) {
+                    Column {
+                        Text(
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.Bold,
+                            maxLines = 1,
+                            text = "Welcome back ${uiState.userProfile.account.preferredName}!",
+                        )
 
-            uiState.userProfile.account.fullAddress?.let {
-                Text(
-                    style = MaterialTheme.typography.bodyLarge,
-                    text = it,
-                )
-            } ?: run {
-                Text(
-                    style = MaterialTheme.typography.bodyLarge,
-                    text = stringResource(resource = Res.string.account_unknown_installation_address),
-                )
-            }
+                        Text(
+                            modifier = Modifier.alpha(0.5f),
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.Bold,
+                            maxLines = 1,
+                            text = stringResource(resource = Res.string.account_number, uiState.userProfile.account.accountNumber),
+                        )
+                    }
 
-            uiState.userProfile.account.movedInAt?.let {
-                Text(
-                    style = MaterialTheme.typography.bodyMedium,
-                    text = stringResource(resource = Res.string.account_moved_in, it.getLocalDateString()),
-                )
-            }
+                    uiState.userProfile.account.fullAddress?.let {
+                        Text(
+                            style = MaterialTheme.typography.bodyLarge,
+                            text = it,
+                        )
+                    } ?: run {
+                        Text(
+                            style = MaterialTheme.typography.bodyLarge,
+                            text = stringResource(resource = Res.string.account_unknown_installation_address),
+                        )
+                    }
 
-            uiState.userProfile.account.movedOutAt?.let {
-                Text(
-                    style = MaterialTheme.typography.bodyMedium,
-                    text = stringResource(resource = Res.string.account_moved_out, it.getLocalDateString()),
-                )
+                    Column {
+                        uiState.userProfile.account.movedInAt?.let {
+                            Text(
+                                style = MaterialTheme.typography.bodyMedium,
+                                text = stringResource(resource = Res.string.account_moved_in, it.getLocalDateString()),
+                            )
+                        }
+
+                        uiState.userProfile.account.movedOutAt?.let {
+                            Text(
+                                style = MaterialTheme.typography.bodyMedium,
+                                text = stringResource(resource = Res.string.account_moved_out, it.getLocalDateString()),
+                            )
+                        }
+                    }
+                }
             }
 
             uiState.userProfile.account.electricityMeterPoints.forEach { meterPoint ->

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountInformationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountInformationScreen.kt
@@ -20,15 +20,11 @@ package com.rwmobi.kunigami.ui.destinations.account
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -37,7 +33,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -45,10 +40,9 @@ import com.rwmobi.kunigami.domain.extensions.getLocalDateString
 import com.rwmobi.kunigami.domain.model.account.UserProfile
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.components.MessageActionScreen
-import com.rwmobi.kunigami.ui.components.SquareButton
 import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
+import com.rwmobi.kunigami.ui.destinations.account.components.AccountOperationButtonBar
 import com.rwmobi.kunigami.ui.destinations.account.components.AppInfoFooter
-import com.rwmobi.kunigami.ui.destinations.account.components.DemoModeConfirmDialog
 import com.rwmobi.kunigami.ui.destinations.account.components.ElectricityMeterPointCard
 import com.rwmobi.kunigami.ui.destinations.account.components.UpdateApiKeyDialog
 import com.rwmobi.kunigami.ui.model.SpecialErrorScreen
@@ -56,18 +50,12 @@ import com.rwmobi.kunigami.ui.previewsampledata.AccountSamples
 import com.rwmobi.kunigami.ui.theme.AppTheme
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
-import kunigami.composeapp.generated.resources.account_clear_cache
 import kunigami.composeapp.generated.resources.account_clear_credential_title
-import kunigami.composeapp.generated.resources.account_demo_mode
 import kunigami.composeapp.generated.resources.account_error_account_empty
 import kunigami.composeapp.generated.resources.account_moved_in
 import kunigami.composeapp.generated.resources.account_moved_out
 import kunigami.composeapp.generated.resources.account_number
 import kunigami.composeapp.generated.resources.account_unknown_installation_address
-import kunigami.composeapp.generated.resources.account_update_api_key
-import kunigami.composeapp.generated.resources.database_remove_outline
-import kunigami.composeapp.generated.resources.eraser
-import kunigami.composeapp.generated.resources.key
 import kunigami.composeapp.generated.resources.retry
 import kunigami.composeapp.generated.resources.unlink
 import org.jetbrains.compose.resources.ExperimentalResourceApi
@@ -158,61 +146,11 @@ internal fun AccountInformationScreen(
             )
         }
 
-        var shouldShowDemoModeConfirmDialog by rememberSaveable { mutableStateOf(false) }
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.Top,
-            horizontalArrangement = Arrangement.spacedBy(
-                dimension.grid_4,
-                alignment = Alignment.CenterHorizontally,
-            ),
-        ) {
-            SquareButton(
-                modifier = Modifier
-                    .width(width = 80.dp)
-                    .wrapContentHeight(),
-                icon = painterResource(resource = Res.drawable.key),
-                text = stringResource(resource = Res.string.account_update_api_key),
-                colors = ButtonDefaults.buttonColors().copy(
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                ),
-                onClick = { isUpdateAPIKeyDialogOpened = true },
-            )
-
-            SquareButton(
-                modifier = Modifier
-                    .width(width = 80.dp)
-                    .wrapContentHeight(),
-                icon = painterResource(resource = Res.drawable.database_remove_outline),
-                text = stringResource(resource = Res.string.account_clear_cache),
-                colors = ButtonDefaults.buttonColors().copy(
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                ),
-                onClick = { uiEvent.onClearCache { getString(resource = it) } },
-            )
-
-            SquareButton(
-                modifier = Modifier
-                    .width(width = 80.dp)
-                    .wrapContentHeight(),
-                icon = painterResource(resource = Res.drawable.eraser),
-                text = stringResource(resource = Res.string.account_demo_mode),
-                colors = ButtonDefaults.buttonColors().copy(
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                ),
-                onClick = { shouldShowDemoModeConfirmDialog = true },
-            )
-        }
-
-        if (shouldShowDemoModeConfirmDialog) {
-            DemoModeConfirmDialog(
-                onSwitchToDemoMode = uiEvent.onClearCredentialButtonClicked,
-                onCancel = { shouldShowDemoModeConfirmDialog = false },
-            )
-        }
+        AccountOperationButtonBar(
+            onUpdateApiKey = { isUpdateAPIKeyDialogOpened = true },
+            onClearCache = { uiEvent.onClearCache { getString(resource = it) } },
+            onSwitchToDemoMode = { uiEvent.onClearCredentialButtonClicked },
+        )
 
         AppInfoFooter(modifier = Modifier.fillMaxWidth())
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/AccountOperationButtonBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/AccountOperationButtonBar.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024. RW MobiMedia UK Limited
+ *
+ * Contributions made by other developers remain the property of their respective authors but are licensed
+ * to RW MobiMedia UK Limited and others under the same licence terms as the main project, as outlined in
+ * the LICENSE file.
+ *
+ * RW MobiMedia UK Limited reserves the exclusive right to distribute this application on app stores.
+ * Reuse of this source code, with or without modifications, requires proper attribution to
+ * RW MobiMedia UK Limited.  Commercial distribution of this code or its derivatives without prior written
+ * permission from RW MobiMedia UK Limited is prohibited.
+ *
+ * Please refer to the LICENSE file for the full terms and conditions.
+ */
+
+package com.rwmobi.kunigami.ui.destinations.account.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.rwmobi.kunigami.ui.components.SquareButton
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
+import com.rwmobi.kunigami.ui.theme.getDimension
+import kunigami.composeapp.generated.resources.Res
+import kunigami.composeapp.generated.resources.account_clear_cache
+import kunigami.composeapp.generated.resources.account_demo_mode
+import kunigami.composeapp.generated.resources.account_update_api_key
+import kunigami.composeapp.generated.resources.database_remove_outline
+import kunigami.composeapp.generated.resources.eraser
+import kunigami.composeapp.generated.resources.key
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun AccountOperationButtonBar(
+    onUpdateApiKey: () -> Unit,
+    onClearCache: () -> Unit,
+    onSwitchToDemoMode: () -> Unit,
+) {
+    val dimension = getScreenSizeInfo().getDimension()
+    var shouldShowDemoModeConfirmDialog by rememberSaveable { mutableStateOf(false) }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.spacedBy(
+            dimension.grid_4,
+            alignment = Alignment.CenterHorizontally,
+        ),
+    ) {
+        SquareButton(
+            modifier = Modifier
+                .width(width = 80.dp)
+                .wrapContentHeight(),
+            icon = painterResource(resource = Res.drawable.key),
+            text = stringResource(resource = Res.string.account_update_api_key),
+            colors = ButtonDefaults.buttonColors().copy(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            ),
+            onClick = onUpdateApiKey,
+        )
+
+        SquareButton(
+            modifier = Modifier
+                .width(width = 80.dp)
+                .wrapContentHeight(),
+            icon = painterResource(resource = Res.drawable.database_remove_outline),
+            text = stringResource(resource = Res.string.account_clear_cache),
+            colors = ButtonDefaults.buttonColors().copy(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            ),
+            onClick = onClearCache,
+        )
+
+        SquareButton(
+            modifier = Modifier
+                .width(width = 80.dp)
+                .wrapContentHeight(),
+            icon = painterResource(resource = Res.drawable.eraser),
+            text = stringResource(resource = Res.string.account_demo_mode),
+            colors = ButtonDefaults.buttonColors().copy(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            ),
+            onClick = { shouldShowDemoModeConfirmDialog = true },
+        )
+    }
+
+    if (shouldShowDemoModeConfirmDialog) {
+        DemoModeConfirmDialog(
+            onSwitchToDemoMode = onSwitchToDemoMode,
+            onCancel = { shouldShowDemoModeConfirmDialog = false },
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/ElectricityMeterPointCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/ElectricityMeterPointCard.kt
@@ -24,11 +24,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Card
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import com.rwmobi.kunigami.domain.model.account.ElectricityMeterPoint
 import com.rwmobi.kunigami.ui.components.IconTextButton
 import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
@@ -113,6 +115,14 @@ internal fun ElectricityMeterPointCard(
                         onClick = onReloadTariff,
                     )
                 }
+            }
+
+            if (meterPoint.meters.isNotEmpty()) {
+                HorizontalDivider(
+                    modifier = Modifier
+                        .padding(horizontal = dimension.grid_2, vertical = dimension.grid_1)
+                        .alpha(0.5f),
+                )
             }
 
             val meterSerialNumberTextStyle = if (requestedLayout is AccountScreenLayoutStyle.Compact) {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductBottomSheetWrapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductBottomSheetWrapper.kt
@@ -18,6 +18,7 @@ package com.rwmobi.kunigami.ui.destinations.tariffs.components
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
@@ -38,6 +39,7 @@ internal fun ProductBottomSheetWrapper(
     val dimension = getScreenSizeInfo().getDimension()
     ModalBottomSheet(
         modifier = modifier,
+        containerColor = CardDefaults.cardColors().containerColor,
         onDismissRequest = onDismissRequest,
         sheetState = bottomSheetState,
     ) {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductScreenLayout.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductScreenLayout.kt
@@ -16,15 +16,18 @@
 package com.rwmobi.kunigami.ui.destinations.tariffs.components
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import com.rwmobi.kunigami.domain.model.product.ExitFeesType
 import com.rwmobi.kunigami.domain.model.product.ProductDetails
 import com.rwmobi.kunigami.domain.model.product.ProductDirection
@@ -43,22 +46,31 @@ internal fun LazyListScope.productScreenLayout(
     item(key = "productFacts") {
         val dimension = getScreenSizeInfo().getDimension()
         Column(
-            modifier = modifier,
+            modifier = modifier.padding(horizontal = dimension.grid_2),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(space = dimension.grid_2),
         ) {
-            ProductFacts(
-                modifier = Modifier.widthIn(max = dimension.windowWidthCompact),
-                productDetails = productDetails,
-            )
+            val blockModifier = Modifier
+                .clip(shape = MaterialTheme.shapes.large)
+                .background(MaterialTheme.colorScheme.surfaceContainer)
+                .padding(dimension.grid_1)
 
-            productDetails.electricityTariff?.let { tariffDetails ->
-                RegionTariff(
-                    modifier = Modifier
-                        .widthIn(max = dimension.windowWidthCompact)
-                        .padding(all = dimension.grid_2),
-                    tariff = tariffDetails,
+            Column(modifier = blockModifier) {
+                ProductFacts(
+                    modifier = Modifier.widthIn(max = dimension.windowWidthCompact),
+                    productDetails = productDetails,
                 )
+            }
+
+            Column(modifier = blockModifier) {
+                productDetails.electricityTariff?.let { tariffDetails ->
+                    RegionTariff(
+                        modifier = Modifier
+                            .widthIn(max = dimension.windowWidthCompact)
+                            .padding(all = dimension.grid_2),
+                        tariff = tariffDetails,
+                    )
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionQueryFilter.kt
@@ -46,7 +46,7 @@ import kunigami.composeapp.generated.resources.presentation_style_week_seven_day
 data class ConsumptionQueryFilter(
     val presentationStyle: ConsumptionPresentationStyle = ConsumptionPresentationStyle.DAY_HALF_HOURLY,
     val referencePoint: Instant = Clock.System.now(),
-    val requestedPeriod: ClosedRange<Instant> = calculateQueryPeriod(referencePoint = Clock.System.now(), ConsumptionPresentationStyle.DAY_HALF_HOURLY),
+    val requestedPeriod: ClosedRange<Instant> = calculateQueryPeriod(referencePoint = referencePoint, ConsumptionPresentationStyle.DAY_HALF_HOURLY),
 ) {
     companion object {
         fun calculateQueryPeriod(referencePoint: Instant, presentationStyle: ConsumptionPresentationStyle): ClosedRange<Instant> {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/previewsampledata/AccountSamples.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/previewsampledata/AccountSamples.kt
@@ -58,6 +58,7 @@ internal object AccountSamples {
     // This account is used in demo mode - usage. Needs to have sensible values.
     val account928 = Account(
         accountNumber = "A-9009A9A9",
+        preferredName = "Ryan",
         fullAddress = "RW MobiMedia UK Limited\n2 Frederick Street\nKing's Cross\nLondon\nWC1X 0ND",
         postcode = "WC1X 0ND",
         movedInAt = Instant.parse("2022-03-28T00:00:00Z"),
@@ -84,6 +85,7 @@ internal object AccountSamples {
 
     val accountTwoElectricityMeterPoint = Account(
         accountNumber = "A-1234A1B1",
+        preferredName = "Ryan",
         fullAddress = "RW MobiMedia UK Limited\n2 Frederick Street\nKing's Cross\nLondon\nWC1X 0ND",
         postcode = "WC1X 0ND",
         movedInAt = Clock.System.now(),

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/AccountSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/AccountSampleData.kt
@@ -26,6 +26,7 @@ import kotlin.time.Duration
 object AccountSampleData {
     val accountA1234A1B1 = Account(
         accountNumber = "A-1234A1B1",
+        preferredName = "Ryan",
         fullAddress = "RW MobiMedia UK Limited\n2 Frederick Street\nKing's Cross\nLondon\nWC1X 0ND",
         postcode = "WC1X 0ND",
         movedInAt = Clock.System.now(),
@@ -64,6 +65,7 @@ object AccountSampleData {
 
     val accountB1234A1A1 = Account(
         accountNumber = "B-1234A1A1",
+        preferredName = "Ryan",
         fullAddress = "10 downing street\nLondon\nW1 1AA",
         postcode = "W1 1AA",
         movedInAt = Instant.parse("2020-11-30T00:00:00Z"),

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetAccountSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/test/samples/GetAccountSampleData.kt
@@ -275,13 +275,21 @@ object GetAccountSampleData {
           }
         ]
       }
-    ]
+    ],
+    "account": {
+      "users": [
+        {
+          "preferredName": "Ryan"
+        }
+      ]
+    }
   }
 }
     """.trimIndent()
 
     val account = Account(
         accountNumber = "B-1234A1A1",
+        preferredName = "Ryan",
         fullAddress = "10 Downing Street, LONDON, W1 1AA",
         postcode = "W1 1AA",
         movedInAt = Instant.parse("2020-11-30T00:00:00Z"),

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/ui/viewmodels/UsageViewModelTest.kt
@@ -36,6 +36,7 @@ import com.rwmobi.kunigami.ui.model.ScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.SpecialErrorScreen
 import com.rwmobi.kunigami.ui.model.StubStringResourceProvider
 import com.rwmobi.kunigami.ui.model.consumption.ConsumptionPresentationStyle
+import com.rwmobi.kunigami.ui.model.consumption.ConsumptionQueryFilter
 import com.rwmobi.kunigami.ui.previewsampledata.AccountSamples
 import com.rwmobi.kunigami.ui.previewsampledata.TariffSamples
 import io.ktor.util.network.UnresolvedAddressException
@@ -287,7 +288,11 @@ class UsageViewModelTest {
         usageViewModel.initialLoad()
         advanceUntilIdle()
 
-        val currentFilter = usageViewModel.uiState.value.consumptionQueryFilter!!
+        // Make sure it must be able to navigate forward
+        val currentFilter = ConsumptionQueryFilter(
+            presentationStyle = ConsumptionPresentationStyle.DAY_HALF_HOURLY,
+            referencePoint = Clock.System.now() - Duration.parse("2d"),
+        )
         usageViewModel.onNextTimeFrame(consumptionQueryFilter = currentFilter)
         advanceUntilIdle()
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,8 +43,8 @@ apollographqlMockServer = "0.1.0"
 testRules = "1.6.1"
 
 # App configurations, not dependencies
-versionCode = "13"
-versionName = "2.2.0"
+versionCode = "14"
+versionName = "2.3.0"
 android-minSdk = "26"
 android-targetSdk = "34"
 android-compileSdk = "34"

--- a/iosApp/OctoMeter.xcodeproj/project.pbxproj
+++ b/iosApp/OctoMeter.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = V8M4R7N63C;
 				ENABLE_PREVIEWS = YES;
@@ -401,7 +401,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.3.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
@@ -422,7 +422,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = V8M4R7N63C;
 				ENABLE_PREVIEWS = YES;
@@ -439,7 +439,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.3.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",

--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - composeApp (2.2.0)
+  - composeApp (2.3.0)
 
 DEPENDENCIES:
   - composeApp (from `../composeApp/`)

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.0</string>
+	<string>2.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
Minor update to the Account screen. 
- When logged in, we now greet the user with the preferred name as returned from the Octopus Energy account.
- Also wrapped the heading section using `Card{}` to make the layout more consistent.


Should be good for another release