### PR TITLE
(#358) fix agile glitches rounding and blink

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/ConsumptionMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/ConsumptionMapper.kt
@@ -17,11 +17,11 @@ package com.rwmobi.kunigami.data.repository.mapper
 
 import com.rwmobi.kunigami.data.source.local.database.entity.ConsumptionEntity
 import com.rwmobi.kunigami.data.source.network.dto.consumption.ConsumptionDto
-import com.rwmobi.kunigami.domain.extensions.roundToNearestEvenHundredth
+import com.rwmobi.kunigami.domain.extensions.roundConsumptionToNearestEvenHundredth
 import com.rwmobi.kunigami.domain.model.consumption.Consumption
 
 fun ConsumptionDto.toConsumption() = Consumption(
-    kWhConsumed = consumption.roundToNearestEvenHundredth(),
+    kWhConsumed = consumption.roundConsumptionToNearestEvenHundredth(),
     interval = intervalStart..intervalEnd,
 )
 
@@ -33,6 +33,6 @@ fun ConsumptionDto.toConsumptionEntity(meterSerial: String) = ConsumptionEntity(
 )
 
 fun ConsumptionEntity.toConsumption() = Consumption(
-    kWhConsumed = kWhConsumed.roundToNearestEvenHundredth(),
+    kWhConsumed = kWhConsumed.roundConsumptionToNearestEvenHundredth(),
     interval = intervalStart..intervalEnd,
 )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/DoubleExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/extensions/DoubleExtensions.kt
@@ -24,7 +24,7 @@ import kotlin.math.roundToLong
  * The rounding method used is rounding half to even, where numbers ending in 5 are rounded up or down, towards the nearest even hundredth decimal place.
  * As a result, 0.015 would be rounded up to 0.02, while 0.025 is rounded down to 0.02.
  */
-fun Double.roundToNearestEvenHundredth(): Double {
+fun Double.roundConsumptionToNearestEvenHundredth(): Double {
     val scaled = this * 100
     val rounded = if (scaled % 1.0 == 0.5) {
         if (scaled.toLong() % 2 == 0L) {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/consumption/GenerateUsageInsightsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/consumption/GenerateUsageInsightsUseCase.kt
@@ -15,7 +15,7 @@
 
 package com.rwmobi.kunigami.domain.usecase.consumption
 
-import com.rwmobi.kunigami.domain.extensions.roundToNearestEvenHundredth
+import com.rwmobi.kunigami.domain.extensions.roundConsumptionToNearestEvenHundredth
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.domain.model.consumption.ConsumptionWithCost
 import com.rwmobi.kunigami.domain.model.consumption.getConsumptionDaySpan
@@ -50,14 +50,14 @@ class GenerateUsageInsightsUseCase {
             val costAnnualProjection = (tariff.vatInclusiveStandingCharge * 365 + consumptionAnnualProjection * consumptionCharge / consumptionAggregateRounded) / 100.0
 
             Insights(
-                consumptionAggregateRounded = consumptionAggregateRounded.roundToNearestEvenHundredth(),
+                consumptionAggregateRounded = consumptionAggregateRounded.roundConsumptionToNearestEvenHundredth(),
                 consumptionTimeSpan = consumptionTimeSpan,
                 consumptionChargeRatio = consumptionChargeRatio.roundToTwoDecimalPlaces(),
                 costWithCharges = costWithCharges.roundToTwoDecimalPlaces(),
                 isTrueCost = isTrueCost,
-                consumptionDailyAverage = consumptionDailyAverage.roundToNearestEvenHundredth(),
+                consumptionDailyAverage = consumptionDailyAverage.roundConsumptionToNearestEvenHundredth(),
                 costDailyAverage = costDailyAverage.roundToTwoDecimalPlaces(),
-                consumptionAnnualProjection = consumptionAnnualProjection.roundToNearestEvenHundredth(),
+                consumptionAnnualProjection = consumptionAnnualProjection.roundConsumptionToNearestEvenHundredth(),
                 costAnnualProjection = costAnnualProjection.roundToTwoDecimalPlaces(),
             )
         }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/IndicatorTextValueGridItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/IndicatorTextValueGridItem.kt
@@ -15,7 +15,6 @@
 
 package com.rwmobi.kunigami.ui.components
 
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -30,11 +29,6 @@ import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -47,7 +41,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.getDimension
-import kotlinx.coroutines.delay
 
 @Composable
 fun IndicatorTextValueGridItem(
@@ -55,22 +48,9 @@ fun IndicatorTextValueGridItem(
     indicatorColor: Color,
     label: String,
     value: String,
-    shouldBlinkValue: Boolean = false,
+    blinkingAlpha: Float = 1f,
 ) {
     val dimension = getScreenSizeInfo().getDimension()
-    var isBlinkingTextVisible by remember { mutableStateOf(true) }
-    val blinkingAlpha by animateFloatAsState(if (isBlinkingTextVisible) 1f else 0f)
-    LaunchedEffect(shouldBlinkValue) {
-        if (shouldBlinkValue) {
-            while (true) {
-                isBlinkingTextVisible = !isBlinkingTextVisible
-                delay(if (isBlinkingTextVisible) 1000 else 500)
-            }
-        } else {
-            // Clean up
-            isBlinkingTextVisible = true
-        }
-    }
 
     Row(
         modifier = modifier.fillMaxWidth()
@@ -138,6 +118,7 @@ private fun Preview() {
             indicatorColor = Color.Red,
             label = "03:30",
             value = "0.05",
+            blinkingAlpha = 1f,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -15,6 +15,7 @@
 
 package com.rwmobi.kunigami.ui.destinations.agile
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -33,7 +34,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.SolidColor
@@ -146,6 +150,16 @@ fun AgileScreen(
                         enabled = uiState.rateGroupedCells.isNotEmpty(),
                         lazyListState = lazyListState,
                     ) { contentModifier ->
+                        // All eligible rate group cell is sharing the same blinking alpha properties
+                        var isBlinkingTextVisible by remember { mutableStateOf(true) }
+                        val blinkingAlpha by animateFloatAsState(if (isBlinkingTextVisible) 1f else 0f)
+                        LaunchedEffect(Unit) {
+                            while (true) {
+                                isBlinkingTextVisible = !isBlinkingTextVisible
+                                delay(if (isBlinkingTextVisible) 1000 else 500)
+                            }
+                        }
+
                         LazyColumn(
                             modifier = contentModifier.conditionalBlur(enabled = uiState.isLoading && uiState.barChartData == null),
                             contentPadding = PaddingValues(bottom = dimension.grid_4),
@@ -230,6 +244,7 @@ fun AgileScreen(
                                         rateRange = uiState.rateRange,
                                         minimumVatInclusivePrice = uiState.minimumVatInclusivePrice,
                                         rowIndex = rowIndex,
+                                        blinkingAlpha = blinkingAlpha,
                                     )
                                 }
                             }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupCells.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupCells.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.rwmobi.kunigami.domain.extensions.getLocalHHMMString
-import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.domain.model.rate.Rate
 import com.rwmobi.kunigami.ui.components.IndicatorTextValueGridItem
 import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
@@ -53,7 +52,7 @@ internal fun RateGroupCells(
         for (columnIndex in columnRangeToRender) {
             val item = partitionedItems.getOrNull(columnIndex)?.getOrNull(rowIndex)
             if (item != null) {
-                val value = item.vatInclusivePrice.roundToTwoDecimalPlaces().toString(precision = 2)
+                val roundedVatInclusivePriceString = item.vatInclusivePrice.toString(precision = 2)
                 val shouldBlinkValue = item.vatInclusivePrice == minimumVatInclusivePrice
 
                 IndicatorTextValueGridItem(
@@ -64,7 +63,7 @@ internal fun RateGroupCells(
                         shouldUseDarkTheme = shouldUseDarkTheme(),
                     ),
                     label = item.validity.start.getLocalHHMMString(),
-                    value = value,
+                    value = roundedVatInclusivePriceString,
                     shouldBlinkValue = shouldBlinkValue,
                 )
             } else {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupCells.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupCells.kt
@@ -37,8 +37,10 @@ internal fun RateGroupCells(
     shouldHideLastColumn: Boolean,
     rateRange: ClosedFloatingPointRange<Double>,
     minimumVatInclusivePrice: Double,
+    blinkingAlpha: Float = 1f,
 ) {
     val dimension = getScreenSizeInfo().getDimension()
+
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_3),
@@ -64,7 +66,7 @@ internal fun RateGroupCells(
                     ),
                     label = item.validity.start.getLocalHHMMString(),
                     value = roundedVatInclusivePriceString,
-                    shouldBlinkValue = shouldBlinkValue,
+                    blinkingAlpha = if (shouldBlinkValue) blinkingAlpha else 1f,
                 )
             } else {
                 Spacer(modifier = Modifier.weight(1f))

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionGroupedCells.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/model/consumption/ConsumptionGroupedCells.kt
@@ -16,7 +16,7 @@
 package com.rwmobi.kunigami.ui.model.consumption
 
 import androidx.compose.runtime.Immutable
-import com.rwmobi.kunigami.domain.extensions.roundToNearestEvenHundredth
+import com.rwmobi.kunigami.domain.extensions.roundConsumptionToNearestEvenHundredth
 import com.rwmobi.kunigami.domain.model.consumption.Consumption
 
 @Immutable
@@ -43,7 +43,7 @@ data class ConsumptionGroupedCells(
 fun List<ConsumptionGroupedCells>.getAggregateConsumption(rounded: Boolean): Double {
     return sumOf { it.getAggregateConsumption() }.run {
         if (rounded) {
-            roundToNearestEvenHundredth()
+            roundConsumptionToNearestEvenHundredth()
         } else {
             this
         }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/DoubleExtensionsKtTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/kunigami/domain/extensions/DoubleExtensionsKtTest.kt
@@ -13,7 +13,7 @@
  * Please refer to the LICENSE file for the full terms and conditions.
  */
 
-import com.rwmobi.kunigami.domain.extensions.roundToNearestEvenHundredth
+import com.rwmobi.kunigami.domain.extensions.roundConsumptionToNearestEvenHundredth
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -25,7 +25,7 @@ class DoubleExtensionsKtTest {
     fun `roundToNearestEvenHundredth should round 0_015 to 0_02`() {
         val input = 0.015
         val expected = 0.02
-        val result = input.roundToNearestEvenHundredth()
+        val result = input.roundConsumptionToNearestEvenHundredth()
         assertEquals(expected, result)
     }
 
@@ -33,7 +33,7 @@ class DoubleExtensionsKtTest {
     fun `roundToNearestEvenHundredth should round 0_025 to 0_02`() {
         val input = 0.025
         val expected = 0.02
-        val result = input.roundToNearestEvenHundredth()
+        val result = input.roundConsumptionToNearestEvenHundredth()
         assertEquals(expected, result)
     }
 
@@ -41,7 +41,7 @@ class DoubleExtensionsKtTest {
     fun `roundToNearestEvenHundredth should round 0_045 to 0_04`() {
         val input = 0.045
         val expected = 0.04
-        val result = input.roundToNearestEvenHundredth()
+        val result = input.roundConsumptionToNearestEvenHundredth()
         assertEquals(expected, result)
     }
 
@@ -49,7 +49,7 @@ class DoubleExtensionsKtTest {
     fun `roundToNearestEvenHundredth should round 0_055 to 0_06`() {
         val input = 0.055
         val expected = 0.06
-        val result = input.roundToNearestEvenHundredth()
+        val result = input.roundConsumptionToNearestEvenHundredth()
         assertEquals(expected, result)
     }
 


### PR DESCRIPTION
Agile screen UI minor fixes:
- Unified current rate tile and rate cells to use the same correct rounding function - provided by KoalaPlot. Our own rounding function is not delivering the expected results and we intended to ditch KoalaPlot, so eventually, we have to fix ours.
- Hoist the blinking text alpha animations at the parent Agile screen level, so all rate cells, when blink, will have the same effects in-sync,