### PR TITLE
[fix] Proguard: add exception affected by compose-plugin 1.8.0

### DIFF
--- a/composeApp/compose-desktop.pro
+++ b/composeApp/compose-desktop.pro
@@ -21,6 +21,7 @@
 
 # Apollo workarounds
 -dontnote okio.**
+-keep class okio.** { *; }
 -keep class com.rwmobi.kunigami.graphql.type.** { *; }
 -keep class com.apollographql.apollo.** { *; }
 -dontnote com.apollographql.**


### PR DESCRIPTION
Not sure why,  but compose-plugin 1.8.0 breaks okio proguard settings. 