### PR TITLE
(#364) Usage screen: fix tiles section to support more tariff types

### DIFF
--- a/composeApp/composeApp.podspec
+++ b/composeApp/composeApp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'composeApp'
-    spec.version                  = '2.3.0'
+    spec.version                  = '2.3.1'
     spec.homepage                 = 'https://github.com/ryanw-mobile/OctoMeter/'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/composeApp/src/commonMain/graphql/com/rwmobi/kunigami/queries/PropertiesQuery.graphql
+++ b/composeApp/src/commonMain/graphql/com/rwmobi/kunigami/queries/PropertiesQuery.graphql
@@ -11,6 +11,10 @@ query PropertiesQuery($accountNumber: String!) {
             meters {
                 serialNumber
                 makeAndType
+                smartImportElectricityMeter {
+                    deviceId
+                    __typename
+                }
                 meterPoint {
                     meters {
                         serialNumber

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/TariffMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/repository/mapper/TariffMapper.kt
@@ -25,7 +25,11 @@ fun SingleEnergyProductQuery.EnergyProduct.toTariff(
     tariffCode: String,
 ): Tariff? {
     val tariffNode = tariffs?.edges
-        ?.firstOrNull { it?.node?.onStandardTariff?.tariffCode == tariffCode }
+        ?.firstOrNull {
+            it?.node?.onStandardTariff?.tariffCode == tariffCode ||
+                it?.node?.onDayNightTariff?.tariffCode == tariffCode ||
+                it?.node?.onThreeRateTariff?.tariffCode == tariffCode
+        }
         ?.node
 
     if (tariffNode == null) {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/Tariff.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/model/product/Tariff.kt
@@ -88,7 +88,28 @@ data class Tariff(
         }
     }
 
-    // TODO: WIP - We do not support dual rates and don't know how it works for now
+    fun containsValidUnitRate(): Boolean {
+        return when (getElectricityTariffType()) {
+            ElectricityTariffType.STANDARD -> {
+                vatInclusiveStandardUnitRate != null || isVariable
+            }
+
+            ElectricityTariffType.DAY_NIGHT -> {
+                vatInclusiveDayUnitRate != null &&
+                    vatInclusiveNightUnitRate != null
+            }
+
+            ElectricityTariffType.THREE_RATE -> {
+                vatInclusiveDayUnitRate != null &&
+                    vatInclusiveNightUnitRate != null &&
+                    vatInclusiveOffPeakRate != null
+            }
+
+            else -> false
+        }
+    }
+
+    // TODO: This function will be removed once we have migrated to get billing data from GraphQL
     fun resolveUnitRate(referencePoint: Instant? = null): Double? {
         return when (getElectricityTariffType()) {
             ElectricityTariffType.STANDARD -> {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TariffSummaryTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TariffSummaryTile.kt
@@ -35,11 +35,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
+import com.rwmobi.kunigami.domain.model.product.ElectricityTariffType
 import com.rwmobi.kunigami.domain.model.product.Tariff
 import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.previewsampledata.TariffSamples
 import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
+import kunigami.composeapp.generated.resources.day_unit_rate
+import kunigami.composeapp.generated.resources.night_unit_rate
+import kunigami.composeapp.generated.resources.off_peak_rate
 import kunigami.composeapp.generated.resources.standard_unit_rate
 import kunigami.composeapp.generated.resources.standing_charge
 import kunigami.composeapp.generated.resources.tariffs_variable
@@ -90,38 +95,11 @@ internal fun TariffSummaryTile(
             )
         }
 
-        val resolvedUnitRate = tariff.resolveUnitRate()
-        val rateString = when {
-            tariff.isVariable -> stringResource(resource = Res.string.tariffs_variable)
-            resolvedUnitRate != null -> stringResource(resource = Res.string.unit_p_kwh, resolvedUnitRate)
-            else -> null
-        }
-
-        if (rateString != null) {
-            HorizontalDivider(
-                modifier = Modifier
-                    .padding(vertical = dimension.grid_1)
-                    .alpha(0.5f),
+        val shouldShowUnitRate = tariff.containsValidUnitRate()
+        if (shouldShowUnitRate) {
+            UnitRateLayout(
+                tariff = tariff,
             )
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_0_5),
-            ) {
-                Text(
-                    modifier = Modifier.weight(weight = 1f),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    text = stringResource(resource = Res.string.standard_unit_rate),
-                )
-                Text(
-                    modifier = Modifier.wrapContentWidth(),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    text = rateString,
-                )
-            }
         }
 
         Spacer(modifier = Modifier.weight(1f))
@@ -132,6 +110,115 @@ internal fun TariffSummaryTile(
             fontWeight = FontWeight.Normal,
             text = stringResource(resource = Res.string.usage_applied_tariff),
         )
+    }
+}
+
+@Composable
+private fun UnitRateLayout(
+    modifier: Modifier = Modifier,
+    tariff: Tariff,
+) {
+    val dimension = getScreenSizeInfo().getDimension()
+    HorizontalDivider(
+        modifier = Modifier
+            .padding(vertical = dimension.grid_1)
+            .alpha(0.5f),
+    )
+
+    when (tariff.getElectricityTariffType()) {
+        ElectricityTariffType.STANDARD -> {
+            val rateString = when {
+                tariff.isVariable -> stringResource(resource = Res.string.tariffs_variable)
+                tariff.vatInclusiveStandardUnitRate != null -> stringResource(resource = Res.string.unit_p_kwh, tariff.vatInclusiveStandardUnitRate)
+                else -> null
+            }
+
+            rateString?.let {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_0_5),
+                ) {
+                    Text(
+                        modifier = Modifier.weight(weight = 1f),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        text = stringResource(resource = Res.string.standard_unit_rate),
+                    )
+                    Text(
+                        modifier = Modifier.wrapContentWidth(),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        text = rateString,
+                    )
+                }
+            }
+        }
+
+        else -> {
+            tariff.vatInclusiveDayUnitRate?.let { rate ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_0_5),
+                ) {
+                    Text(
+                        modifier = Modifier.weight(weight = 1f),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        text = stringResource(resource = Res.string.day_unit_rate),
+                    )
+                    Text(
+                        modifier = Modifier.wrapContentWidth(),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        text = stringResource(resource = Res.string.unit_p_kwh, rate.roundToTwoDecimalPlaces()),
+                    )
+                }
+            }
+
+            tariff.vatInclusiveNightUnitRate?.let { rate ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_0_5),
+                ) {
+                    Text(
+                        modifier = Modifier.weight(weight = 1f),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        text = stringResource(resource = Res.string.night_unit_rate),
+                    )
+                    Text(
+                        modifier = Modifier.wrapContentWidth(),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        text = stringResource(resource = Res.string.unit_p_kwh, rate.roundToTwoDecimalPlaces()),
+                    )
+                }
+            }
+
+            tariff.vatInclusiveOffPeakRate?.let { rate ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_0_5),
+                ) {
+                    Text(
+                        modifier = Modifier.weight(weight = 1f),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        text = stringResource(resource = Res.string.off_peak_rate),
+                    )
+                    Text(
+                        modifier = Modifier.wrapContentWidth(),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        text = stringResource(resource = Res.string.unit_p_kwh, rate.roundToTwoDecimalPlaces()),
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,8 +43,8 @@ apollographqlMockServer = "0.1.0"
 testRules = "1.6.1"
 
 # App configurations, not dependencies
-versionCode = "14"
-versionName = "2.3.0"
+versionCode = "15"
+versionName = "2.3.1"
 android-minSdk = "26"
 android-targetSdk = "34"
 android-compileSdk = "34"

--- a/iosApp/OctoMeter.xcodeproj/project.pbxproj
+++ b/iosApp/OctoMeter.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = V8M4R7N63C;
 				ENABLE_PREVIEWS = YES;
@@ -401,7 +401,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.0;
+				MARKETING_VERSION = 2.3.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
@@ -422,7 +422,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = V8M4R7N63C;
 				ENABLE_PREVIEWS = YES;
@@ -439,7 +439,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.0;
+				MARKETING_VERSION = 2.3.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",

--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - composeApp (2.3.0)
+  - composeApp (2.3.1)
 
 DEPENDENCIES:
   - composeApp (from `../composeApp/`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../composeApp/"
 
 SPEC CHECKSUMS:
-  composeApp: be2eed0e93f9f2e0672a8aaf85099a186731e2d1
+  composeApp: 370b588122b7702f52bd2ba74fdbb187caee68c3
 
 PODFILE CHECKSUM: 132f4b88956762bee62e7893fe00dca16e0d8114
 

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.0</string>
+	<string>2.3.1</string>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
There's a bug in the current implementation that we do not map the day-night and three-rate tariff unit rates to domain models, so the tiles are not displaying for tariffs like Octopus Go.

This marks the release of v2.3.1 