### PR TITLE
ReferenceTariffTile: replace dotted colour indicator with coloured corner wedge

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/ReferenceTariffTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/ReferenceTariffTile.kt
@@ -28,8 +28,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.text.font.FontWeight
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.domain.model.product.Tariff
@@ -53,15 +53,20 @@ internal fun ReferenceTariffTile(
         modifier = modifier
             .clip(shape = MaterialTheme.shapes.large)
             .background(MaterialTheme.colorScheme.surfaceContainer)
-            .padding(dimension.grid_2)
             .drawBehind {
-                val width = dimension.grid_2.toPx()
-                drawCircle(
+                val triangleSize = dimension.grid_1_5.toPx() * 2
+                val path = Path().apply {
+                    moveTo(size.width, 0f)
+                    lineTo(size.width - triangleSize, 0f) // Top edge
+                    lineTo(size.width, triangleSize) // Right edge
+                    close()
+                }
+                drawPath(
+                    path = path,
                     color = indicatorColor,
-                    radius = width / 2f,
-                    center = Offset(x = size.width, y = 0f),
                 )
-            },
+            }
+            .padding(dimension.grid_2),
         verticalArrangement = Arrangement.Top,
     ) {
         tariff.vatInclusiveStandardUnitRate?.let { unitRate ->


### PR DESCRIPTION
A minor UI change to improve the presentation of reference tariffs on the Agile screen:

![Screenshot 2025-01-01 at 20 19 41](https://github.com/user-attachments/assets/54b637a5-6285-47e4-8fbd-a846af2c8106)
