### PR TITLE
[chore] Renovate: limit compose updates to stable releases only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,13 @@
         "com.google.devtools.ksp"
       ],
       "groupName": "kotlin"
+    },
+    {
+      "matchPackagePatterns": [
+        "org.jetbrains.compose.*"
+      ],
+      "allowedVersions": "1.*.*",
+      "groupName": "compose"
     }
   ],
   "automerge": true,


### PR DESCRIPTION
Applying an experimental configuration to bar automatic updates for strange development compose library versions