### PR TITLE
(#372) iOS: Get rid of missing compliance warning

### DIFF
--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -39,6 +39,8 @@
 	</array>
 	<key>UIStatusBarHidden</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIStatusBarStyle</key>
 	<string></string>
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
Updated the plist, hoping to remove one manual step in the release process.