### PR TITLE
App: bump version to 2.4.0 (build 16)

### DIFF
--- a/composeApp/composeApp.podspec
+++ b/composeApp/composeApp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'composeApp'
-    spec.version                  = '2.3.1'
+    spec.version                  = '2.4.0'
     spec.homepage                 = 'https://github.com/ryanw-mobile/OctoMeter/'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,8 +45,8 @@ apollographqlKotlinxDateTime = "0.0.4"
 testRules = "1.6.1"
 
 # App configurations, not dependencies
-versionCode = "15"
-versionName = "2.3.1"
+versionCode = "16"
+versionName = "2.4.0"
 android-minSdk = "26"
 android-targetSdk = "34"
 android-compileSdk = "35"

--- a/iosApp/OctoMeter.xcodeproj/project.pbxproj
+++ b/iosApp/OctoMeter.xcodeproj/project.pbxproj
@@ -318,7 +318,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = V8M4R7N63C;
 				ENABLE_PREVIEWS = YES;
@@ -335,7 +335,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.1;
+				MARKETING_VERSION = 2.4.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
@@ -355,7 +355,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = V8M4R7N63C;
 				ENABLE_PREVIEWS = YES;
@@ -372,7 +372,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.1;
+				MARKETING_VERSION = 2.4.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.1</string>
+	<string>2.4.0</string>
 	<key>CFBundleVersion</key>
-	<string>15</string>
+	<string>16</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
We have to release this before the current TestFlight distribution expires.
Further fine-tune will be done in the coming two months.