### PR TITLE
(#368) AgileScreen: adjust live meter readings interval

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/graphql/ApolloGraphQLEndpoint.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/data/source/network/graphql/ApolloGraphQLEndpoint.kt
@@ -110,7 +110,7 @@ class ApolloGraphQLEndpoint(
                     meterDeviceId = meterDeviceId,
                     start = Optional.present(start),
                     end = Optional.present(end),
-                    grouping = Optional.present(TelemetryGrouping.TEN_SECONDS),
+                    grouping = Optional.present(TelemetryGrouping.ONE_MINUTE),
                 ),
                 requireAuthentication = true,
             )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/consumption/GetLiveConsumptionUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/domain/usecase/consumption/GetLiveConsumptionUseCase.kt
@@ -54,9 +54,9 @@ class GetLiveConsumptionUseCase(
                         end = end,
                     ).fold(
                         onSuccess = { consumption ->
-                            consumption.sortedByDescending {
+                            consumption.maxByOrNull {
                                 it.readAt
-                            }.firstOrNull()
+                            }
                         },
                         onFailure = { throw it },
                     )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/viewmodels/AgileViewModel.kt
@@ -52,7 +52,7 @@ import kotlinx.datetime.Clock
 import kotlin.math.ceil
 import kotlin.math.floor
 import kotlin.math.min
-import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration.Companion.minutes
 
 class AgileViewModel(
     private val getLatestProductByKeywordUseCase: GetLatestProductByKeywordUseCase,
@@ -167,7 +167,7 @@ class AgileViewModel(
     private fun liveConsumptionFlow(meterDeviceId: String) = flow {
         while (true) {
             emit(getLiveConsumptionUseCase(meterDeviceId))
-            delay(10.seconds)
+            delay(1.minutes)
         }
     }
 


### PR DESCRIPTION
Currently we provide 10-second live meter readings, so it will be 6*60 = 360 GraphQL requests per hour, and we hit the API limit which made this function technically useless.

This PR changes to group the live meter readings every 1 minute, so we should generate only 60 API calls, to see if this is still workable.