### PR TITLE
(#424) App: migrate dimension and MaterialTheme usages to AppTheme

### DIFF
--- a/composeApp/src/androidInstrumentedTest/kotlin/com/rwmobi/kunigami/ui/components/IconTextButtonPreview.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/rwmobi/kunigami/ui/components/IconTextButtonPreview.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewFontScale
@@ -42,7 +41,7 @@ private fun Preview() {
                 icon = org.jetbrains.compose.resources.painterResource(resource = Res.drawable.coin),
                 text = "Money Generator",
                 colors = ButtonDefaults.buttonColors().copy(
-                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    contentColor = AppTheme.colorScheme.onPrimaryContainer,
                 ),
                 onClick = {},
             )
@@ -50,10 +49,10 @@ private fun Preview() {
             IconTextButton(
                 icon = org.jetbrains.compose.resources.painterResource(resource = Res.drawable.coin),
                 text = "Money Generator",
-                shape = MaterialTheme.shapes.large,
+                shape = AppTheme.shapes.large,
                 colors = ButtonDefaults.buttonColors().copy(
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    containerColor = AppTheme.colorScheme.secondaryContainer,
+                    contentColor = AppTheme.colorScheme.onSecondaryContainer,
                 ),
                 onClick = {},
             )

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/rwmobi/kunigami/ui/components/SquareButtonPreview.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/rwmobi/kunigami/ui/components/SquareButtonPreview.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -53,8 +52,8 @@ private fun Preview(
                     icon = painterResource(resource = Res.drawable.coin),
                     text = "Money Generator",
                     colors = ButtonDefaults.buttonColors().copy(
-                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                        containerColor = AppTheme.colorScheme.secondaryContainer,
+                        contentColor = AppTheme.colorScheme.onSecondaryContainer,
                     ),
                     onClick = {},
                 )
@@ -66,8 +65,8 @@ private fun Preview(
                     icon = painterResource(resource = Res.drawable.coin),
                     text = "Money",
                     colors = ButtonDefaults.buttonColors().copy(
-                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                        containerColor = AppTheme.colorScheme.secondaryContainer,
+                        contentColor = AppTheme.colorScheme.onSecondaryContainer,
                     ),
                     onClick = {},
                 )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/App.kt
@@ -32,7 +32,6 @@ import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
@@ -122,7 +121,7 @@ fun App(
                         Column {
                             HorizontalDivider(
                                 modifier = Modifier.fillMaxWidth(),
-                                color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                                color = AppTheme.colorScheme.surfaceContainerHighest,
                             )
 
                             AppBottomNavigationBar(
@@ -159,7 +158,7 @@ fun App(
                             VerticalDivider(
                                 modifier = Modifier.fillMaxHeight()
                                     .wrapContentWidth(),
-                                color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                                color = AppTheme.colorScheme.surfaceContainerHighest,
                             )
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/AppBottomNavigationBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/AppBottomNavigationBar.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
@@ -32,9 +31,8 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.navigation.AppDestination
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.content_description_navigation_bar
 import org.jetbrains.compose.resources.painterResource
@@ -46,13 +44,11 @@ fun AppBottomNavigationBar(
     navController: NavController,
     onCurrentRouteSecondTapped: (item: AppDestination) -> Unit,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     val navigationBarContentDescription = stringResource(Res.string.content_description_navigation_bar)
     NavigationBar(
         modifier = modifier.semantics { contentDescription = navigationBarContentDescription },
         tonalElevation = 0.dp,
-        containerColor = MaterialTheme.colorScheme.background,
+        containerColor = AppTheme.colorScheme.background,
     ) {
         val navBackStackEntry by navController.currentBackStackEntryAsState()
         val currentRoute = navBackStackEntry?.destination?.route
@@ -78,7 +74,7 @@ fun AppBottomNavigationBar(
                 },
                 icon = {
                     Icon(
-                        modifier = Modifier.size(size = dimension.navigationIconSize),
+                        modifier = Modifier.size(size = AppTheme.dimens.navigationIconSize),
                         painter = painterResource(resource = item.iconResId),
                         contentDescription = null,
                     )
@@ -86,7 +82,7 @@ fun AppBottomNavigationBar(
                 label = {
                     Text(
                         text = stringResource(resource = item.titleResId).uppercase(),
-                        style = MaterialTheme.typography.labelSmall,
+                        style = AppTheme.typography.labelSmall,
                     )
                 },
             )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/AppNavigationRail.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/AppNavigationRail.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationRail
 import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.Text
@@ -33,9 +32,8 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.navigation.AppDestination
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.content_description_navigation_rail
 import org.jetbrains.compose.resources.painterResource
@@ -50,11 +48,10 @@ fun AppNavigationRail(
     val navigationRailContentDescription = stringResource(Res.string.content_description_navigation_rail)
     NavigationRail(
         modifier = modifier.semantics { contentDescription = navigationRailContentDescription },
-        containerColor = MaterialTheme.colorScheme.background,
+        containerColor = AppTheme.colorScheme.background,
     ) {
         val navBackStackEntry by navController.currentBackStackEntryAsState()
         val currentRoute = navBackStackEntry?.destination?.route
-        val dimension = getScreenSizeInfo().getDimension()
 
         Spacer(Modifier.weight(1f))
 
@@ -64,7 +61,7 @@ fun AppNavigationRail(
             val itemContentDescription = stringResource(item.titleResId)
             NavigationRailItem(
                 modifier = Modifier
-                    .padding(vertical = dimension.defaultFullPadding)
+                    .padding(vertical = AppTheme.dimens.defaultFullPadding)
                     .semantics { contentDescription = itemContentDescription },
                 selected = selected,
                 onClick = {
@@ -81,7 +78,7 @@ fun AppNavigationRail(
                 },
                 icon = {
                     Icon(
-                        modifier = Modifier.size(size = dimension.navigationIconSize),
+                        modifier = Modifier.size(size = AppTheme.dimens.navigationIconSize),
                         painter = painterResource(resource = item.iconResId),
                         contentDescription = null,
                     )
@@ -89,7 +86,7 @@ fun AppNavigationRail(
                 label = {
                     Text(
                         text = stringResource(resource = item.titleResId).uppercase(),
-                        style = MaterialTheme.typography.labelMedium,
+                        style = AppTheme.typography.labelMedium,
                     )
                 },
             )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/CommonPreviewSetup.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/CommonPreviewSetup.kt
@@ -28,18 +28,13 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.unit.dp
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.AppTheme
-import com.rwmobi.kunigami.ui.theme.Dimension
-import com.rwmobi.kunigami.ui.theme.getDimension
 
 @Composable
 internal fun CommonPreviewSetup(
     modifier: Modifier = Modifier,
-    content: @Composable (dimension: Dimension) -> Unit = {},
+    content: @Composable () -> Unit = {},
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -63,7 +58,7 @@ internal fun CommonPreviewSetup(
             .verticalScroll(
                 state = rememberScrollState(),
             ),
-        verticalArrangement = Arrangement.spacedBy(space = dimension.grid_4),
+        verticalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_4),
     ) {
         AppTheme(
             useDarkTheme = false,
@@ -71,9 +66,9 @@ internal fun CommonPreviewSetup(
             Surface {
                 Column(
                     modifier = modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(space = dimension.grid_2),
+                    verticalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_2),
                 ) {
-                    content(dimension)
+                    content()
                 }
             }
         }
@@ -84,9 +79,9 @@ internal fun CommonPreviewSetup(
             Surface {
                 Column(
                     modifier = modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(space = dimension.grid_2),
+                    verticalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_2),
                 ) {
-                    content(dimension)
+                    content()
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/DemoModeCtaAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/DemoModeCtaAdaptive.kt
@@ -24,14 +24,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.agile_demo_introduction
 import kunigami.composeapp.generated.resources.blackboard
@@ -72,31 +70,29 @@ private fun DemoModeCTACompact(
     ctaButtonLabel: String,
     onCtaButtonClicked: () -> Unit,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Column(
         modifier = modifier
-            .clip(shape = MaterialTheme.shapes.medium)
-            .background(color = MaterialTheme.colorScheme.surfaceContainerHighest)
-            .padding(all = dimension.grid_2),
-        verticalArrangement = Arrangement.spacedBy(space = dimension.grid_2),
+            .clip(shape = AppTheme.shapes.medium)
+            .background(color = AppTheme.colorScheme.surfaceContainerHighest)
+            .padding(all = AppTheme.dimens.grid_2),
+        verticalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_2),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_2),
+            horizontalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_2),
         ) {
             Icon(
-                modifier = Modifier.size(size = dimension.grid_4),
+                modifier = Modifier.size(size = AppTheme.dimens.grid_4),
                 painter = painterResource(resource = Res.drawable.blackboard),
-                tint = MaterialTheme.colorScheme.onSurface,
+                tint = AppTheme.colorScheme.onSurface,
                 contentDescription = null,
             )
 
             Text(
                 modifier = Modifier.weight(weight = 1f),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
+                style = AppTheme.typography.bodyMedium,
+                color = AppTheme.colorScheme.onSurface,
                 text = description,
             )
         }
@@ -117,34 +113,32 @@ private fun DemoModeCTAWide(
     ctaButtonLabel: String,
     onCtaButtonClicked: () -> Unit,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Column(
         modifier = modifier
-            .clip(shape = MaterialTheme.shapes.medium)
-            .background(color = MaterialTheme.colorScheme.surfaceContainerHighest)
+            .clip(shape = AppTheme.shapes.medium)
+            .background(color = AppTheme.colorScheme.surfaceContainerHighest)
             .padding(
-                vertical = dimension.grid_1,
-                horizontal = dimension.grid_2,
+                vertical = AppTheme.dimens.grid_1,
+                horizontal = AppTheme.dimens.grid_2,
             ),
-        verticalArrangement = Arrangement.spacedBy(space = dimension.grid_2),
+        verticalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_2),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_2),
+            horizontalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_2),
         ) {
             Icon(
-                modifier = Modifier.size(size = dimension.grid_4),
+                modifier = Modifier.size(size = AppTheme.dimens.grid_4),
                 painter = painterResource(resource = Res.drawable.blackboard),
-                tint = MaterialTheme.colorScheme.onSurface,
+                tint = AppTheme.colorScheme.onSurface,
                 contentDescription = null,
             )
 
             Text(
                 modifier = Modifier.weight(weight = 1f),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
+                style = AppTheme.typography.bodyMedium,
+                color = AppTheme.colorScheme.onSurface,
                 text = description,
             )
 

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/DualTitleBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/DualTitleBar.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -32,8 +31,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 
 @Composable
 internal fun DualTitleBar(
@@ -41,18 +39,17 @@ internal fun DualTitleBar(
     title: String,
     subtitle: String? = null,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     Surface {
         Column(
-            modifier = modifier.padding(horizontal = dimension.grid_3),
+            modifier = modifier.padding(horizontal = AppTheme.dimens.grid_3),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
                 modifier = Modifier.fillMaxWidth(),
                 textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                style = AppTheme.typography.titleMedium,
+                color = AppTheme.colorScheme.onSecondaryContainer,
                 fontWeight = FontWeight.Bold,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
@@ -63,8 +60,8 @@ internal fun DualTitleBar(
                 Text(
                     modifier = Modifier.fillMaxWidth(),
                     textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer.copy(
+                    style = AppTheme.typography.bodySmall,
+                    color = AppTheme.colorScheme.onSecondaryContainer.copy(
                         alpha = 0.68f,
                     ),
                     maxLines = 1,
@@ -82,7 +79,7 @@ private fun Preview() {
     CommonPreviewSetup {
         DualTitleBar(
             modifier = Modifier
-                .background(color = MaterialTheme.colorScheme.secondary)
+                .background(color = AppTheme.colorScheme.secondary)
                 .fillMaxWidth()
                 .height(height = 64.dp),
             title = "Sample title",

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/IconTextButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/IconTextButton.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -40,8 +39,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.coin
 import org.jetbrains.compose.resources.painterResource
@@ -52,7 +50,7 @@ fun IconTextButton(
     icon: Painter,
     text: String,
     colors: ButtonColors = ButtonDefaults.buttonColors().copy(
-        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        contentColor = AppTheme.colorScheme.onPrimaryContainer,
     ),
     shape: Shape = ButtonDefaults.shape,
     onClick: () -> Unit,
@@ -61,7 +59,6 @@ fun IconTextButton(
     CompositionLocalProvider(
         LocalDensity provides Density(currentDensity.density, fontScale = 1f),
     ) {
-        val dimension = getScreenSizeInfo().getDimension()
         Button(
             modifier = modifier,
             shape = shape,
@@ -84,11 +81,11 @@ fun IconTextButton(
                     contentDescription = null,
                 )
 
-                Spacer(modifier = Modifier.width(width = dimension.grid_1))
+                Spacer(modifier = Modifier.width(width = AppTheme.dimens.grid_1))
 
                 Text(
                     modifier = Modifier.wrapContentHeight(),
-                    style = MaterialTheme.typography.labelMedium,
+                    style = AppTheme.typography.labelMedium,
                     color = colors.contentColor,
                     text = text,
                 )
@@ -105,7 +102,7 @@ private fun Preview() {
             icon = painterResource(resource = Res.drawable.coin),
             text = "Money Generator",
             colors = ButtonDefaults.buttonColors().copy(
-                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                contentColor = AppTheme.colorScheme.onPrimaryContainer,
             ),
             onClick = {},
         )
@@ -113,10 +110,10 @@ private fun Preview() {
         IconTextButton(
             icon = painterResource(resource = Res.drawable.coin),
             text = "Money Generator",
-            shape = MaterialTheme.shapes.large,
+            shape = AppTheme.shapes.large,
             colors = ButtonDefaults.buttonColors().copy(
-                containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                containerColor = AppTheme.colorScheme.secondaryContainer,
+                contentColor = AppTheme.colorScheme.onSecondaryContainer,
             ),
             onClick = {},
         )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/IndicatorTextValueGridItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/IndicatorTextValueGridItem.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -39,8 +38,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 
 @Composable
 fun IndicatorTextValueGridItem(
@@ -50,32 +48,32 @@ fun IndicatorTextValueGridItem(
     value: String,
     blinkingAlpha: Float = 1f,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
+    val grid1Width = AppTheme.dimens.grid_1
 
     Row(
         modifier = modifier.fillMaxWidth()
             .alpha(blinkingAlpha)
             .drawBehind {
-                val width = dimension.grid_1.toPx()
+                val width = grid1Width.toPx()
                 drawRect(
                     color = indicatorColor,
                     size = Size(width, size.height),
                 )
             }
-            .padding(vertical = dimension.grid_0_25),
-        horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_1),
+            .padding(vertical = AppTheme.dimens.grid_0_25),
+        horizontalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_1),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Spacer(modifier = Modifier.width(width = dimension.grid_1))
+        Spacer(modifier = Modifier.width(width = AppTheme.dimens.grid_1))
 
         Text(
             modifier = Modifier.wrapContentWidth(),
             fontFamily = FontFamily.Monospace,
-            style = MaterialTheme.typography.bodyMedium,
+            style = AppTheme.typography.bodyMedium,
             text = label,
         )
 
-        val dottedLineColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.16f)
+        val dottedLineColor = AppTheme.colorScheme.onBackground.copy(alpha = 0.16f)
         Box(
             modifier = Modifier
                 .weight(1.0f)
@@ -100,7 +98,7 @@ fun IndicatorTextValueGridItem(
         Text(
             modifier = Modifier.wrapContentWidth(),
             fontFamily = FontFamily.Monospace,
-            style = MaterialTheme.typography.bodyMedium,
+            style = AppTheme.typography.bodyMedium,
             fontWeight = FontWeight.Bold,
             text = value,
         )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/LabelValueRow.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/LabelValueRow.kt
@@ -23,8 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 
 @Composable
 internal fun LabelValueRow(
@@ -33,10 +32,9 @@ internal fun LabelValueRow(
     label: String?,
     value: String?,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     Row(
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_1),
+        horizontalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_1),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         label?.let {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/LargeTitleWithIcon.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/LargeTitleWithIcon.kt
@@ -19,14 +19,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 
 @Composable
 fun LargeTitleWithIcon(
@@ -34,15 +32,14 @@ fun LargeTitleWithIcon(
     icon: Painter,
     label: String,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_1),
+        horizontalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_1),
     ) {
         Icon(
-            modifier = Modifier.size(size = dimension.grid_3),
-            tint = MaterialTheme.colorScheme.onBackground.copy(
+            modifier = Modifier.size(size = AppTheme.dimens.grid_3),
+            tint = AppTheme.colorScheme.onBackground.copy(
                 alpha = 0.32f,
             ),
             painter = icon,
@@ -51,7 +48,7 @@ fun LargeTitleWithIcon(
 
         Text(
             modifier = Modifier.weight(1f),
-            style = MaterialTheme.typography.titleLarge,
+            style = AppTheme.typography.titleLarge,
             text = label,
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/LoadingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/LoadingScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -32,8 +31,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kunigami.composeapp.generated.resources.Res
@@ -44,8 +42,6 @@ import org.jetbrains.compose.resources.painterResource
 fun LoadingScreen(
     modifier: Modifier = Modifier,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -65,12 +61,12 @@ fun LoadingScreen(
     ) {
         Column(
             modifier = Modifier
-                .clip(shape = MaterialTheme.shapes.large)
+                .clip(shape = AppTheme.shapes.large)
                 .background(
                     color = Color.DarkGray.copy(alpha = 0.48f),
                 )
                 .wrapContentSize()
-                .padding(all = dimension.grid_2),
+                .padding(all = AppTheme.dimens.grid_2),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/MessageActionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/MessageActionScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -36,8 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.wallet
 import org.jetbrains.compose.resources.ExperimentalResourceApi
@@ -54,8 +52,6 @@ fun MessageActionScreen(
     secondaryButtonLabel: String? = null,
     onSecondaryButtonClicked: (() -> Unit)? = null,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Column(
         modifier = modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,
@@ -63,54 +59,54 @@ fun MessageActionScreen(
     ) {
         Icon(
             modifier = Modifier
-                .padding(all = dimension.grid_4)
-                .size(size = dimension.minTouchTarget),
+                .padding(all = AppTheme.dimens.grid_4)
+                .size(size = AppTheme.dimens.minTouchTarget),
             painter = icon,
-            tint = MaterialTheme.colorScheme.error,
+            tint = AppTheme.colorScheme.error,
             contentDescription = null,
         )
 
         Text(
-            modifier = Modifier.padding(horizontal = dimension.grid_4),
-            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(horizontal = AppTheme.dimens.grid_4),
+            style = AppTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
             text = text,
         )
 
-        Spacer(modifier = Modifier.height(height = dimension.grid_1))
+        Spacer(modifier = Modifier.height(height = AppTheme.dimens.grid_1))
 
         description?.let {
             Text(
-                modifier = Modifier.padding(horizontal = dimension.grid_4),
+                modifier = Modifier.padding(horizontal = AppTheme.dimens.grid_4),
                 textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.titleMedium,
+                style = AppTheme.typography.titleMedium,
                 text = it,
             )
         }
 
         if (primaryButtonLabel != null && onPrimaryButtonClicked != null) {
-            Spacer(modifier = Modifier.height(height = dimension.grid_4))
+            Spacer(modifier = Modifier.height(height = AppTheme.dimens.grid_4))
 
             Button(
                 onClick = onPrimaryButtonClicked,
             ) {
                 Text(
-                    modifier = Modifier.padding(horizontal = dimension.grid_2),
-                    style = MaterialTheme.typography.labelMedium,
+                    modifier = Modifier.padding(horizontal = AppTheme.dimens.grid_2),
+                    style = AppTheme.typography.labelMedium,
                     text = primaryButtonLabel.uppercase(),
                 )
             }
         }
 
         if (secondaryButtonLabel != null && onSecondaryButtonClicked != null) {
-            Spacer(modifier = Modifier.height(height = dimension.grid_2))
+            Spacer(modifier = Modifier.height(height = AppTheme.dimens.grid_2))
 
             TextButton(
                 onClick = onSecondaryButtonClicked,
             ) {
                 Text(
-                    modifier = Modifier.padding(horizontal = dimension.grid_2),
-                    style = MaterialTheme.typography.labelMedium,
+                    modifier = Modifier.padding(horizontal = AppTheme.dimens.grid_2),
+                    style = AppTheme.typography.labelMedium,
                     text = secondaryButtonLabel,
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/SquareButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/SquareButton.kt
@@ -27,7 +27,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -41,8 +40,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.coin
 import org.jetbrains.compose.resources.painterResource
@@ -53,8 +51,8 @@ internal fun SquareButton(
     icon: Painter,
     text: String,
     colors: ButtonColors = ButtonDefaults.buttonColors().copy(
-        containerColor = MaterialTheme.colorScheme.secondaryContainer,
-        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        containerColor = AppTheme.colorScheme.secondaryContainer,
+        contentColor = AppTheme.colorScheme.onSecondaryContainer,
     ),
     onClick: () -> Unit,
 ) {
@@ -62,7 +60,6 @@ internal fun SquareButton(
     CompositionLocalProvider(
         LocalDensity provides Density(currentDensity.density, fontScale = 1f),
     ) {
-        val dimension = getScreenSizeInfo().getDimension()
         Column(
             modifier = modifier
                 .wrapContentHeight()
@@ -70,13 +67,13 @@ internal fun SquareButton(
                     role = Role.Button
                     contentDescription = text
                 },
-            verticalArrangement = Arrangement.spacedBy(dimension.grid_1),
+            verticalArrangement = Arrangement.spacedBy(AppTheme.dimens.grid_1),
         ) {
             Button(
                 modifier = Modifier
                     .fillMaxWidth()
                     .aspectRatio(ratio = 1f),
-                shape = MaterialTheme.shapes.medium,
+                shape = AppTheme.shapes.medium,
                 colors = colors,
                 onClick = onClick,
             ) {
@@ -92,9 +89,9 @@ internal fun SquareButton(
 
             Text(
                 modifier = Modifier.fillMaxWidth(),
-                style = MaterialTheme.typography.labelMedium,
+                style = AppTheme.typography.labelMedium,
                 textAlign = TextAlign.Center,
-                color = MaterialTheme.colorScheme.onSurface,
+                color = AppTheme.colorScheme.onSurface,
                 text = text,
             )
         }
@@ -114,8 +111,8 @@ private fun Preview(
             icon = painterResource(resource = Res.drawable.coin),
             text = "Money Generator",
             colors = ButtonDefaults.buttonColors().copy(
-                containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                containerColor = AppTheme.colorScheme.secondaryContainer,
+                contentColor = AppTheme.colorScheme.onSecondaryContainer,
             ),
             onClick = {},
         )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TagWithIcon.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TagWithIcon.kt
@@ -21,15 +21,13 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.domain.model.product.ProductFeature
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -39,29 +37,27 @@ fun TagWithIcon(
     icon: Painter,
     text: String,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Row(
         modifier = modifier
             .background(
-                color = MaterialTheme.colorScheme.secondaryContainer,
-                shape = MaterialTheme.shapes.medium,
+                color = AppTheme.colorScheme.secondaryContainer,
+                shape = AppTheme.shapes.medium,
             )
             .padding(
-                horizontal = dimension.grid_1,
-                vertical = dimension.grid_0_5,
+                horizontal = AppTheme.dimens.grid_1,
+                vertical = AppTheme.dimens.grid_0_5,
             ),
     ) {
         Icon(
             modifier = Modifier.size(size = 16.dp),
             contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            tint = AppTheme.colorScheme.onSecondaryContainer,
             painter = icon,
         )
         Text(
-            modifier = Modifier.padding(start = dimension.grid_1),
-            color = MaterialTheme.colorScheme.onSecondaryContainer,
-            style = MaterialTheme.typography.labelMedium,
+            modifier = Modifier.padding(start = AppTheme.dimens.grid_1),
+            color = AppTheme.colorScheme.onSecondaryContainer,
+            style = AppTheme.typography.labelMedium,
             text = text.uppercase(),
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TariffSummaryTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/TariffSummaryTile.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -38,9 +37,8 @@ import androidx.compose.ui.text.font.FontWeight
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.domain.model.product.ElectricityTariffType
 import com.rwmobi.kunigami.domain.model.product.Tariff
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.previewsampledata.TariffSamples
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.day_unit_rate
 import kunigami.composeapp.generated.resources.night_unit_rate
@@ -58,20 +56,19 @@ internal fun TariffSummaryTile(
     modifier: Modifier = Modifier,
     tariff: Tariff,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     Column(
         modifier = modifier
-            .clip(shape = MaterialTheme.shapes.large)
-            .background(MaterialTheme.colorScheme.surfaceContainer)
-            .padding(dimension.grid_2),
+            .clip(shape = AppTheme.shapes.large)
+            .background(AppTheme.colorScheme.surfaceContainer)
+            .padding(AppTheme.dimens.grid_2),
         verticalArrangement = Arrangement.Top,
     ) {
         Text(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(bottom = dimension.grid_1),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
+                .padding(bottom = AppTheme.dimens.grid_1),
+            style = AppTheme.typography.bodyMedium,
+            color = AppTheme.colorScheme.onSurface,
             fontWeight = FontWeight.Bold,
             text = tariff.displayName,
         )
@@ -79,18 +76,18 @@ internal fun TariffSummaryTile(
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_0_5),
+            horizontalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_0_5),
         ) {
             Text(
                 modifier = Modifier.weight(weight = 1f),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
+                style = AppTheme.typography.bodyMedium,
+                color = AppTheme.colorScheme.onSurface,
                 text = stringResource(resource = Res.string.standing_charge),
             )
             Text(
                 modifier = Modifier.wrapContentWidth(),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
+                style = AppTheme.typography.bodyMedium,
+                color = AppTheme.colorScheme.onSurface,
                 text = stringResource(resource = Res.string.unit_p_day, tariff.vatInclusiveStandingCharge),
             )
         }
@@ -106,7 +103,7 @@ internal fun TariffSummaryTile(
 
         Text(
             modifier = Modifier.fillMaxWidth(),
-            style = MaterialTheme.typography.labelSmall,
+            style = AppTheme.typography.labelSmall,
             fontWeight = FontWeight.Normal,
             text = stringResource(resource = Res.string.usage_applied_tariff),
         )
@@ -118,10 +115,9 @@ private fun UnitRateLayout(
     modifier: Modifier = Modifier,
     tariff: Tariff,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     HorizontalDivider(
         modifier = Modifier
-            .padding(vertical = dimension.grid_1)
+            .padding(vertical = AppTheme.dimens.grid_1)
             .alpha(0.5f),
     )
 
@@ -137,18 +133,18 @@ private fun UnitRateLayout(
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_0_5),
+                    horizontalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_0_5),
                 ) {
                     Text(
                         modifier = Modifier.weight(weight = 1f),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
+                        style = AppTheme.typography.bodyMedium,
+                        color = AppTheme.colorScheme.onSurface,
                         text = stringResource(resource = Res.string.standard_unit_rate),
                     )
                     Text(
                         modifier = Modifier.wrapContentWidth(),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
+                        style = AppTheme.typography.bodyMedium,
+                        color = AppTheme.colorScheme.onSurface,
                         text = rateString,
                     )
                 }
@@ -160,18 +156,18 @@ private fun UnitRateLayout(
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_0_5),
+                    horizontalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_0_5),
                 ) {
                     Text(
                         modifier = Modifier.weight(weight = 1f),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
+                        style = AppTheme.typography.bodyMedium,
+                        color = AppTheme.colorScheme.onSurface,
                         text = stringResource(resource = Res.string.day_unit_rate),
                     )
                     Text(
                         modifier = Modifier.wrapContentWidth(),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
+                        style = AppTheme.typography.bodyMedium,
+                        color = AppTheme.colorScheme.onSurface,
                         text = stringResource(resource = Res.string.unit_p_kwh, rate.roundToTwoDecimalPlaces()),
                     )
                 }
@@ -181,18 +177,18 @@ private fun UnitRateLayout(
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_0_5),
+                    horizontalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_0_5),
                 ) {
                     Text(
                         modifier = Modifier.weight(weight = 1f),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
+                        style = AppTheme.typography.bodyMedium,
+                        color = AppTheme.colorScheme.onSurface,
                         text = stringResource(resource = Res.string.night_unit_rate),
                     )
                     Text(
                         modifier = Modifier.wrapContentWidth(),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
+                        style = AppTheme.typography.bodyMedium,
+                        color = AppTheme.colorScheme.onSurface,
                         text = stringResource(resource = Res.string.unit_p_kwh, rate.roundToTwoDecimalPlaces()),
                     )
                 }
@@ -202,18 +198,18 @@ private fun UnitRateLayout(
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_0_5),
+                    horizontalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_0_5),
                 ) {
                     Text(
                         modifier = Modifier.weight(weight = 1f),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
+                        style = AppTheme.typography.bodyMedium,
+                        color = AppTheme.colorScheme.onSurface,
                         text = stringResource(resource = Res.string.off_peak_rate),
                     )
                     Text(
                         modifier = Modifier.wrapContentWidth(),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
+                        style = AppTheme.typography.bodyMedium,
+                        color = AppTheme.colorScheme.onSurface,
                         text = stringResource(resource = Res.string.unit_p_kwh, rate.roundToTwoDecimalPlaces()),
                     )
                 }
@@ -225,21 +221,21 @@ private fun UnitRateLayout(
 @Preview
 @Composable
 private fun Preview() {
-    CommonPreviewSetup { dimension ->
+    CommonPreviewSetup {
         Column(
-            verticalArrangement = Arrangement.spacedBy(dimension.grid_1),
+            verticalArrangement = Arrangement.spacedBy(AppTheme.dimens.grid_1),
         ) {
             TariffSummaryTile(
                 modifier = Modifier
-                    .width(dimension.widgetWidthFull)
-                    .height(dimension.widgetHeight),
+                    .width(AppTheme.dimens.widgetWidthFull)
+                    .height(AppTheme.dimens.widgetHeight),
                 tariff = TariffSamples.var221101,
             )
 
             TariffSummaryTile(
                 modifier = Modifier
-                    .width(dimension.widgetWidthFull)
-                    .height(dimension.widgetHeight),
+                    .width(AppTheme.dimens.widgetWidthFull)
+                    .height(AppTheme.dimens.widgetHeight),
                 tariff = TariffSamples.fix12M240411,
             )
         }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/WidgetCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/WidgetCard.kt
@@ -22,14 +22,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 
 @Composable
 fun WidgetCard(
@@ -38,24 +36,22 @@ fun WidgetCard(
     contents: @Composable () -> Unit,
     footer: @Composable (() -> Unit)? = null,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Column(
         modifier = modifier
             .sizeIn(
-                minWidth = dimension.windowWidthMedium / 2,
-                maxWidth = dimension.windowWidthCompact,
+                minWidth = AppTheme.dimens.windowWidthMedium / 2,
+                maxWidth = AppTheme.dimens.windowWidthCompact,
             )
             .fillMaxSize()
-            .padding(all = dimension.grid_2),
-        verticalArrangement = Arrangement.spacedBy(space = dimension.grid_1),
+            .padding(all = AppTheme.dimens.grid_2),
+        verticalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_1),
     ) {
         heading?.let { headingText ->
             Text(
                 modifier = Modifier.fillMaxWidth(),
-                style = MaterialTheme.typography.labelMedium,
+                style = AppTheme.typography.labelMedium,
                 fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = AppTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
                 text = headingText,
             )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/AxisLabel.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/AxisLabel.kt
@@ -15,11 +15,11 @@
 
 package com.rwmobi.kunigami.ui.components.koalaplot
 
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
+import com.rwmobi.kunigami.ui.theme.AppTheme
 
 @Composable
 fun AxisLabel(
@@ -28,8 +28,8 @@ fun AxisLabel(
 ) {
     Text(
         modifier = modifier,
-        color = MaterialTheme.colorScheme.onBackground,
-        style = MaterialTheme.typography.labelMedium,
+        color = AppTheme.colorScheme.onBackground,
+        style = AppTheme.typography.labelMedium,
         overflow = TextOverflow.Visible,
         maxLines = 1,
         text = label,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/ChartTitle.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/ChartTitle.kt
@@ -16,19 +16,19 @@
 package com.rwmobi.kunigami.ui.components.koalaplot
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.rwmobi.kunigami.ui.theme.AppTheme
 
 @Composable
 fun ChartTitle(title: String) {
     Column {
         Text(
             text = title,
-            color = MaterialTheme.colorScheme.onBackground,
-            style = MaterialTheme.typography.titleLarge,
+            color = AppTheme.colorScheme.onBackground,
+            style = AppTheme.typography.titleLarge,
             modifier = Modifier.align(Alignment.CenterHorizontally),
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/VerticalBarChart.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/VerticalBarChart.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -42,10 +41,9 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.composehelper.palette.RatePalette
 import com.rwmobi.kunigami.ui.composehelper.shouldUseDarkTheme
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import io.github.koalaplot.core.ChartLayout
 import io.github.koalaplot.core.bar.DefaultVerticalBar
 import io.github.koalaplot.core.bar.VerticalBarPlot
@@ -74,8 +72,6 @@ fun VerticalBarChart(
     yAxisTitle: String? = null,
     backgroundPlot: @Composable ((scope: XYGraphScope<Int, Double>) -> Unit)? = null,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Box {
         var showTooltipIndex: Int? by remember { mutableStateOf(null) }
         ChartLayout(modifier = modifier) {
@@ -88,13 +84,13 @@ fun VerticalBarChart(
                 xAxisLabels = { index ->
                     labelGenerator(index)?.let { label ->
                         AxisLabel(
-                            modifier = Modifier.padding(horizontal = dimension.grid_1),
+                            modifier = Modifier.padding(horizontal = AppTheme.dimens.grid_1),
                             label = label,
                         )
                     }
                 },
                 xAxisStyle = AxisStyle(
-                    color = MaterialTheme.colorScheme.onBackground.copy(
+                    color = AppTheme.colorScheme.onBackground.copy(
                         alpha = 0.25f,
                     ),
                     majorTickSize = 4.dp,
@@ -106,7 +102,7 @@ fun VerticalBarChart(
                         XAxisTitle(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(top = dimension.grid_1),
+                                .padding(top = AppTheme.dimens.grid_1),
                             title = it,
                         )
                     }
@@ -126,7 +122,7 @@ fun VerticalBarChart(
                 ),
                 yAxisLabels = {
                     AxisLabel(
-                        modifier = Modifier.absolutePadding(right = dimension.grid_0_25),
+                        modifier = Modifier.absolutePadding(right = AppTheme.dimens.grid_0_25),
                         label = it.toString(precision = 1),
                     )
                 },
@@ -135,13 +131,13 @@ fun VerticalBarChart(
                         YAxisTitle(
                             modifier = Modifier
                                 .fillMaxHeight()
-                                .padding(end = dimension.grid_1),
+                                .padding(end = AppTheme.dimens.grid_1),
                             title = it,
                         )
                     }
                 },
                 horizontalMajorGridLineStyle = LineStyle(
-                    brush = SolidColor(MaterialTheme.colorScheme.onBackground),
+                    brush = SolidColor(AppTheme.colorScheme.onBackground),
                     strokeWidth = 1.dp,
                     pathEffect = null,
                     alpha = 0.5f,
@@ -149,7 +145,7 @@ fun VerticalBarChart(
                     blendMode = DrawScope.DefaultBlendMode,
                 ),
                 horizontalMinorGridLineStyle = LineStyle(
-                    brush = SolidColor(MaterialTheme.colorScheme.onBackground),
+                    brush = SolidColor(AppTheme.colorScheme.onBackground),
                     strokeWidth = 1.dp,
                     pathEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 4f), 0f), // Configure dashed pattern
                     alpha = 0.25f,
@@ -218,7 +214,7 @@ fun VerticalBarChart(
             HoverElement(
                 modifier = Modifier
                     .align(alignment = Alignment.TopCenter)
-                    .offset(y = dimension.grid_2),
+                    .offset(y = AppTheme.dimens.grid_2),
                 text = tooltipGenerator(index),
             )
         }
@@ -230,18 +226,16 @@ private fun HoverElement(
     modifier: Modifier = Modifier,
     text: String,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Text(
         modifier = modifier
-            .clip(shape = MaterialTheme.shapes.small)
-            .background(color = MaterialTheme.colorScheme.inverseSurface)
+            .clip(shape = AppTheme.shapes.small)
+            .background(color = AppTheme.colorScheme.inverseSurface)
             .padding(
-                horizontal = dimension.grid_2,
-                vertical = dimension.grid_1,
+                horizontal = AppTheme.dimens.grid_2,
+                vertical = AppTheme.dimens.grid_1,
             ),
-        style = MaterialTheme.typography.labelMedium,
-        color = MaterialTheme.colorScheme.inverseOnSurface,
+        style = AppTheme.typography.labelMedium,
+        color = AppTheme.colorScheme.inverseOnSurface,
         textAlign = TextAlign.Center,
         text = text,
     )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/XAxisTitle.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/XAxisTitle.kt
@@ -17,13 +17,13 @@ package com.rwmobi.kunigami.ui.components.koalaplot
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import com.rwmobi.kunigami.ui.theme.AppTheme
 
 @Composable
 fun XAxisTitle(
@@ -39,9 +39,9 @@ fun XAxisTitle(
             maxLines = 1,
             textAlign = TextAlign.Center,
             text = title,
-            color = MaterialTheme.colorScheme.onBackground,
+            color = AppTheme.colorScheme.onBackground,
             fontWeight = FontWeight.Bold,
-            style = MaterialTheme.typography.labelMedium,
+            style = AppTheme.typography.labelMedium,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/YAxisTitle.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/components/koalaplot/YAxisTitle.kt
@@ -17,13 +17,13 @@ package com.rwmobi.kunigami.ui.components.koalaplot
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import io.github.koalaplot.core.util.VerticalRotation
 import io.github.koalaplot.core.util.rotateVertically
 
@@ -42,9 +42,9 @@ fun YAxisTitle(
             maxLines = 1,
             textAlign = TextAlign.Center,
             text = title,
-            color = MaterialTheme.colorScheme.onBackground,
+            color = AppTheme.colorScheme.onBackground,
             fontWeight = FontWeight.Bold,
-            style = MaterialTheme.typography.labelMedium,
+            style = AppTheme.typography.labelMedium,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/DrawHalfCircleArcSegment.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/DrawHalfCircleArcSegment.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -37,6 +36,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.composehelper.palette.generateGYRHueSpectrum
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.coin
 import org.jetbrains.compose.resources.painterResource
@@ -147,7 +147,7 @@ private fun Preview() {
     CommonPreviewSetup {
         Surface(modifier = Modifier.padding(all = 24.dp)) {
             val iconPainter = painterResource(resource = Res.drawable.coin)
-            val colorFilter = MaterialTheme.colorScheme.onSurface
+            val colorFilter = AppTheme.colorScheme.onSurface
             Box(
                 modifier = Modifier
                     .width(512.dp)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/DrawPlainColorArc.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/DrawPlainColorArc.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -36,6 +35,7 @@ import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.coin
 import org.jetbrains.compose.resources.painterResource
@@ -98,7 +98,7 @@ private fun Preview() {
     CommonPreviewSetup {
         Surface(modifier = Modifier.padding(all = 24.dp)) {
             val iconPainter = painterResource(resource = Res.drawable.coin)
-            val colorFilter = MaterialTheme.colorScheme.onSurface
+            val colorFilter = AppTheme.colorScheme.onSurface
             Box(
                 modifier = Modifier
                     .width(512.dp)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/palette/GenerateFreezingBlueSpectrum.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/palette/GenerateFreezingBlueSpectrum.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.theme.AppTheme
 
 fun generateFreezingBlueSpectrum(
     initialSaturation: Float = 0.4f, // Starting with a moderate saturation
@@ -55,11 +56,11 @@ private fun Preview() {
     val gradient = Brush.horizontalGradient(colors)
     CommonPreviewSetup(
         modifier = Modifier,
-    ) { dimension ->
+    ) {
         Box(
             modifier = Modifier
-                .padding(dimension.grid_6)
-                .height(dimension.grid_6)
+                .padding(AppTheme.dimens.grid_6)
+                .height(AppTheme.dimens.grid_6)
                 .fillMaxWidth()
                 .background(brush = gradient),
         )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/palette/GenerateGYRHueSpectrum.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/composehelper/palette/GenerateGYRHueSpectrum.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.theme.AppTheme
 
 fun generateGYRHueSpectrum(
     saturation: Float = 0.5f,
@@ -52,11 +53,11 @@ private fun preview() {
     val gradient = Brush.horizontalGradient(colors)
     CommonPreviewSetup(
         modifier = Modifier,
-    ) { dimension ->
+    ) {
         Box(
             modifier = Modifier
-                .padding(dimension.grid_6)
-                .height(dimension.grid_6)
+                .padding(AppTheme.dimens.grid_6)
+                .height(AppTheme.dimens.grid_6)
                 .fillMaxWidth()
                 .background(brush = gradient),
         )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountInformationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountInformationScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -42,7 +41,6 @@ import com.rwmobi.kunigami.domain.extensions.getLocalDateString
 import com.rwmobi.kunigami.domain.model.account.UserProfile
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.components.MessageActionScreen
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.destinations.account.components.AccountOperationButtonBar
 import com.rwmobi.kunigami.ui.destinations.account.components.AppInfoFooter
 import com.rwmobi.kunigami.ui.destinations.account.components.ElectricityMeterPointCard
@@ -50,7 +48,6 @@ import com.rwmobi.kunigami.ui.destinations.account.components.UpdateApiKeyDialog
 import com.rwmobi.kunigami.ui.model.SpecialErrorScreen
 import com.rwmobi.kunigami.ui.previewsampledata.AccountSamples
 import com.rwmobi.kunigami.ui.theme.AppTheme
-import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.account_clear_credential_title
 import kunigami.composeapp.generated.resources.account_error_account_empty
@@ -71,11 +68,9 @@ internal fun AccountInformationScreen(
     uiState: AccountUIState,
     uiEvent: AccountUIEvent,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(space = dimension.grid_3),
+        verticalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_3),
     ) {
         if (uiState.userProfile?.account == null) {
             MessageActionScreen(
@@ -88,7 +83,7 @@ internal fun AccountInformationScreen(
                 onSecondaryButtonClicked = uiEvent.onClearCredentialButtonClicked,
             )
         } else {
-            Spacer(modifier = Modifier.height(height = dimension.grid_1))
+            Spacer(modifier = Modifier.height(height = AppTheme.dimens.grid_1))
 
             Card(
                 modifier = Modifier.fillMaxWidth(),
@@ -96,12 +91,12 @@ internal fun AccountInformationScreen(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(dimension.grid_2),
-                    verticalArrangement = Arrangement.spacedBy(dimension.grid_2),
+                        .padding(AppTheme.dimens.grid_2),
+                    verticalArrangement = Arrangement.spacedBy(AppTheme.dimens.grid_2),
                 ) {
                     Column {
                         Text(
-                            style = MaterialTheme.typography.titleLarge,
+                            style = AppTheme.typography.titleLarge,
                             fontWeight = FontWeight.Bold,
                             maxLines = 1,
                             text = "Welcome back ${uiState.userProfile.account.preferredName}!",
@@ -109,7 +104,7 @@ internal fun AccountInformationScreen(
 
                         Text(
                             modifier = Modifier.alpha(0.5f),
-                            style = MaterialTheme.typography.bodyLarge,
+                            style = AppTheme.typography.bodyLarge,
                             fontWeight = FontWeight.Bold,
                             maxLines = 1,
                             text = stringResource(resource = Res.string.account_number, uiState.userProfile.account.accountNumber),
@@ -118,12 +113,12 @@ internal fun AccountInformationScreen(
 
                     uiState.userProfile.account.fullAddress?.let {
                         Text(
-                            style = MaterialTheme.typography.bodyLarge,
+                            style = AppTheme.typography.bodyLarge,
                             text = it,
                         )
                     } ?: run {
                         Text(
-                            style = MaterialTheme.typography.bodyLarge,
+                            style = AppTheme.typography.bodyLarge,
                             text = stringResource(resource = Res.string.account_unknown_installation_address),
                         )
                     }
@@ -131,14 +126,14 @@ internal fun AccountInformationScreen(
                     Column {
                         uiState.userProfile.account.movedInAt?.let {
                             Text(
-                                style = MaterialTheme.typography.bodyMedium,
+                                style = AppTheme.typography.bodyMedium,
                                 text = stringResource(resource = Res.string.account_moved_in, it.getLocalDateString()),
                             )
                         }
 
                         uiState.userProfile.account.movedOutAt?.let {
                             Text(
-                                style = MaterialTheme.typography.bodyMedium,
+                                style = AppTheme.typography.bodyMedium,
                                 text = stringResource(resource = Res.string.account_moved_out, it.getLocalDateString()),
                             )
                         }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/AccountScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -37,11 +36,9 @@ import com.rwmobi.kunigami.ui.components.ErrorScreenHandler
 import com.rwmobi.kunigami.ui.components.LoadingScreen
 import com.rwmobi.kunigami.ui.components.ScrollbarMultiplatform
 import com.rwmobi.kunigami.ui.composehelper.conditionalBlur
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.SpecialErrorScreen
 import com.rwmobi.kunigami.ui.previewsampledata.FakeDemoUserProfile
 import com.rwmobi.kunigami.ui.theme.AppTheme
-import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.navigation_account
 import org.jetbrains.compose.resources.stringResource
@@ -62,7 +59,6 @@ fun AccountScreen(
         }
     }
 
-    val dimension = getScreenSizeInfo().getDimension()
     val lazyListState = rememberLazyListState()
 
     Box(modifier = modifier) {
@@ -90,9 +86,9 @@ fun AccountScreen(
                     if (accountNumber != null) {
                         DualTitleBar(
                             modifier = Modifier
-                                .background(color = MaterialTheme.colorScheme.secondary)
+                                .background(color = AppTheme.colorScheme.secondary)
                                 .fillMaxWidth()
-                                .height(height = dimension.minListItemHeight),
+                                .height(height = AppTheme.dimens.minListItemHeight),
                             title = stringResource(resource = Res.string.navigation_account),
                         )
                     }
@@ -111,11 +107,11 @@ fun AccountScreen(
                                         val widthConstraintModifier = when (uiState.requestedLayout) {
                                             is AccountScreenLayoutStyle.Compact -> Modifier.fillMaxWidth()
                                             is AccountScreenLayoutStyle.Wide -> Modifier.fillMaxWidth()
-                                            else -> Modifier.widthIn(max = dimension.windowWidthMedium)
+                                            else -> Modifier.widthIn(max = AppTheme.dimens.windowWidthMedium)
                                         }
 
                                         OnboardingScreen(
-                                            modifier = widthConstraintModifier.padding(all = dimension.grid_2),
+                                            modifier = widthConstraintModifier.padding(all = AppTheme.dimens.grid_2),
                                             uiState = uiState,
                                             uiEvent = uiEvent,
                                         )
@@ -132,11 +128,11 @@ fun AccountScreen(
                                         val widthConstraintModifier = when (uiState.requestedLayout) {
                                             is AccountScreenLayoutStyle.Compact -> Modifier.fillMaxWidth()
                                             is AccountScreenLayoutStyle.Wide -> Modifier.fillMaxWidth()
-                                            else -> Modifier.widthIn(max = dimension.windowWidthMedium)
+                                            else -> Modifier.widthIn(max = AppTheme.dimens.windowWidthMedium)
                                         }
 
                                         AccountInformationScreen(
-                                            modifier = widthConstraintModifier.padding(horizontal = dimension.grid_2),
+                                            modifier = widthConstraintModifier.padding(horizontal = AppTheme.dimens.grid_2),
                                             uiState = uiState,
                                             uiEvent = uiEvent,
                                         )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/OnboardingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/OnboardingScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -36,11 +35,9 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.destinations.account.components.AppInfoFooter
 import com.rwmobi.kunigami.ui.destinations.account.components.CredentialsInputForm
 import com.rwmobi.kunigami.ui.theme.AppTheme
-import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.bulb
 import kunigami.composeapp.generated.resources.onboarding_introduction_1
@@ -59,7 +56,6 @@ internal fun OnboardingScreen(
     uiState: AccountUIState,
     uiEvent: AccountUIEvent,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     val focusManager = LocalFocusManager.current
 
     Column(
@@ -70,56 +66,56 @@ internal fun OnboardingScreen(
                 )
             },
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(space = dimension.grid_2),
+        verticalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_2),
     ) {
         Text(
-            style = MaterialTheme.typography.displaySmall,
+            style = AppTheme.typography.displaySmall,
             text = stringResource(resource = Res.string.onboarding_welcome_aboard),
         )
 
         Text(
-            style = MaterialTheme.typography.bodyMedium,
+            style = AppTheme.typography.bodyMedium,
             text = stringResource(resource = Res.string.onboarding_introduction_1),
         )
 
         Image(
             modifier = Modifier
-                .size(size = dimension.grid_6)
+                .size(size = AppTheme.dimens.grid_6)
                 .align(alignment = Alignment.CenterHorizontally),
             painter = painterResource(Res.drawable.bulb),
-            colorFilter = ColorFilter.tint(color = MaterialTheme.colorScheme.secondary),
+            colorFilter = ColorFilter.tint(color = AppTheme.colorScheme.secondary),
             contentDescription = null,
         )
 
         Text(
             modifier = Modifier.fillMaxWidth(),
             textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.titleMedium,
+            style = AppTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
             text = stringResource(resource = Res.string.onboarding_question_1),
         )
 
         Text(
-            style = MaterialTheme.typography.bodyMedium,
+            style = AppTheme.typography.bodyMedium,
             text = stringResource(resource = Res.string.onboarding_introduction_2),
         )
 
         CredentialsInputForm(
             modifier = Modifier.fillMaxWidth()
-                .padding(vertical = dimension.grid_2),
+                .padding(vertical = AppTheme.dimens.grid_2),
             isSubmitButtonEnabled = !uiState.isLoading,
             onSubmitCredentials = uiEvent.onSubmitCredentials,
         )
 
         Text(
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
+            style = AppTheme.typography.bodyMedium,
+            color = AppTheme.colorScheme.onSurface,
             text = stringResource(resource = Res.string.onboarding_reminder_1),
         )
 
         Text(
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
+            style = AppTheme.typography.bodyMedium,
+            color = AppTheme.colorScheme.onSurface,
             text = stringResource(resource = Res.string.onboarding_reminder_2),
         )
 

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/AccountOperationButtonBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/AccountOperationButtonBar.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -31,8 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.ui.components.SquareButton
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.account_clear_cache
 import kunigami.composeapp.generated.resources.account_demo_mode
@@ -49,13 +47,12 @@ internal fun AccountOperationButtonBar(
     onClearCache: () -> Unit,
     onSwitchToDemoMode: () -> Unit,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     var shouldShowDemoModeConfirmDialog by rememberSaveable { mutableStateOf(false) }
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.Top,
         horizontalArrangement = Arrangement.spacedBy(
-            dimension.grid_4,
+            AppTheme.dimens.grid_4,
             alignment = Alignment.CenterHorizontally,
         ),
     ) {
@@ -66,8 +63,8 @@ internal fun AccountOperationButtonBar(
             icon = painterResource(resource = Res.drawable.key),
             text = stringResource(resource = Res.string.account_update_api_key),
             colors = ButtonDefaults.buttonColors().copy(
-                containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                containerColor = AppTheme.colorScheme.secondaryContainer,
+                contentColor = AppTheme.colorScheme.onSecondaryContainer,
             ),
             onClick = onUpdateApiKey,
         )
@@ -79,8 +76,8 @@ internal fun AccountOperationButtonBar(
             icon = painterResource(resource = Res.drawable.database_remove_outline),
             text = stringResource(resource = Res.string.account_clear_cache),
             colors = ButtonDefaults.buttonColors().copy(
-                containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                containerColor = AppTheme.colorScheme.secondaryContainer,
+                contentColor = AppTheme.colorScheme.onSecondaryContainer,
             ),
             onClick = onClearCache,
         )
@@ -92,8 +89,8 @@ internal fun AccountOperationButtonBar(
             icon = painterResource(resource = Res.drawable.eraser),
             text = stringResource(resource = Res.string.account_demo_mode),
             colors = ButtonDefaults.buttonColors().copy(
-                containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                containerColor = AppTheme.colorScheme.secondaryContainer,
+                contentColor = AppTheme.colorScheme.onSecondaryContainer,
             ),
             onClick = { shouldShowDemoModeConfirmDialog = true },
         )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/AppInfoFooter.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/AppInfoFooter.kt
@@ -20,15 +20,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import composeapp.kunigami.BuildConfig
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.account_version_api_disclaimer
@@ -38,8 +36,6 @@ import org.jetbrains.compose.resources.stringResource
 internal fun AppInfoFooter(
     modifier: Modifier = Modifier,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Column(
         modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -50,10 +46,10 @@ internal fun AppInfoFooter(
 
         Text(
             modifier = modifier.padding(
-                vertical = dimension.grid_2,
-                horizontal = dimension.grid_4,
+                vertical = AppTheme.dimens.grid_2,
+                horizontal = AppTheme.dimens.grid_4,
             ),
-            style = MaterialTheme.typography.titleMedium,
+            style = AppTheme.typography.titleMedium,
             textAlign = TextAlign.Center,
             text = stringResource(resource = Res.string.account_version_api_disclaimer, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE, BuildConfig.GITHUB_LINK),
         )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/CredentialsInputForm.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/CredentialsInputForm.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -43,8 +42,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.onboarding_button_connect
 import kunigami.composeapp.generated.resources.onboarding_getting_started
@@ -63,14 +61,12 @@ internal fun CredentialsInputForm(
     isSubmitButtonEnabled: Boolean,
     onSubmitCredentials: (apiKey: String, accountNumber: String, stringResolver: suspend (resId: StringResource) -> String) -> Unit,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Column(
         modifier = modifier
-            .clip(shape = MaterialTheme.shapes.medium)
-            .background(color = MaterialTheme.colorScheme.surfaceContainer)
-            .padding(all = dimension.grid_3),
-        verticalArrangement = Arrangement.spacedBy(space = dimension.grid_2),
+            .clip(shape = AppTheme.shapes.medium)
+            .background(color = AppTheme.colorScheme.surfaceContainer)
+            .padding(all = AppTheme.dimens.grid_3),
+        verticalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_2),
     ) {
         val keyboardController = LocalSoftwareKeyboardController.current
         val accountFocusRequester = FocusRequester()
@@ -78,7 +74,7 @@ internal fun CredentialsInputForm(
         var account by rememberSaveable { mutableStateOf("") }
 
         Text(
-            style = MaterialTheme.typography.titleLarge,
+            style = AppTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
             text = stringResource(resource = Res.string.onboarding_getting_started),
         )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/ElectricityMeterPointCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/ElectricityMeterPointCard.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Card
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -33,9 +32,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import com.rwmobi.kunigami.domain.model.account.ElectricityMeterPoint
 import com.rwmobi.kunigami.ui.components.IconTextButton
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.destinations.account.AccountScreenLayoutStyle
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.account_error_null_tariff
 import kunigami.composeapp.generated.resources.account_mpan
@@ -55,25 +53,23 @@ internal fun ElectricityMeterPointCard(
     onReloadTariff: () -> Unit,
     onMeterSerialNumberSelected: (mpan: String, meterSerialNumber: String) -> Unit,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Card(modifier = modifier) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(bottom = dimension.grid_2),
-            verticalArrangement = Arrangement.spacedBy(space = dimension.grid_1),
+                .padding(bottom = AppTheme.dimens.grid_2),
+            verticalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_1),
         ) {
             Text(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(color = MaterialTheme.colorScheme.secondaryContainer)
+                    .background(color = AppTheme.colorScheme.secondaryContainer)
                     .padding(
-                        horizontal = dimension.grid_2,
-                        vertical = dimension.grid_0_5,
+                        horizontal = AppTheme.dimens.grid_2,
+                        vertical = AppTheme.dimens.grid_0_5,
                     ),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                style = AppTheme.typography.titleMedium,
+                color = AppTheme.colorScheme.onSecondaryContainer,
                 text = stringResource(resource = Res.string.account_mpan, meterPoint.mpan),
             )
 
@@ -85,9 +81,9 @@ internal fun ElectricityMeterPointCard(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(
-                                    start = dimension.grid_2,
-                                    end = dimension.grid_2,
-                                    bottom = dimension.grid_1,
+                                    start = AppTheme.dimens.grid_2,
+                                    end = AppTheme.dimens.grid_2,
+                                    bottom = AppTheme.dimens.grid_1,
                                 )
                                 .wrapContentHeight(),
                             agreement = agreement,
@@ -99,12 +95,12 @@ internal fun ElectricityMeterPointCard(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(
-                            start = dimension.grid_2,
-                            end = dimension.grid_2,
-                            bottom = dimension.grid_2,
+                            start = AppTheme.dimens.grid_2,
+                            end = AppTheme.dimens.grid_2,
+                            bottom = AppTheme.dimens.grid_2,
                         ),
                     horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(space = dimension.grid_2),
+                    verticalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_2),
                 ) {
                     Text(text = stringResource(resource = Res.string.account_error_null_tariff))
 
@@ -120,21 +116,21 @@ internal fun ElectricityMeterPointCard(
             if (meterPoint.meters.isNotEmpty()) {
                 HorizontalDivider(
                     modifier = Modifier
-                        .padding(horizontal = dimension.grid_2, vertical = dimension.grid_1)
+                        .padding(horizontal = AppTheme.dimens.grid_2, vertical = AppTheme.dimens.grid_1)
                         .alpha(0.5f),
                 )
             }
 
             val meterSerialNumberTextStyle = if (requestedLayout is AccountScreenLayoutStyle.Compact) {
-                MaterialTheme.typography.labelMedium
+                AppTheme.typography.labelMedium
             } else {
-                MaterialTheme.typography.titleMedium
+                AppTheme.typography.titleMedium
             }
 
             Column(
                 modifier = Modifier.fillMaxWidth()
-                    .padding(horizontal = dimension.grid_2),
-                verticalArrangement = Arrangement.spacedBy(space = dimension.grid_1),
+                    .padding(horizontal = AppTheme.dimens.grid_2),
+                verticalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_1),
             ) {
                 meterPoint.meters.forEach { meter ->
                     MeterSerialNumberEntry(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/MeterSerialNumberEntry.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/MeterSerialNumberEntry.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectable
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -43,8 +42,7 @@ import androidx.compose.ui.unit.Density
 import com.rwmobi.kunigami.domain.extensions.getLocalDateString
 import com.rwmobi.kunigami.domain.model.account.ElectricityMeter
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.account_meter_serial
 import kunigami.composeapp.generated.resources.dashboard
@@ -62,7 +60,6 @@ internal fun MeterSerialNumberEntry(
     onMeterSerialNumberSelected: () -> Unit,
 ) {
     val currentDensity = LocalDensity.current
-    val dimension = getScreenSizeInfo().getDimension()
     CompositionLocalProvider(
         LocalDensity provides Density(currentDensity.density, fontScale = 1f),
     ) {
@@ -71,9 +68,9 @@ internal fun MeterSerialNumberEntry(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clip(shape = MaterialTheme.shapes.small)
-                .background(color = MaterialTheme.colorScheme.surfaceContainerLow)
-                .heightIn(min = dimension.minTouchTarget)
+                .clip(shape = AppTheme.shapes.small)
+                .background(color = AppTheme.colorScheme.surfaceContainerLow)
+                .heightIn(min = AppTheme.dimens.minTouchTarget)
                 .selectable(
                     selected = isMeterSelected,
                     role = Role.RadioButton,
@@ -84,16 +81,16 @@ internal fun MeterSerialNumberEntry(
                     },
                 )
                 .padding(
-                    horizontal = dimension.grid_1,
-                    vertical = dimension.grid_0_5,
+                    horizontal = AppTheme.dimens.grid_1,
+                    vertical = AppTheme.dimens.grid_0_5,
                 ),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_1),
+            horizontalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_1),
         ) {
             Image(
                 modifier = Modifier
-                    .size(size = dimension.grid_3),
-                colorFilter = ColorFilter.tint(color = MaterialTheme.colorScheme.onSurfaceVariant),
+                    .size(size = AppTheme.dimens.grid_3),
+                colorFilter = ColorFilter.tint(color = AppTheme.colorScheme.onSurfaceVariant),
                 painter = painterResource(resource = Res.drawable.dashboard),
                 contentDescription = null,
             )
@@ -104,7 +101,7 @@ internal fun MeterSerialNumberEntry(
                         modifier = Modifier.fillMaxWidth(),
                         overflow = TextOverflow.Ellipsis,
                         style = meterSerialNumberTextStyle,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        color = AppTheme.colorScheme.onSurfaceVariant,
                         maxLines = 1,
                         text = stringResource(Res.string.account_meter_serial, serialNumber),
                     )
@@ -113,7 +110,7 @@ internal fun MeterSerialNumberEntry(
                         Text(
                             modifier = Modifier.fillMaxWidth(),
                             overflow = TextOverflow.Ellipsis,
-                            style = MaterialTheme.typography.bodySmall,
+                            style = AppTheme.typography.bodySmall,
                             maxLines = 1,
                             text = it,
                         )
@@ -122,7 +119,7 @@ internal fun MeterSerialNumberEntry(
                     if (readingSource != null && readAt != null && value != null) {
                         Text(
                             modifier = Modifier.fillMaxWidth(),
-                            style = MaterialTheme.typography.bodySmall,
+                            style = AppTheme.typography.bodySmall,
                             text = "$readingSource: ${value.toInt()} (${readAt.getLocalDateString()})",
                         )
                     }
@@ -153,7 +150,7 @@ private fun Preview() {
                 readAt = Instant.parse("2024-07-21T00:00:00+00:00"),
                 value = 2480.10,
             ),
-            meterSerialNumberTextStyle = MaterialTheme.typography.titleMedium,
+            meterSerialNumberTextStyle = AppTheme.typography.titleMedium,
             onMeterSerialNumberSelected = {},
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/SimpleTitleButtonCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/SimpleTitleButtonCard.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -32,8 +31,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.text.font.FontWeight
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.components.IconTextButton
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.account_update_api_key
 import kunigami.composeapp.generated.resources.key
@@ -49,24 +47,22 @@ internal fun SimpleTitleButtonCard(
     buttonPainter: Painter,
     onButtonClicked: () -> Unit,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Row(
         modifier = modifier
-            .clip(shape = MaterialTheme.shapes.medium)
-            .background(color = MaterialTheme.colorScheme.surfaceContainerHighest)
-            .padding(all = dimension.grid_2),
+            .clip(shape = AppTheme.shapes.medium)
+            .background(color = AppTheme.colorScheme.surfaceContainerHighest)
+            .padding(all = AppTheme.dimens.grid_2),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
             modifier = Modifier.weight(1f),
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface,
+            style = AppTheme.typography.titleMedium,
+            color = AppTheme.colorScheme.onSurface,
             fontWeight = FontWeight.Bold,
             text = title,
         )
 
-        Spacer(modifier = Modifier.size(size = dimension.grid_4))
+        Spacer(modifier = Modifier.size(size = AppTheme.dimens.grid_4))
 
         IconTextButton(
             icon = buttonPainter,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/TariffLayout.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/account/components/TariffLayout.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -38,8 +37,7 @@ import com.rwmobi.kunigami.domain.extensions.getLocalDateString
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.domain.model.account.Agreement
 import com.rwmobi.kunigami.domain.model.product.Tariff
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.account_tariff_date_range
 import kunigami.composeapp.generated.resources.account_tariff_day_unit_rate
@@ -62,21 +60,19 @@ internal fun TariffLayout(
     agreement: Agreement,
     showDivider: Boolean = false,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Column(
         modifier = modifier,
     ) {
         Text(
             modifier = Modifier.fillMaxWidth(),
-            style = MaterialTheme.typography.titleMedium,
+            style = AppTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
             text = agreement.displayName,
         )
 
         Text(
             modifier = Modifier.fillMaxWidth(),
-            style = MaterialTheme.typography.bodySmall,
+            style = AppTheme.typography.bodySmall,
             text = agreement.fullName,
         )
 
@@ -86,11 +82,11 @@ internal fun TariffLayout(
 
         Text(
             modifier = Modifier.fillMaxWidth(),
-            style = MaterialTheme.typography.bodySmall,
+            style = AppTheme.typography.bodySmall,
             text = stringResource(resource = Res.string.agile_product_code_retail_region, agreement.tariffCode, regionCodeStringResource),
         )
 
-        Spacer(modifier = Modifier.height(height = dimension.grid_2))
+        Spacer(modifier = Modifier.height(height = AppTheme.dimens.grid_2))
 
         val tariffPeriod = if (agreement.period.endInclusive != Instant.DISTANT_FUTURE) {
             stringResource(
@@ -106,11 +102,11 @@ internal fun TariffLayout(
         }
 
         Text(
-            style = MaterialTheme.typography.bodyMedium,
+            style = AppTheme.typography.bodyMedium,
             text = tariffPeriod,
         )
 
-        Spacer(modifier = Modifier.height(height = dimension.grid_1))
+        Spacer(modifier = Modifier.height(height = AppTheme.dimens.grid_1))
 
         if (agreement.isHalfHourlyTariff) {
             showHalfHourlyRate()
@@ -127,7 +123,7 @@ internal fun TariffLayout(
             HorizontalDivider(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = dimension.grid_2),
+                    .padding(top = AppTheme.dimens.grid_2),
             )
         }
     }
@@ -160,7 +156,6 @@ private fun RateRow(
     label: String,
     rate: Double,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -169,15 +164,15 @@ private fun RateRow(
         horizontalArrangement = Arrangement.End,
     ) {
         Text(
-            style = MaterialTheme.typography.bodyMedium,
+            style = AppTheme.typography.bodyMedium,
             textAlign = TextAlign.End,
             text = label,
         )
 
-        Spacer(modifier = Modifier.width(dimension.grid_2))
+        Spacer(modifier = Modifier.width(AppTheme.dimens.grid_2))
 
         Text(
-            style = MaterialTheme.typography.titleLarge,
+            style = AppTheme.typography.titleLarge,
             text = rate.roundToTwoDecimalPlaces().toString(),
         )
     }
@@ -187,7 +182,7 @@ private fun RateRow(
 private fun showHalfHourlyRate() {
     Text(
         modifier = Modifier.fillMaxWidth(),
-        style = MaterialTheme.typography.titleMedium,
+        style = AppTheme.typography.titleMedium,
         textAlign = TextAlign.End,
         text = stringResource(resource = Res.string.tariffs_half_hourly_rate),
     )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/AgileScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -52,7 +51,6 @@ import com.rwmobi.kunigami.ui.components.LoadingScreen
 import com.rwmobi.kunigami.ui.components.ScrollbarMultiplatform
 import com.rwmobi.kunigami.ui.components.koalaplot.VerticalBarChart
 import com.rwmobi.kunigami.ui.composehelper.conditionalBlur
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.destinations.agile.components.AgileTariffCardAdaptive
 import com.rwmobi.kunigami.ui.destinations.agile.components.RateGroupCells
 import com.rwmobi.kunigami.ui.destinations.agile.components.RateGroupTitle
@@ -61,8 +59,8 @@ import com.rwmobi.kunigami.ui.model.SpecialErrorScreen
 import com.rwmobi.kunigami.ui.model.chart.BarChartData
 import com.rwmobi.kunigami.ui.model.chart.RequestedChartLayout
 import com.rwmobi.kunigami.ui.model.rate.RateGroupWithPartitions
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import com.rwmobi.kunigami.ui.theme.cyanish
-import com.rwmobi.kunigami.ui.theme.getDimension
 import com.rwmobi.kunigami.ui.theme.purpleish
 import io.github.koalaplot.core.style.LineStyle
 import io.github.koalaplot.core.xygraph.HorizontalLineAnnotation
@@ -96,7 +94,6 @@ fun AgileScreen(
         }
     }
 
-    val dimension = getScreenSizeInfo().getDimension()
     val lazyListState = rememberLazyListState()
 
     Box(modifier = modifier) {
@@ -139,9 +136,9 @@ fun AgileScreen(
 
                     DualTitleBar(
                         modifier = Modifier
-                            .background(color = MaterialTheme.colorScheme.secondary)
+                            .background(color = AppTheme.colorScheme.secondary)
                             .fillMaxWidth()
-                            .height(height = dimension.minListItemHeight),
+                            .height(height = AppTheme.dimens.minListItemHeight),
                         title = uiState.agileTariff?.displayName ?: "",
                         subtitle = subtitle,
                     )
@@ -163,7 +160,7 @@ fun AgileScreen(
 
                         LazyColumn(
                             modifier = contentModifier.conditionalBlur(enabled = uiState.isLoading && uiState.barChartData == null),
-                            contentPadding = PaddingValues(bottom = dimension.grid_4),
+                            contentPadding = PaddingValues(bottom = AppTheme.dimens.grid_4),
                             state = lazyListState,
                         ) {
                             if (uiState.isDemoMode == true) {
@@ -171,7 +168,7 @@ fun AgileScreen(
                                     DemoModeCtaAdaptive(
                                         modifier = Modifier
                                             .fillMaxWidth()
-                                            .padding(all = dimension.grid_2),
+                                            .padding(all = AppTheme.dimens.grid_2),
                                         description = stringResource(resource = Res.string.agile_demo_introduction),
                                         ctaButtonLabel = stringResource(resource = Res.string.provide_api_key),
                                         onCtaButtonClicked = uiEvent.onNavigateToAccountTab,
@@ -193,8 +190,8 @@ fun AgileScreen(
                                         .background(color = CardDefaults.cardColors().containerColor)
                                         .fillMaxWidth()
                                         .padding(
-                                            horizontal = dimension.grid_3,
-                                            vertical = dimension.grid_1,
+                                            horizontal = AppTheme.dimens.grid_3,
+                                            vertical = AppTheme.dimens.grid_1,
                                         ),
                                     latestFixedTariff = uiState.latestFixedTariff,
                                     latestFlexibleTariff = uiState.latestFlexibleTariff,
@@ -207,12 +204,12 @@ fun AgileScreen(
 
                             if (uiState.rateGroupedCells.isNotEmpty()) {
                                 item(key = "headingUnitRateDetails") {
-                                    Spacer(modifier = Modifier.height(height = dimension.grid_1))
+                                    Spacer(modifier = Modifier.height(height = AppTheme.dimens.grid_1))
 
                                     LargeTitleWithIcon(
                                         modifier = Modifier
                                             .fillMaxWidth()
-                                            .padding(all = dimension.grid_2),
+                                            .padding(all = AppTheme.dimens.grid_2),
                                         icon = painterResource(resource = Res.drawable.revenue),
                                         label = stringResource(resource = Res.string.agile_unit_rate_details),
                                     )
@@ -225,8 +222,8 @@ fun AgileScreen(
                                         modifier = Modifier
                                             .fillMaxWidth()
                                             .padding(
-                                                vertical = dimension.grid_2,
-                                                horizontal = dimension.grid_4,
+                                                vertical = AppTheme.dimens.grid_2,
+                                                horizontal = AppTheme.dimens.grid_4,
                                             ),
                                         title = rateGroupsWithPartitions.title,
                                     )
@@ -238,8 +235,8 @@ fun AgileScreen(
                                         modifier = Modifier
                                             .fillMaxWidth()
                                             .padding(
-                                                horizontal = dimension.grid_4,
-                                                vertical = dimension.grid_0_25,
+                                                horizontal = AppTheme.dimens.grid_4,
+                                                vertical = AppTheme.dimens.grid_0_25,
                                             ),
                                         partitionedItems = rateGroupsWithPartitions.partitionedItems,
                                         shouldHideLastColumn = shouldHideLastRateGroupColumn,
@@ -300,9 +297,8 @@ private fun LazyListScope.renderChart(
     barChartData: BarChartData,
 ) {
     item(key = "chart") {
-        val dimension = getScreenSizeInfo().getDimension()
         Box(
-            modifier = Modifier.padding(top = dimension.grid_1),
+            modifier = Modifier.padding(top = AppTheme.dimens.grid_1),
         ) {
             val constraintModifier = when (uiState.requestedChartLayout) {
                 is RequestedChartLayout.Portrait -> {
@@ -319,7 +315,7 @@ private fun LazyListScope.renderChart(
             }
 
             VerticalBarChart(
-                modifier = constraintModifier.padding(all = dimension.grid_2),
+                modifier = constraintModifier.padding(all = AppTheme.dimens.grid_2),
                 showToolTipOnClick = uiState.showToolTipOnClick,
                 entries = barChartData.verticalBarPlotEntries,
                 yAxisRange = uiState.rateRange,
@@ -336,7 +332,7 @@ private fun LazyListScope.renderChart(
                             location = fixedUnitRate,
                             lineStyle = LineStyle(
                                 brush = SolidColor(purpleish),
-                                strokeWidth = dimension.grid_0_25,
+                                strokeWidth = AppTheme.dimens.grid_0_25,
                                 pathEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 16f), 0f),
                                 alpha = 0.8f,
                                 colorFilter = null, // No color filter
@@ -350,7 +346,7 @@ private fun LazyListScope.renderChart(
                             location = flexibleUnitRate,
                             lineStyle = LineStyle(
                                 brush = SolidColor(cyanish),
-                                strokeWidth = dimension.grid_0_25,
+                                strokeWidth = AppTheme.dimens.grid_0_25,
                                 pathEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 16f), 0f),
                                 alpha = 0.8f,
                                 colorFilter = null, // No color filter

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/AgileTariffCardAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/AgileTariffCardAdaptive.kt
@@ -42,7 +42,6 @@ import com.rwmobi.kunigami.domain.model.product.Tariff
 import com.rwmobi.kunigami.domain.model.rate.PaymentMethod
 import com.rwmobi.kunigami.domain.model.rate.Rate
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.composehelper.palette.RatePalette
 import com.rwmobi.kunigami.ui.composehelper.shouldUseDarkTheme
 import com.rwmobi.kunigami.ui.model.rate.RateGroup
@@ -50,8 +49,8 @@ import com.rwmobi.kunigami.ui.model.rate.RateTrend
 import com.rwmobi.kunigami.ui.model.rate.findActiveRate
 import com.rwmobi.kunigami.ui.model.rate.getRateTrend
 import com.rwmobi.kunigami.ui.previewsampledata.TariffSamples
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import com.rwmobi.kunigami.ui.theme.cyanish
-import com.rwmobi.kunigami.ui.theme.getDimension
 import com.rwmobi.kunigami.ui.theme.purpleish
 import kotlinx.coroutines.delay
 import kunigami.composeapp.generated.resources.Res
@@ -184,17 +183,16 @@ private fun AgileTariffCardCompact(
     latestFixedTariff: Tariff? = null,
     latestFlexibleTariff: Tariff? = null,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(dimension.grid_1),
+        verticalArrangement = Arrangement.spacedBy(AppTheme.dimens.grid_1),
     ) {
         val tileModifier = Modifier
             .weight(1f)
-            .height(dimension.widgetHeight)
+            .height(AppTheme.dimens.widgetHeight)
 
         Row(
-            horizontalArrangement = Arrangement.spacedBy(dimension.grid_1),
+            horizontalArrangement = Arrangement.spacedBy(AppTheme.dimens.grid_1),
             modifier = Modifier
                 .fillMaxWidth()
                 .height(intrinsicSize = IntrinsicSize.Min),
@@ -216,7 +214,7 @@ private fun AgileTariffCardCompact(
         }
 
         Row(
-            horizontalArrangement = Arrangement.spacedBy(dimension.grid_1),
+            horizontalArrangement = Arrangement.spacedBy(AppTheme.dimens.grid_1),
         ) {
             ReferenceTariffTiles(
                 modifier = tileModifier,
@@ -273,16 +271,15 @@ private fun AgileTariffCardExpanded(
     latestFixedTariff: Tariff? = null,
     latestFlexibleTariff: Tariff? = null,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     FlowRow(
         modifier = modifier.fillMaxSize(),
         horizontalArrangement = Arrangement.Center,
-        verticalArrangement = Arrangement.spacedBy(dimension.grid_1),
+        verticalArrangement = Arrangement.spacedBy(AppTheme.dimens.grid_1),
     ) {
         val tileModifier = Modifier
-            .width(dimension.widgetWidthFull)
-            .height(dimension.widgetHeight)
-            .padding(horizontal = dimension.grid_0_5)
+            .width(AppTheme.dimens.widgetWidthFull)
+            .height(AppTheme.dimens.widgetHeight)
+            .padding(horizontal = AppTheme.dimens.grid_0_5)
 
         CurrentRateTile(
             modifier = tileModifier,
@@ -317,14 +314,14 @@ private fun AgileTariffCardExpanded(
 @Preview
 @Composable
 private fun PreviewCompact() {
-    CommonPreviewSetup { dimension ->
+    CommonPreviewSetup {
         AgileTariffCardAdaptive(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(
-                    start = dimension.grid_3,
-                    end = dimension.grid_3,
-                    top = dimension.grid_1,
+                    start = AppTheme.dimens.grid_3,
+                    end = AppTheme.dimens.grid_3,
+                    top = AppTheme.dimens.grid_1,
                 ),
             rateRange = 0.0..5.0,
             rateGroupedCells = listOf(
@@ -353,14 +350,14 @@ private fun PreviewCompact() {
 @Preview
 @Composable
 private fun PreviewExpanded() {
-    CommonPreviewSetup { dimension ->
+    CommonPreviewSetup {
         AgileTariffCardAdaptive(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(
-                    start = dimension.grid_3,
-                    end = dimension.grid_3,
-                    top = dimension.grid_1,
+                    start = AppTheme.dimens.grid_3,
+                    end = AppTheme.dimens.grid_3,
+                    top = AppTheme.dimens.grid_1,
                 ),
             rateRange = 0.0..5.0,
             rateGroupedCells = listOf(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/CurrentRateTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/CurrentRateTile.kt
@@ -31,7 +31,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -50,9 +49,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.components.HorizontalAnimatedTintedPainterResource
 import com.rwmobi.kunigami.ui.components.VerticalAnimatedTintedPainterResource
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.rate.RateTrend
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import io.github.koalaplot.core.util.toString
 import kotlinx.coroutines.delay
 import kunigami.composeapp.generated.resources.Res
@@ -70,12 +68,11 @@ internal fun CurrentRateTile(
     rateTrend: RateTrend?,
     rateTrendIconTint: Color? = null,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     Column(
         modifier = modifier
-            .clip(shape = MaterialTheme.shapes.large)
-            .background(MaterialTheme.colorScheme.surfaceContainer)
-            .padding(dimension.grid_2),
+            .clip(shape = AppTheme.shapes.large)
+            .background(AppTheme.colorScheme.surfaceContainer)
+            .padding(AppTheme.dimens.grid_2),
         verticalArrangement = Arrangement.Top,
     ) {
         val animatedVatInclusivePrice by animateFloatAsState(
@@ -91,13 +88,13 @@ internal fun CurrentRateTile(
                     modifier = Modifier.wrapContentSize(),
                     maxLines = 1,
                     overflow = TextOverflow.Clip,
-                    style = MaterialTheme.typography.displayMedium,
+                    style = AppTheme.typography.displayMedium,
                     text = animatedVatInclusivePrice.toString(precision = 2),
                 )
 
                 if (rateTrend != null && rateTrendIconTint != null) {
                     val rateTrendModifier = Modifier
-                        .size(size = dimension.grid_4)
+                        .size(size = AppTheme.dimens.grid_4)
                         .semantics { contentDescription = rateTrend.name }
 
                     when (rateTrend) {
@@ -137,11 +134,11 @@ internal fun CurrentRateTile(
         }
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(dimension.grid_1),
+            horizontalArrangement = Arrangement.spacedBy(AppTheme.dimens.grid_1),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                style = MaterialTheme.typography.bodyMedium,
+                style = AppTheme.typography.bodyMedium,
                 fontWeight = FontWeight.Bold,
                 text = stringResource(resource = Res.string.p_kwh),
             )
@@ -153,10 +150,10 @@ internal fun CurrentRateTile(
             ) {
                 Text(
                     modifier = Modifier
-                        .background(MaterialTheme.colorScheme.errorContainer)
-                        .padding(horizontal = dimension.grid_1),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onErrorContainer,
+                        .background(AppTheme.colorScheme.errorContainer)
+                        .padding(horizontal = AppTheme.dimens.grid_1),
+                    style = AppTheme.typography.labelSmall,
+                    color = AppTheme.colorScheme.onErrorContainer,
                     fontWeight = FontWeight.Bold,
                     text = stringResource(resource = Res.string.overpriced).uppercase(),
                 )
@@ -167,7 +164,7 @@ internal fun CurrentRateTile(
 
         Text(
             modifier = Modifier.fillMaxWidth(),
-            style = MaterialTheme.typography.bodyMedium,
+            style = AppTheme.typography.bodyMedium,
             text = stringResource(resource = Res.string.agile_current_rate),
         )
     }
@@ -176,11 +173,11 @@ internal fun CurrentRateTile(
 @Preview
 @Composable
 private fun Preview() {
-    CommonPreviewSetup { dimension ->
+    CommonPreviewSetup {
         CurrentRateTile(
             modifier = Modifier
-                .width(dimension.widgetWidthFull)
-                .height(dimension.widgetHeight),
+                .width(AppTheme.dimens.widgetWidthFull)
+                .height(AppTheme.dimens.widgetHeight),
             isCurrentRateOverpriced = true,
             rateTrendIconTint = Color.Red,
             rateTrend = RateTrend.DOWN,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/GaugeWidget.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/GaugeWidget.kt
@@ -28,7 +28,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -51,6 +50,7 @@ import com.rwmobi.kunigami.ui.composehelper.drawPlainColorArc
 import com.rwmobi.kunigami.ui.composehelper.palette.RatePalette
 import com.rwmobi.kunigami.ui.composehelper.palette.generateGYRHueSpectrum
 import com.rwmobi.kunigami.ui.composehelper.shouldUseDarkTheme
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.agile_expire
 import org.jetbrains.compose.resources.stringResource
@@ -143,7 +143,7 @@ internal fun GaugeWidget(
                     verticalArrangement = Arrangement.Bottom,
                 ) {
                     Text(
-                        style = MaterialTheme.typography.bodyMedium.copy(
+                        style = AppTheme.typography.bodyMedium.copy(
                             lineHeightStyle = LineHeightStyle(
                                 alignment = LineHeightStyle.Alignment.Bottom,
                                 trim = LineHeightStyle.Trim.Both,
@@ -154,7 +154,7 @@ internal fun GaugeWidget(
                         text = stringResource(resource = Res.string.agile_expire),
                     )
                     Text(
-                        style = MaterialTheme.typography.headlineMedium.copy(
+                        style = AppTheme.typography.headlineMedium.copy(
                             lineHeightStyle = LineHeightStyle(
                                 alignment = LineHeightStyle.Alignment.Bottom,
                                 trim = LineHeightStyle.Trim.Both,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/LiveConsumptionTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/LiveConsumptionTile.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -37,8 +36,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextOverflow
 import com.rwmobi.kunigami.domain.model.consumption.LiveConsumption
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.agile_live_consumption
 import kunigami.composeapp.generated.resources.w
@@ -50,12 +48,11 @@ internal fun LiveConsumptionTile(
     modifier: Modifier = Modifier,
     liveConsumption: LiveConsumption,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     Column(
         modifier = modifier
-            .clip(shape = MaterialTheme.shapes.large)
-            .background(MaterialTheme.colorScheme.surfaceContainer)
-            .padding(dimension.grid_2),
+            .clip(shape = AppTheme.shapes.large)
+            .background(AppTheme.colorScheme.surfaceContainer)
+            .padding(AppTheme.dimens.grid_2),
         verticalArrangement = Arrangement.Top,
     ) {
         val animatedVatInclusivePrice by animateIntAsState(
@@ -65,20 +62,20 @@ internal fun LiveConsumptionTile(
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(dimension.grid_1),
+            horizontalArrangement = Arrangement.spacedBy(AppTheme.dimens.grid_1),
         ) {
             Text(
                 modifier = Modifier.wrapContentSize(),
                 maxLines = 1,
                 overflow = TextOverflow.Clip,
-                style = MaterialTheme.typography.displayMedium,
+                style = AppTheme.typography.displayMedium,
                 text = animatedVatInclusivePrice.toString(),
             )
 
             Text(
                 modifier = Modifier.wrapContentSize(),
                 maxLines = 1,
-                style = MaterialTheme.typography.titleMedium,
+                style = AppTheme.typography.titleMedium,
                 text = stringResource(resource = Res.string.w),
             )
         }
@@ -87,7 +84,7 @@ internal fun LiveConsumptionTile(
 
         Text(
             modifier = Modifier.fillMaxWidth(),
-            style = MaterialTheme.typography.bodyMedium,
+            style = AppTheme.typography.bodyMedium,
             text = stringResource(resource = Res.string.agile_live_consumption),
         )
     }
@@ -96,11 +93,11 @@ internal fun LiveConsumptionTile(
 @Preview
 @Composable
 private fun Preview() {
-    CommonPreviewSetup { dimension ->
+    CommonPreviewSetup {
         LiveConsumptionTile(
             modifier = Modifier
-                .width(dimension.widgetWidthFull)
-                .height(dimension.widgetHeight),
+                .width(AppTheme.dimens.widgetWidthFull)
+                .height(AppTheme.dimens.widgetHeight),
             LiveConsumption(
                 readAt = Clock.System.now(),
                 demand = 1560,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGaugeCountdownTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGaugeCountdownTile.kt
@@ -21,14 +21,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 
 @Composable
 internal fun RateGaugeCountdownTile(
@@ -37,12 +35,11 @@ internal fun RateGaugeCountdownTile(
     targetPercentage: Float,
     colorPalette: List<Color>,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     Column(
         modifier = modifier
-            .clip(shape = MaterialTheme.shapes.large)
-            .background(MaterialTheme.colorScheme.surfaceContainer)
-            .padding(dimension.grid_2),
+            .clip(shape = AppTheme.shapes.large)
+            .background(AppTheme.colorScheme.surfaceContainer)
+            .padding(AppTheme.dimens.grid_2),
         verticalArrangement = Arrangement.Top,
     ) {
         Row(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupCells.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupCells.kt
@@ -23,10 +23,9 @@ import androidx.compose.ui.Modifier
 import com.rwmobi.kunigami.domain.extensions.getLocalHHMMString
 import com.rwmobi.kunigami.domain.model.rate.Rate
 import com.rwmobi.kunigami.ui.components.IndicatorTextValueGridItem
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.composehelper.palette.RatePalette
 import com.rwmobi.kunigami.ui.composehelper.shouldUseDarkTheme
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import io.github.koalaplot.core.util.toString
 
 @Composable
@@ -39,11 +38,9 @@ internal fun RateGroupCells(
     minimumVatInclusivePrice: Double,
     blinkingAlpha: Float = 1f,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Row(
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_3),
+        horizontalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_3),
     ) {
         val columnRangeToRender = if (shouldHideLastColumn) {
             0..<partitionedItems.lastIndex

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupTitle.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/RateGroupTitle.kt
@@ -20,13 +20,13 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.agile_vat_unit_rate
 import org.jetbrains.compose.resources.stringResource
@@ -42,14 +42,14 @@ internal fun RateGroupTitle(
     ) {
         Text(
             modifier = Modifier.weight(1f),
-            style = MaterialTheme.typography.titleMedium,
+            style = AppTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
             text = title,
         )
 
         Text(
             modifier = Modifier.wrapContentSize(),
-            style = MaterialTheme.typography.labelMedium,
+            style = AppTheme.typography.labelMedium,
             fontWeight = FontWeight.Bold,
             text = stringResource(resource = Res.string.agile_vat_unit_rate),
         )
@@ -59,13 +59,13 @@ internal fun RateGroupTitle(
 @Preview
 @Composable
 private fun Preview() {
-    CommonPreviewSetup { dimension ->
+    CommonPreviewSetup {
         RateGroupTitle(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(
-                    vertical = dimension.grid_2,
-                    horizontal = dimension.grid_4,
+                    vertical = AppTheme.dimens.grid_2,
+                    horizontal = AppTheme.dimens.grid_4,
                 ),
             title = "Sample title",
         )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/ReferenceTariffTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/agile/components/ReferenceTariffTile.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -35,10 +34,9 @@ import androidx.compose.ui.text.font.FontWeight
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.domain.model.product.Tariff
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.previewsampledata.TariffSamples
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import com.rwmobi.kunigami.ui.theme.cyanish
-import com.rwmobi.kunigami.ui.theme.getDimension
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.p_kwh
 import org.jetbrains.compose.resources.stringResource
@@ -49,32 +47,32 @@ internal fun ReferenceTariffTile(
     tariff: Tariff,
     indicatorColor: Color,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
+    val dimensGrid1 = AppTheme.dimens.grid_1
     Column(
         modifier = modifier
-            .clip(shape = MaterialTheme.shapes.large)
-            .background(MaterialTheme.colorScheme.surfaceContainer)
+            .clip(shape = AppTheme.shapes.large)
+            .background(AppTheme.colorScheme.surfaceContainer)
             .drawBehind {
-                val stripeWidth = dimension.grid_1.toPx()
+                val stripeWidth = dimensGrid1.toPx()
                 drawRect(
                     color = indicatorColor,
                     topLeft = Offset(x = size.width - stripeWidth, y = 0f),
                     size = Size(width = stripeWidth, height = size.height),
                 )
             }
-            .padding(dimension.grid_2),
+            .padding(AppTheme.dimens.grid_2),
         verticalArrangement = Arrangement.Top,
     ) {
         tariff.vatInclusiveStandardUnitRate?.let { unitRate ->
             Text(
                 text = unitRate.roundToTwoDecimalPlaces().toString(),
-                style = MaterialTheme.typography.headlineMedium,
+                style = AppTheme.typography.headlineMedium,
                 modifier = Modifier.fillMaxWidth(),
             )
 
             Text(
                 text = stringResource(resource = Res.string.p_kwh),
-                style = MaterialTheme.typography.bodySmall,
+                style = AppTheme.typography.bodySmall,
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -84,15 +82,15 @@ internal fun ReferenceTariffTile(
 
         Text(
             text = tariff.displayName,
-            style = MaterialTheme.typography.labelMedium,
+            style = AppTheme.typography.labelMedium,
             fontWeight = FontWeight.Normal,
             modifier = Modifier.fillMaxWidth(),
         )
 
         Text(
             text = tariff.tariffCode,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurface.copy(
+            style = AppTheme.typography.labelSmall,
+            color = AppTheme.colorScheme.onSurface.copy(
                 alpha = 0.5f,
             ),
             fontWeight = FontWeight.Normal,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/TariffsScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -44,14 +43,13 @@ import com.rwmobi.kunigami.ui.components.ErrorScreenHandler
 import com.rwmobi.kunigami.ui.components.LoadingScreen
 import com.rwmobi.kunigami.ui.components.ScrollbarMultiplatform
 import com.rwmobi.kunigami.ui.composehelper.conditionalBlur
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.destinations.tariffs.components.ButtonTitleBar
 import com.rwmobi.kunigami.ui.destinations.tariffs.components.PostcodeInputBar
 import com.rwmobi.kunigami.ui.destinations.tariffs.components.ProductBottomSheetWrapper
 import com.rwmobi.kunigami.ui.destinations.tariffs.components.ProductListItemAdaptive
 import com.rwmobi.kunigami.ui.destinations.tariffs.components.ProductPaneWrapper
 import com.rwmobi.kunigami.ui.model.SpecialErrorScreen
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.arrow_ios_back_fill
 import kunigami.composeapp.generated.resources.close_fill
@@ -78,7 +76,6 @@ fun TariffsScreen(
         }
     }
 
-    val dimension = getScreenSizeInfo().getDimension()
     val mainLazyListState = rememberLazyListState()
 
     Box(modifier = modifier) {
@@ -104,9 +101,9 @@ fun TariffsScreen(
                         ) {
                             DualTitleBar(
                                 modifier = Modifier
-                                    .background(color = MaterialTheme.colorScheme.secondary)
+                                    .background(color = AppTheme.colorScheme.secondary)
                                     .fillMaxWidth()
-                                    .height(height = dimension.minListItemHeight),
+                                    .height(height = AppTheme.dimens.minListItemHeight),
                                 title = stringResource(resource = Res.string.navigation_tariffs),
                             )
 
@@ -134,7 +131,7 @@ fun TariffsScreen(
                                                     },
                                                 )
                                                 .fillMaxWidth()
-                                                .padding(vertical = dimension.grid_1),
+                                                .padding(vertical = AppTheme.dimens.grid_1),
                                             productSummary = product,
                                             useWideLayout = uiState.requestedWideListLayout,
                                         )
@@ -142,7 +139,7 @@ fun TariffsScreen(
                                         if (index < uiState.productSummaries.lastIndex) {
                                             HorizontalDivider(
                                                 modifier = Modifier.fillMaxWidth(),
-                                                color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                                                color = AppTheme.colorScheme.surfaceContainerHighest,
                                             )
                                         }
                                     }
@@ -164,7 +161,7 @@ fun TariffsScreen(
                     if (uiState.requestedLayout == TariffScreenLayoutStyle.ListDetailPane) {
                         VerticalDivider(
                             modifier = Modifier.fillMaxHeight(),
-                            color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                            color = AppTheme.colorScheme.surfaceContainerHighest,
                         )
 
                         ProductPaneWrapper(
@@ -174,16 +171,16 @@ fun TariffsScreen(
                             uiState.productDetails?.let { productDetails ->
                                 ButtonTitleBar(
                                     modifier = Modifier
-                                        .background(color = MaterialTheme.colorScheme.secondary)
+                                        .background(color = AppTheme.colorScheme.secondary)
                                         .fillMaxWidth()
-                                        .height(height = dimension.minListItemHeight),
+                                        .height(height = AppTheme.dimens.minListItemHeight),
                                     title = productDetails.displayName,
-                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    color = AppTheme.colorScheme.onSecondaryContainer,
                                     rightButton = {
                                         IconButton(onClick = uiEvent.onProductDetailsDismissed) {
                                             Icon(
                                                 painter = painterResource(resource = Res.drawable.close_fill),
-                                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                                tint = AppTheme.colorScheme.onSecondaryContainer,
                                                 contentDescription = stringResource(resource = Res.string.content_description_dismiss_this_pane),
                                             )
                                         }
@@ -204,16 +201,16 @@ fun TariffsScreen(
                 ) {
                     ButtonTitleBar(
                         modifier = Modifier
-                            .background(color = MaterialTheme.colorScheme.secondary)
+                            .background(color = AppTheme.colorScheme.secondary)
                             .fillMaxWidth()
-                            .height(height = dimension.minListItemHeight),
+                            .height(height = AppTheme.dimens.minListItemHeight),
                         title = uiState.productDetails?.displayName ?: "",
-                        color = MaterialTheme.colorScheme.onSecondary,
+                        color = AppTheme.colorScheme.onSecondary,
                         leftButton = {
                             IconButton(onClick = uiEvent.onProductDetailsDismissed) {
                                 Icon(
                                     painter = painterResource(resource = Res.drawable.arrow_ios_back_fill),
-                                    tint = MaterialTheme.colorScheme.onSecondary,
+                                    tint = AppTheme.colorScheme.onSecondary,
                                     contentDescription = stringResource(resource = Res.string.content_description_navigate_back),
                                 )
                             }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/CloseButtonBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/CloseButtonBar.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -31,15 +30,16 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.theme.AppTheme
 
 @Composable
 internal fun ButtonTitleBar(
     modifier: Modifier = Modifier
-        .background(color = MaterialTheme.colorScheme.secondary)
+        .background(color = AppTheme.colorScheme.secondary)
         .fillMaxWidth()
         .height(height = 56.dp),
     title: String,
-    color: Color = MaterialTheme.colorScheme.onSecondaryContainer,
+    color: Color = AppTheme.colorScheme.onSecondaryContainer,
     leftButton: @Composable (() -> Unit)? = null,
     rightButton: @Composable (() -> Unit)? = null,
 ) {
@@ -51,7 +51,7 @@ internal fun ButtonTitleBar(
                 .fillMaxWidth()
                 .align(alignment = Alignment.Center),
             textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.titleMedium,
+            style = AppTheme.typography.titleMedium,
             color = color,
             fontWeight = FontWeight.Bold,
             maxLines = 1,
@@ -76,12 +76,12 @@ internal fun ButtonTitleBar(
 @Preview
 @Composable
 private fun Preview() {
-    CommonPreviewSetup { dimension ->
+    CommonPreviewSetup {
         ButtonTitleBar(
             modifier = Modifier
-                .background(color = MaterialTheme.colorScheme.secondary)
+                .background(color = AppTheme.colorScheme.secondary)
                 .fillMaxWidth()
-                .height(height = dimension.minListItemHeight),
+                .height(height = AppTheme.dimens.minListItemHeight),
             title = "Sample Title",
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/PostcodeInputBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/PostcodeInputBar.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -36,8 +35,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.content_description_edit_postcode
 import kunigami.composeapp.generated.resources.settings_24_regular
@@ -51,7 +49,6 @@ internal fun PostcodeInputBar(
     postcode: String,
     onUpdatePostcode: (String) -> Unit,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     var showEditPostcodeDialog by remember { mutableStateOf(false) }
 
     if (showEditPostcodeDialog) {
@@ -68,26 +65,26 @@ internal fun PostcodeInputBar(
     Column(modifier = modifier) {
         Row(
             modifier = Modifier
-                .background(color = MaterialTheme.colorScheme.surfaceContainerLow)
+                .background(color = AppTheme.colorScheme.surfaceContainerLow)
                 .fillMaxWidth()
-                .height(height = dimension.minListItemHeight)
-                .padding(start = dimension.grid_2),
+                .height(height = AppTheme.dimens.minListItemHeight)
+                .padding(start = AppTheme.dimens.grid_2),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
                 modifier = Modifier.weight(1f),
-                style = MaterialTheme.typography.bodyMedium,
+                style = AppTheme.typography.bodyMedium,
                 text = stringResource(resource = Res.string.tariffs_postcode, postcode),
             )
 
             IconButton(
-                modifier = Modifier.size(size = dimension.imageButtonSize),
+                modifier = Modifier.size(size = AppTheme.dimens.imageButtonSize),
                 onClick = { showEditPostcodeDialog = true },
             ) {
                 Icon(
                     modifier = Modifier.padding(
-                        horizontal = dimension.grid_1,
-                        vertical = dimension.grid_0_5,
+                        horizontal = AppTheme.dimens.grid_1,
+                        vertical = AppTheme.dimens.grid_0_5,
                     ),
                     painter = painterResource(resource = Res.drawable.settings_24_regular),
                     contentDescription = stringResource(resource = Res.string.content_description_edit_postcode),
@@ -97,7 +94,7 @@ internal fun PostcodeInputBar(
 
         HorizontalDivider(
             modifier = Modifier.fillMaxWidth(),
-            color = MaterialTheme.colorScheme.surfaceContainerHighest,
+            color = AppTheme.colorScheme.surfaceContainerHighest,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductBottomSheetWrapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductBottomSheetWrapper.kt
@@ -25,8 +25,7 @@ import androidx.compose.material3.SheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.rwmobi.kunigami.domain.model.product.ProductDetails
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -36,19 +35,20 @@ internal fun ProductBottomSheetWrapper(
     bottomSheetState: SheetState,
     onDismissRequest: () -> Unit,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     ModalBottomSheet(
         modifier = modifier,
         containerColor = CardDefaults.cardColors().containerColor,
         onDismissRequest = onDismissRequest,
         sheetState = bottomSheetState,
     ) {
+        val productScreenLayoutModifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = AppTheme.dimens.grid_1)
+
         LazyColumn {
             productDetails?.let {
                 productScreenLayout(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = dimension.grid_1),
+                    modifier = productScreenLayoutModifier,
                     productDetails = it,
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductFacts.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductFacts.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -35,8 +34,7 @@ import androidx.compose.ui.unit.Density
 import com.rwmobi.kunigami.domain.extensions.getLocalDateString
 import com.rwmobi.kunigami.domain.model.product.ProductDetails
 import com.rwmobi.kunigami.ui.components.TagWithIcon
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.tariffs_available_from
 import kunigami.composeapp.generated.resources.tariffs_available_to
@@ -51,19 +49,17 @@ internal fun ProductFacts(
     modifier: Modifier = Modifier,
     productDetails: ProductDetails,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Column(
         modifier = modifier.padding(
-            vertical = dimension.grid_1,
-            horizontal = dimension.grid_2,
+            vertical = AppTheme.dimens.grid_1,
+            horizontal = AppTheme.dimens.grid_2,
         ),
     ) {
         Text(
             modifier = Modifier
                 .fillMaxWidth()
                 .wrapContentHeight(),
-            style = MaterialTheme.typography.headlineMedium,
+            style = AppTheme.typography.headlineMedium,
             fontWeight = FontWeight.ExtraBold,
             text = productDetails.displayName,
         )
@@ -73,18 +69,18 @@ internal fun ProductFacts(
                 modifier = Modifier
                     .fillMaxWidth()
                     .wrapContentHeight(),
-                style = MaterialTheme.typography.titleMedium,
+                style = AppTheme.typography.titleMedium,
                 text = productDetails.fullName,
             )
         }
 
         Text(
             modifier = Modifier.wrapContentSize(),
-            style = MaterialTheme.typography.labelMedium,
+            style = AppTheme.typography.labelMedium,
             text = productDetails.code,
         )
 
-        Spacer(modifier = Modifier.size(size = dimension.grid_1))
+        Spacer(modifier = Modifier.size(size = AppTheme.dimens.grid_1))
 
         val availableFromDate = productDetails.availability.start.getLocalDateString()
         val availableTo = if (productDetails.availability.endInclusive != Instant.DISTANT_FUTURE) {
@@ -95,7 +91,7 @@ internal fun ProductFacts(
 
         Text(
             modifier = Modifier.fillMaxWidth(),
-            style = MaterialTheme.typography.bodyMedium,
+            style = AppTheme.typography.bodyMedium,
             text = stringResource(
                 resource = Res.string.tariffs_available_from,
                 availableFromDate,
@@ -106,22 +102,22 @@ internal fun ProductFacts(
         productDetails.term?.let {
             Text(
                 modifier = Modifier.fillMaxWidth(),
-                style = MaterialTheme.typography.bodyMedium,
+                style = AppTheme.typography.bodyMedium,
                 text = stringResource(resource = Res.string.tariffs_fixed_term_months, it),
             )
         }
 
-        Spacer(modifier = Modifier.size(size = dimension.grid_1))
+        Spacer(modifier = Modifier.size(size = AppTheme.dimens.grid_1))
 
         if (productDetails.features.isNotEmpty()) {
             val currentDensity = LocalDensity.current
             CompositionLocalProvider(
                 LocalDensity provides Density(currentDensity.density, fontScale = 1f),
             ) {
-                FlowRow(modifier = Modifier.padding(vertical = dimension.grid_1)) {
+                FlowRow(modifier = Modifier.padding(vertical = AppTheme.dimens.grid_1)) {
                     productDetails.features.forEach {
                         TagWithIcon(
-                            modifier = Modifier.padding(end = dimension.grid_0_5),
+                            modifier = Modifier.padding(end = AppTheme.dimens.grid_0_5),
                             icon = painterResource(resource = it.iconResource),
                             text = stringResource(resource = it.stringResource),
                         )
@@ -130,11 +126,11 @@ internal fun ProductFacts(
             }
         }
 
-        Spacer(modifier = Modifier.size(size = dimension.grid_1))
+        Spacer(modifier = Modifier.size(size = AppTheme.dimens.grid_1))
 
         Text(
             modifier = Modifier.fillMaxWidth(),
-            style = MaterialTheme.typography.bodyMedium,
+            style = AppTheme.typography.bodyMedium,
             text = productDetails.description,
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductListItemAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductListItemAdaptive.kt
@@ -31,7 +31,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -44,9 +43,7 @@ import com.rwmobi.kunigami.domain.model.product.ProductFeature
 import com.rwmobi.kunigami.domain.model.product.ProductSummary
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.components.TagWithIcon
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.Dimension
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.tariffs_fixed_term_months
 import org.jetbrains.compose.resources.painterResource
@@ -77,19 +74,17 @@ private fun ProductListItemCompact(
     modifier: Modifier = Modifier,
     productSummary: ProductSummary,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Column(
         modifier = modifier.padding(
-            vertical = dimension.grid_1,
-            horizontal = dimension.grid_2,
+            vertical = AppTheme.dimens.grid_1,
+            horizontal = AppTheme.dimens.grid_2,
         ),
     ) {
         Text(
             modifier = Modifier
                 .fillMaxWidth()
                 .wrapContentHeight(),
-            style = MaterialTheme.typography.titleMedium,
+            style = AppTheme.typography.titleMedium,
             fontWeight = FontWeight.ExtraBold,
             text = productSummary.displayName,
         )
@@ -99,36 +94,35 @@ private fun ProductListItemCompact(
                 modifier = Modifier
                     .fillMaxWidth()
                     .wrapContentHeight(),
-                style = MaterialTheme.typography.titleSmall,
+                style = AppTheme.typography.titleSmall,
                 text = productSummary.fullName,
             )
         }
 
-        Spacer(modifier = Modifier.size(size = dimension.grid_1))
+        Spacer(modifier = Modifier.size(size = AppTheme.dimens.grid_1))
 
         productSummary.term?.let {
             Text(
                 modifier = Modifier.fillMaxWidth(),
-                style = MaterialTheme.typography.bodyMedium,
+                style = AppTheme.typography.bodyMedium,
                 text = stringResource(resource = Res.string.tariffs_fixed_term_months, it),
             )
 
-            Spacer(modifier = Modifier.size(size = dimension.grid_1))
+            Spacer(modifier = Modifier.size(size = AppTheme.dimens.grid_1))
         }
 
-        Spacer(modifier = Modifier.size(size = dimension.grid_1))
+        Spacer(modifier = Modifier.size(size = AppTheme.dimens.grid_1))
 
         Text(
             modifier = Modifier.fillMaxWidth(),
-            style = MaterialTheme.typography.bodyMedium,
+            style = AppTheme.typography.bodyMedium,
             text = productSummary.description,
         )
 
-        Spacer(modifier = Modifier.size(size = dimension.grid_1))
+        Spacer(modifier = Modifier.size(size = AppTheme.dimens.grid_1))
 
         if (productSummary.features.isNotEmpty()) {
             ProductFeaturesFlowRow(
-                dimension = dimension,
                 productSummary = productSummary,
             )
         }
@@ -140,16 +134,14 @@ internal fun ProductListItemWide(
     modifier: Modifier = Modifier,
     productSummary: ProductSummary,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Row(
         modifier = modifier
             .height(intrinsicSize = IntrinsicSize.Min)
             .padding(
-                vertical = dimension.grid_1,
-                horizontal = dimension.grid_2,
+                vertical = AppTheme.dimens.grid_1,
+                horizontal = AppTheme.dimens.grid_2,
             ),
-        horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_2),
+        horizontalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_2),
     ) {
         Column(
             modifier = Modifier
@@ -158,7 +150,7 @@ internal fun ProductListItemWide(
         ) {
             Text(
                 modifier = Modifier.fillMaxWidth(),
-                style = MaterialTheme.typography.titleMedium,
+                style = AppTheme.typography.titleMedium,
                 fontWeight = FontWeight.ExtraBold,
                 text = productSummary.displayName,
             )
@@ -166,21 +158,21 @@ internal fun ProductListItemWide(
             if (productSummary.fullName != productSummary.displayName) {
                 Text(
                     modifier = Modifier.fillMaxWidth(),
-                    style = MaterialTheme.typography.titleSmall,
+                    style = AppTheme.typography.titleSmall,
                     text = productSummary.fullName,
                 )
             }
 
-            Spacer(modifier = Modifier.size(size = dimension.grid_1))
+            Spacer(modifier = Modifier.size(size = AppTheme.dimens.grid_1))
 
             productSummary.term?.let {
                 Text(
                     modifier = Modifier.fillMaxWidth(),
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = AppTheme.typography.bodyMedium,
                     text = stringResource(resource = Res.string.tariffs_fixed_term_months, it),
                 )
 
-                Spacer(modifier = Modifier.size(size = dimension.grid_1))
+                Spacer(modifier = Modifier.size(size = AppTheme.dimens.grid_1))
             }
         }
 
@@ -188,17 +180,16 @@ internal fun ProductListItemWide(
             modifier = Modifier
                 .weight(weight = 2f)
                 .fillMaxHeight(),
-            verticalArrangement = Arrangement.spacedBy(dimension.grid_1),
+            verticalArrangement = Arrangement.spacedBy(AppTheme.dimens.grid_1),
         ) {
             Text(
                 modifier = Modifier.fillMaxWidth(),
-                style = MaterialTheme.typography.bodyMedium,
+                style = AppTheme.typography.bodyMedium,
                 text = productSummary.description,
             )
 
             if (productSummary.features.isNotEmpty()) {
                 ProductFeaturesFlowRow(
-                    dimension = dimension,
                     productSummary = productSummary,
                 )
             }
@@ -209,7 +200,6 @@ internal fun ProductListItemWide(
 @Composable
 private fun ProductFeaturesFlowRow(
     modifier: Modifier = Modifier,
-    dimension: Dimension,
     productSummary: ProductSummary,
 ) {
     val currentDensity = LocalDensity.current
@@ -217,13 +207,13 @@ private fun ProductFeaturesFlowRow(
         FlowRow(
             modifier = modifier
                 .fillMaxWidth()
-                .padding(vertical = dimension.grid_1),
-            verticalArrangement = Arrangement.spacedBy(space = dimension.grid_1),
+                .padding(vertical = AppTheme.dimens.grid_1),
+            verticalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_1),
             horizontalArrangement = Arrangement.End,
         ) {
             productSummary.features.forEach {
                 TagWithIcon(
-                    modifier = Modifier.padding(end = dimension.grid_0_5),
+                    modifier = Modifier.padding(end = AppTheme.dimens.grid_0_5),
                     icon = painterResource(resource = it.iconResource),
                     text = stringResource(resource = it.stringResource),
                 )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductPaneWrapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductPaneWrapper.kt
@@ -25,8 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.rwmobi.kunigami.domain.model.product.ProductDetails
 import com.rwmobi.kunigami.ui.components.ScrollbarMultiplatform
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 
 @Composable
 internal fun ProductPaneWrapper(
@@ -34,8 +33,6 @@ internal fun ProductPaneWrapper(
     productDetails: ProductDetails? = null,
     header: @Composable () -> Unit,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     val detailLazyListState = rememberLazyListState()
     ScrollbarMultiplatform(
         modifier = modifier,
@@ -44,12 +41,14 @@ internal fun ProductPaneWrapper(
         Column(modifier = contentModifier.fillMaxSize()) {
             header()
 
+            val productScreenLayoutModifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = AppTheme.dimens.grid_1)
+
             LazyColumn(state = detailLazyListState) {
                 productDetails?.let { product ->
                     productScreenLayout(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = dimension.grid_1),
+                        modifier = productScreenLayoutModifier,
                         productDetails = product,
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductScreenLayout.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductScreenLayout.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,8 +34,7 @@ import com.rwmobi.kunigami.domain.model.product.ProductFeature
 import com.rwmobi.kunigami.domain.model.product.Tariff
 import com.rwmobi.kunigami.domain.model.product.TariffPaymentTerm
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kotlin.time.Instant
 
 internal fun LazyListScope.productScreenLayout(
@@ -44,20 +42,19 @@ internal fun LazyListScope.productScreenLayout(
     productDetails: ProductDetails,
 ) {
     item(key = "productFacts") {
-        val dimension = getScreenSizeInfo().getDimension()
         Column(
-            modifier = modifier.padding(horizontal = dimension.grid_2),
+            modifier = modifier.padding(horizontal = AppTheme.dimens.grid_2),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(space = dimension.grid_2),
+            verticalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_2),
         ) {
             val blockModifier = Modifier
-                .clip(shape = MaterialTheme.shapes.large)
-                .background(MaterialTheme.colorScheme.surfaceContainer)
-                .padding(dimension.grid_1)
+                .clip(shape = AppTheme.shapes.large)
+                .background(AppTheme.colorScheme.surfaceContainer)
+                .padding(AppTheme.dimens.grid_1)
 
             Column(modifier = blockModifier) {
                 ProductFacts(
-                    modifier = Modifier.widthIn(max = dimension.windowWidthCompact),
+                    modifier = Modifier.widthIn(max = AppTheme.dimens.windowWidthCompact),
                     productDetails = productDetails,
                 )
             }
@@ -66,8 +63,8 @@ internal fun LazyListScope.productScreenLayout(
                 productDetails.electricityTariff?.let { tariffDetails ->
                     RegionTariff(
                         modifier = Modifier
-                            .widthIn(max = dimension.windowWidthCompact)
-                            .padding(all = dimension.grid_2),
+                            .widthIn(max = AppTheme.dimens.windowWidthCompact)
+                            .padding(all = AppTheme.dimens.grid_2),
                         tariff = tariffDetails,
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductTariff.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/tariffs/components/ProductTariff.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -35,9 +34,8 @@ import com.rwmobi.kunigami.domain.model.product.Tariff
 import com.rwmobi.kunigami.domain.model.product.TariffPaymentTerm
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.components.LabelValueRow
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.previewsampledata.TariffSamples
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.day_unit_rate
 import kunigami.composeapp.generated.resources.night_unit_rate
@@ -58,11 +56,9 @@ internal fun RegionTariff(
     modifier: Modifier,
     tariff: Tariff,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Column(
         modifier = modifier.wrapContentHeight(),
-        verticalArrangement = Arrangement.spacedBy(space = dimension.grid_2),
+        verticalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_2),
     ) {
         with(tariff) {
             Row(
@@ -72,14 +68,14 @@ internal fun RegionTariff(
                 val region = stringResource(resource = getRetailRegion()?.stringResource ?: Res.string.retail_region_unknown)
                 Text(
                     modifier = Modifier.weight(1f),
-                    style = MaterialTheme.typography.titleLarge,
+                    style = AppTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.secondary,
+                    color = AppTheme.colorScheme.secondary,
                     text = region,
                 )
 
                 Text(
-                    style = MaterialTheme.typography.titleSmall,
+                    style = AppTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
                     text = tariffCode,
                 )
@@ -88,7 +84,7 @@ internal fun RegionTariff(
             if (tariffPaymentTerm == TariffPaymentTerm.DIRECT_DEBIT_MONTHLY) {
                 Text(
                     modifier = Modifier.fillMaxWidth(),
-                    style = MaterialTheme.typography.titleMedium,
+                    style = AppTheme.typography.titleMedium,
                     fontStyle = FontStyle.Italic,
                     text = stringResource(resource = Res.string.tariffs_direct_debit_monthly),
                 )
@@ -96,7 +92,7 @@ internal fun RegionTariff(
 
             LabelValueRow(
                 modifier = Modifier.fillMaxWidth(),
-                style = MaterialTheme.typography.bodyMedium,
+                style = AppTheme.typography.bodyMedium,
                 label = stringResource(resource = Res.string.tariffs_exit_fees),
                 value = if (exitFeesType != ExitFeesType.NONE) {
                     stringResource(
@@ -110,7 +106,7 @@ internal fun RegionTariff(
 
             LabelValueRow(
                 modifier = Modifier.fillMaxWidth(),
-                style = MaterialTheme.typography.bodyMedium,
+                style = AppTheme.typography.bodyMedium,
                 label = stringResource(resource = Res.string.standing_charge),
                 value = stringResource(
                     resource = Res.string.unit_p_day,
@@ -121,7 +117,7 @@ internal fun RegionTariff(
             vatInclusiveStandardUnitRate?.let { unitRate ->
                 LabelValueRow(
                     modifier = Modifier.fillMaxWidth(),
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = AppTheme.typography.bodyMedium,
                     label = stringResource(resource = Res.string.standard_unit_rate),
                     value = stringResource(
                         resource = Res.string.unit_p_kwh,
@@ -133,7 +129,7 @@ internal fun RegionTariff(
             vatInclusiveDayUnitRate?.let { unitRate ->
                 LabelValueRow(
                     modifier = Modifier.fillMaxWidth(),
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = AppTheme.typography.bodyMedium,
                     label = stringResource(resource = Res.string.day_unit_rate),
                     value = stringResource(
                         resource = Res.string.unit_p_kwh,
@@ -145,7 +141,7 @@ internal fun RegionTariff(
             vatInclusiveNightUnitRate?.let { unitRate ->
                 LabelValueRow(
                     modifier = Modifier.fillMaxWidth(),
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = AppTheme.typography.bodyMedium,
                     label = stringResource(resource = Res.string.night_unit_rate),
                     value = stringResource(
                         resource = Res.string.unit_p_kwh,
@@ -157,7 +153,7 @@ internal fun RegionTariff(
             vatInclusiveOffPeakRate?.let { unitRate ->
                 LabelValueRow(
                     modifier = Modifier.fillMaxWidth(),
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = AppTheme.typography.bodyMedium,
                     label = stringResource(resource = Res.string.off_peak_rate),
                     value = stringResource(
                         resource = Res.string.unit_p_kwh,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/UsageScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -42,7 +41,6 @@ import com.rwmobi.kunigami.ui.components.MessageActionScreen
 import com.rwmobi.kunigami.ui.components.ScrollbarMultiplatform
 import com.rwmobi.kunigami.ui.components.koalaplot.VerticalBarChart
 import com.rwmobi.kunigami.ui.composehelper.conditionalBlur
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.destinations.usage.components.ConsumptionGroupCells
 import com.rwmobi.kunigami.ui.destinations.usage.components.NavigationOptionsBar
 import com.rwmobi.kunigami.ui.destinations.usage.components.RateGroupTitle
@@ -53,7 +51,7 @@ import com.rwmobi.kunigami.ui.model.chart.BarChartData
 import com.rwmobi.kunigami.ui.model.chart.RequestedChartLayout
 import com.rwmobi.kunigami.ui.model.consumption.ConsumptionGroupWithPartitions
 import com.rwmobi.kunigami.ui.model.consumption.ConsumptionQueryFilter
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.bolt
 import kunigami.composeapp.generated.resources.error_screen_no_data_description_no_auth
@@ -84,7 +82,6 @@ fun UsageScreen(
         }
     }
 
-    val dimension = getScreenSizeInfo().getDimension()
     val lazyListState = rememberLazyListState()
 
     Box(modifier = modifier) {
@@ -126,9 +123,9 @@ fun UsageScreen(
 
                         TitleNavigationBar(
                             modifier = Modifier
-                                .background(color = MaterialTheme.colorScheme.secondary)
+                                .background(color = AppTheme.colorScheme.secondary)
                                 .fillMaxWidth()
-                                .height(height = dimension.minListItemHeight),
+                                .height(height = AppTheme.dimens.minListItemHeight),
                             currentPresentationStyle = consumptionQueryFilter.presentationStyle,
                             title = consumptionQueryFilter.getConsumptionPeriodString(),
                             canNavigateBack = consumptionQueryFilter.canNavigateBackward(firstTariffStartDate = firstTariffStartDate),
@@ -164,7 +161,7 @@ fun UsageScreen(
                     ) { contentModifier ->
                         LazyColumn(
                             modifier = contentModifier.conditionalBlur(enabled = uiState.isLoading),
-                            contentPadding = PaddingValues(bottom = dimension.grid_4),
+                            contentPadding = PaddingValues(bottom = AppTheme.dimens.grid_4),
                             state = lazyListState,
                         ) {
                             if (uiState.isDemoMode == true) {
@@ -172,7 +169,7 @@ fun UsageScreen(
                                     DemoModeCtaAdaptive(
                                         modifier = Modifier
                                             .fillMaxWidth()
-                                            .padding(all = dimension.grid_2),
+                                            .padding(all = AppTheme.dimens.grid_2),
                                         description = stringResource(resource = Res.string.usage_demo_introduction),
                                         ctaButtonLabel = stringResource(resource = Res.string.provide_api_key),
                                         onCtaButtonClicked = uiEvent.onNavigateToAccountTab,
@@ -206,8 +203,8 @@ fun UsageScreen(
                                             .background(color = CardDefaults.cardColors().containerColor)
                                             .fillMaxWidth()
                                             .padding(
-                                                horizontal = dimension.grid_3,
-                                                vertical = dimension.grid_1,
+                                                horizontal = AppTheme.dimens.grid_3,
+                                                vertical = AppTheme.dimens.grid_1,
                                             ),
                                         layoutType = uiState.requestedAdaptiveLayout,
                                         tariff = uiState.tariff,
@@ -219,7 +216,7 @@ fun UsageScreen(
                                     LargeTitleWithIcon(
                                         modifier = Modifier
                                             .fillMaxWidth()
-                                            .padding(all = dimension.grid_2),
+                                            .padding(all = AppTheme.dimens.grid_2),
                                         icon = painterResource(resource = Res.drawable.bolt),
                                         label = stringResource(resource = Res.string.usage_energy_consumption_breakdown),
                                     )
@@ -267,7 +264,6 @@ private fun LazyListScope.consumptionBarChart(
 ) {
     item(key = "chart") {
         Box {
-            val dimension = getScreenSizeInfo().getDimension()
             val constraintModifier = when (uiState.requestedChartLayout) {
                 is RequestedChartLayout.Portrait -> {
                     Modifier
@@ -283,7 +279,7 @@ private fun LazyListScope.consumptionBarChart(
             }
 
             VerticalBarChart(
-                modifier = constraintModifier.padding(all = dimension.grid_2),
+                modifier = constraintModifier.padding(all = AppTheme.dimens.grid_2),
                 showToolTipOnClick = uiState.showToolTipOnClick,
                 entries = barChartData.verticalBarPlotEntries,
                 yAxisRange = uiState.consumptionRange,
@@ -307,13 +303,12 @@ private fun LazyListScope.consumptionBreakdown(
 ) {
     consumptionGroupsWithPartitions.forEach { consumptionGroupWithPartitions ->
         item(key = "${consumptionGroupWithPartitions.title}Title") {
-            val dimension = getScreenSizeInfo().getDimension()
             RateGroupTitle(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(
-                        vertical = dimension.grid_2,
-                        horizontal = dimension.grid_4,
+                        vertical = AppTheme.dimens.grid_2,
+                        horizontal = AppTheme.dimens.grid_4,
                     ),
                 consumptionGroupWithPartitions = consumptionGroupWithPartitions,
             )
@@ -321,13 +316,12 @@ private fun LazyListScope.consumptionBreakdown(
 
         val maxRows = consumptionGroupWithPartitions.partitionedItems.maxOf { it.size }
         items(maxRows) { rowIndex ->
-            val dimension = getScreenSizeInfo().getDimension()
             ConsumptionGroupCells(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(
-                        horizontal = dimension.grid_4,
-                        vertical = dimension.grid_0_25,
+                        horizontal = AppTheme.dimens.grid_4,
+                        vertical = AppTheme.dimens.grid_0_25,
                     ),
                 partitionedItems = consumptionGroupWithPartitions.partitionedItems,
                 shouldHideLastColumn = shouldHideLastConsumptionGroupColumn,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/AnimatedRatioBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/AnimatedRatioBar.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -38,6 +37,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import io.github.koalaplot.core.util.toString
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.unit_percent
@@ -48,8 +48,8 @@ internal fun AnimatedRatioBar(
     modifier: Modifier = Modifier,
     consumptionRatio: Double, // Ratio between 0.0 and 1.0
 ) {
-    val consumptionColor = MaterialTheme.colorScheme.primary
-    val standingChargeColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+    val consumptionColor = AppTheme.colorScheme.primary
+    val standingChargeColor = AppTheme.colorScheme.onSurface.copy(alpha = 0.3f)
 
     var targetRatio by remember { mutableStateOf(0f) }
     // Trigger the animation when the composable is first composed
@@ -63,7 +63,7 @@ internal fun AnimatedRatioBar(
 
     Box(
         modifier = modifier
-            .clip(shape = MaterialTheme.shapes.large)
+            .clip(shape = AppTheme.shapes.large)
             .drawBehind {
                 val consumptionWidth = size.width * animatedRatio
                 val standingChargeWidth = size.width - consumptionWidth
@@ -86,7 +86,7 @@ internal fun AnimatedRatioBar(
     ) {
         Text(
             modifier = Modifier.align(alignment = Alignment.Center),
-            style = MaterialTheme.typography.labelSmall,
+            style = AppTheme.typography.labelSmall,
             color = Color.White,
             text = stringResource(resource = Res.string.unit_percent, (animatedRatio * 100).toString(precision = 0)),
         )
@@ -98,11 +98,11 @@ internal fun AnimatedRatioBar(
 private fun Preview() {
     CommonPreviewSetup(
         modifier = Modifier.padding(all = 8.dp),
-    ) { dimension ->
+    ) {
         AnimatedRatioBar(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(dimension.grid_2),
+                .height(AppTheme.dimens.grid_2),
             consumptionRatio = 0.64,
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/ConsumptionGroupCells.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/ConsumptionGroupCells.kt
@@ -27,11 +27,10 @@ import com.rwmobi.kunigami.domain.extensions.getLocalHHMMString
 import com.rwmobi.kunigami.domain.extensions.getLocalMonthString
 import com.rwmobi.kunigami.domain.model.consumption.Consumption
 import com.rwmobi.kunigami.ui.components.IndicatorTextValueGridItem
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.composehelper.palette.RatePalette
 import com.rwmobi.kunigami.ui.composehelper.shouldUseDarkTheme
 import com.rwmobi.kunigami.ui.model.consumption.ConsumptionPresentationStyle
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import io.github.koalaplot.core.util.toString
 
 @Composable
@@ -43,10 +42,9 @@ internal fun ConsumptionGroupCells(
     consumptionRange: ClosedFloatingPointRange<Double>,
     presentationStyle: ConsumptionPresentationStyle,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     Row(
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(space = dimension.grid_3),
+        horizontalArrangement = Arrangement.spacedBy(space = AppTheme.dimens.grid_3),
     ) {
         val columnRangeToRender = if (shouldHideLastColumn) {
             0..<partitionedItems.lastIndex

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/ConsumptionTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/ConsumptionTile.kt
@@ -24,17 +24,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.consumption.Insights
 import com.rwmobi.kunigami.ui.previewsampledata.InsightsSamples
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.kwh
 import kunigami.composeapp.generated.resources.usage_insights_consumption
@@ -46,23 +44,22 @@ internal fun ConsumptionTile(
     modifier: Modifier = Modifier,
     insights: Insights,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     Column(
         modifier = modifier
-            .clip(shape = MaterialTheme.shapes.large)
-            .background(MaterialTheme.colorScheme.surfaceContainer)
-            .padding(dimension.grid_2),
+            .clip(shape = AppTheme.shapes.large)
+            .background(AppTheme.colorScheme.surfaceContainer)
+            .padding(AppTheme.dimens.grid_2),
         verticalArrangement = Arrangement.Top,
     ) {
         Text(
             modifier = Modifier.fillMaxWidth(),
-            style = MaterialTheme.typography.headlineMedium,
+            style = AppTheme.typography.headlineMedium,
             text = insights.consumptionAggregateRounded.toString(),
         )
 
         Text(
             modifier = Modifier.fillMaxWidth(),
-            style = MaterialTheme.typography.bodySmall,
+            style = AppTheme.typography.bodySmall,
             fontWeight = FontWeight.Bold,
             text = stringResource(resource = Res.string.kwh),
         )
@@ -71,9 +68,9 @@ internal fun ConsumptionTile(
 
         Text(
             modifier = Modifier.fillMaxWidth(),
-            style = MaterialTheme.typography.labelSmall,
+            style = AppTheme.typography.labelSmall,
             fontWeight = FontWeight.Normal,
-            color = MaterialTheme.colorScheme.onSurface,
+            color = AppTheme.colorScheme.onSurface,
             text = pluralStringResource(
                 resource = Res.plurals.usage_insights_consumption,
                 quantity = insights.consumptionTimeSpan,
@@ -86,11 +83,11 @@ internal fun ConsumptionTile(
 @Preview
 @Composable
 private fun Preview() {
-    CommonPreviewSetup { dimension ->
+    CommonPreviewSetup {
         ConsumptionTile(
             modifier = Modifier
-                .height(dimension.widgetHeight)
-                .width(dimension.widgetWidthHalf),
+                .height(AppTheme.dimens.widgetHeight)
+                .width(AppTheme.dimens.widgetWidthHalf),
             insights = InsightsSamples.trueCost,
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/DailyAverageTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/DailyAverageTile.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -37,10 +36,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.consumption.Insights
 import com.rwmobi.kunigami.ui.previewsampledata.InsightsSamples
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.kwh
 import kunigami.composeapp.generated.resources.unit_pound
@@ -52,42 +50,41 @@ internal fun DailyAverageTile(
     modifier: Modifier = Modifier,
     insights: Insights,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     Column(
         modifier = modifier
-            .clip(shape = MaterialTheme.shapes.large)
-            .background(MaterialTheme.colorScheme.surfaceContainer)
-            .padding(dimension.grid_2),
+            .clip(shape = AppTheme.shapes.large)
+            .background(AppTheme.colorScheme.surfaceContainer)
+            .padding(AppTheme.dimens.grid_2),
         verticalArrangement = Arrangement.Top,
     ) {
         Text(
             modifier = Modifier.wrapContentWidth(),
-            style = MaterialTheme.typography.titleLarge,
-            color = MaterialTheme.colorScheme.onSurface,
+            style = AppTheme.typography.titleLarge,
+            color = AppTheme.colorScheme.onSurface,
             text = stringResource(resource = Res.string.unit_pound, insights.costDailyAverage.roundToTwoDecimalPlaces().toString()),
         )
 
         HorizontalDivider(
             modifier = Modifier
-                .padding(vertical = dimension.grid_1)
+                .padding(vertical = AppTheme.dimens.grid_1)
                 .alpha(0.5f),
         )
 
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(dimension.grid_1),
+            horizontalArrangement = Arrangement.spacedBy(AppTheme.dimens.grid_1),
         ) {
             Text(
                 modifier = Modifier.wrapContentWidth(),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
+                style = AppTheme.typography.titleMedium,
+                color = AppTheme.colorScheme.onSurface,
                 text = insights.consumptionDailyAverage.roundToTwoDecimalPlaces().toString(),
             )
 
             Text(
                 modifier = Modifier.wrapContentWidth(),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
+                style = AppTheme.typography.bodyMedium,
+                color = AppTheme.colorScheme.onSurface,
                 text = stringResource(resource = Res.string.kwh),
             )
         }
@@ -97,7 +94,7 @@ internal fun DailyAverageTile(
         Text(
             modifier = Modifier.fillMaxWidth(),
             text = stringResource(resource = Res.string.usage_estimated_daily),
-            style = MaterialTheme.typography.labelSmall,
+            style = AppTheme.typography.labelSmall,
             fontWeight = FontWeight.Normal,
         )
     }
@@ -106,10 +103,10 @@ internal fun DailyAverageTile(
 @Preview
 @Composable
 private fun Preview() {
-    CommonPreviewSetup { dimension ->
+    CommonPreviewSetup {
         DailyAverageTile(
-            modifier = Modifier.height(dimension.widgetHeight)
-                .width(dimension.widgetWidthHalf),
+            modifier = Modifier.height(AppTheme.dimens.widgetHeight)
+                .width(AppTheme.dimens.widgetWidthHalf),
             insights = InsightsSamples.trueCost,
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/InsightsTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/InsightsTile.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -33,10 +32,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextAlign
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.consumption.Insights
 import com.rwmobi.kunigami.ui.previewsampledata.InsightsSamples
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.standing_charge
 import kunigami.composeapp.generated.resources.unit_pound
@@ -50,18 +48,16 @@ internal fun InsightsTile(
     modifier: Modifier = Modifier,
     insights: Insights,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     Column(
         modifier = modifier
-            .clip(shape = MaterialTheme.shapes.large)
-            .background(MaterialTheme.colorScheme.surfaceContainer)
-            .padding(dimension.grid_2),
+            .clip(shape = AppTheme.shapes.large)
+            .background(AppTheme.colorScheme.surfaceContainer)
+            .padding(AppTheme.dimens.grid_2),
         verticalArrangement = Arrangement.Top,
     ) {
         Text(
-            style = MaterialTheme.typography.headlineMedium,
-            color = MaterialTheme.colorScheme.onSurface,
+            style = AppTheme.typography.headlineMedium,
+            color = AppTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
             text = stringResource(
                 resource = Res.string.unit_pound,
@@ -76,8 +72,8 @@ internal fun InsightsTile(
         }
 
         Text(
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface,
+            style = AppTheme.typography.titleMedium,
+            color = AppTheme.colorScheme.onSurface,
             textAlign = TextAlign.Left,
             text = costLabel,
         )
@@ -94,12 +90,12 @@ internal fun InsightsTile(
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             Text(
-                style = MaterialTheme.typography.labelSmall,
+                style = AppTheme.typography.labelSmall,
                 text = stringResource(resource = Res.string.usage_consumption),
             )
-            Spacer(modifier = Modifier.width(dimension.grid_1))
+            Spacer(modifier = Modifier.width(AppTheme.dimens.grid_1))
             Text(
-                style = MaterialTheme.typography.labelSmall,
+                style = AppTheme.typography.labelSmall,
                 text = stringResource(resource = Res.string.standing_charge),
             )
         }
@@ -109,11 +105,11 @@ internal fun InsightsTile(
 @Preview
 @Composable
 private fun Preview() {
-    CommonPreviewSetup { dimension ->
+    CommonPreviewSetup {
         InsightsTile(
             modifier = Modifier
-                .width(dimension.widgetWidthFull)
-                .height(dimension.widgetHeight),
+                .width(AppTheme.dimens.widgetWidthFull)
+                .height(AppTheme.dimens.widgetHeight),
             insights = InsightsSamples.trueCost,
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/NavigationOptionsBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/NavigationOptionsBar.kt
@@ -27,14 +27,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.dashboard
 import kunigami.composeapp.generated.resources.skip_forward
@@ -48,26 +46,25 @@ internal fun NavigationOptionsBar(
     selectedMpan: String?,
     onNavigateToLatest: () -> Unit,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     Column(modifier = modifier) {
         Row(
             modifier = Modifier
-                .background(color = MaterialTheme.colorScheme.surfaceContainerLow)
+                .background(color = AppTheme.colorScheme.surfaceContainerLow)
                 .fillMaxWidth()
-                .height(height = dimension.minListItemHeight),
+                .height(height = AppTheme.dimens.minListItemHeight),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             selectedMpan?.let { mpan ->
                 Icon(
                     modifier = Modifier
-                        .size(size = dimension.grid_4)
-                        .padding(start = dimension.grid_2),
+                        .size(size = AppTheme.dimens.grid_4)
+                        .padding(start = AppTheme.dimens.grid_2),
                     painter = painterResource(resource = Res.drawable.dashboard),
                     contentDescription = null,
                 )
                 Text(
-                    modifier = Modifier.padding(start = dimension.grid_1),
-                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(start = AppTheme.dimens.grid_1),
+                    style = AppTheme.typography.bodyMedium,
                     text = mpan,
                 )
             }
@@ -75,13 +72,13 @@ internal fun NavigationOptionsBar(
             Spacer(modifier = Modifier.weight(1f))
 
             IconButton(
-                modifier = Modifier.size(size = dimension.imageButtonSize),
+                modifier = Modifier.size(size = AppTheme.dimens.imageButtonSize),
                 onClick = onNavigateToLatest,
             ) {
                 Icon(
                     modifier = Modifier.padding(
-                        horizontal = dimension.grid_1,
-                        vertical = dimension.grid_0_5,
+                        horizontal = AppTheme.dimens.grid_1,
+                        vertical = AppTheme.dimens.grid_0_5,
                     ),
                     painter = painterResource(resource = Res.drawable.skip_forward),
                     contentDescription = stringResource(resource = Res.string.usage_latest),
@@ -91,7 +88,7 @@ internal fun NavigationOptionsBar(
 
         HorizontalDivider(
             modifier = Modifier.fillMaxWidth(),
-            color = MaterialTheme.colorScheme.surfaceContainerHighest,
+            color = AppTheme.colorScheme.surfaceContainerHighest,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/PresentationStyleDropdownMenu.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/PresentationStyleDropdownMenu.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -31,9 +30,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.consumption.ConsumptionPresentationStyle
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.circle_check
 import kunigami.composeapp.generated.resources.selected
@@ -49,12 +47,10 @@ internal fun PresentationStyleDropdownMenu(
     onDismiss: () -> Unit,
     onSwitchPresentationStyle: (consumptionPresentationStyle: ConsumptionPresentationStyle) -> Unit,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
-
     DropdownMenu(
         modifier = modifier,
         expanded = expanded,
-        offset = DpOffset(0.dp, dimension.grid_1),
+        offset = DpOffset(0.dp, AppTheme.dimens.grid_1),
         onDismissRequest = { onDismiss() },
     ) {
         ConsumptionPresentationStyle.entries.forEach { presentationStyle ->
@@ -62,13 +58,13 @@ internal fun PresentationStyleDropdownMenu(
                 modifier = Modifier,
                 enabled = currentPresentationStyle != presentationStyle,
                 colors = MenuDefaults.itemColors().copy(
-                    textColor = MaterialTheme.colorScheme.onSurface,
+                    textColor = AppTheme.colorScheme.onSurface,
                 ),
                 contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                 trailingIcon = {
                     if (currentPresentationStyle == presentationStyle) {
                         Icon(
-                            modifier = Modifier.size(size = dimension.grid_3),
+                            modifier = Modifier.size(size = AppTheme.dimens.grid_3),
                             painter = painterResource(resource = Res.drawable.circle_check),
                             contentDescription = stringResource(resource = Res.string.selected),
                         )
@@ -77,7 +73,7 @@ internal fun PresentationStyleDropdownMenu(
                 onClick = { onSwitchPresentationStyle(presentationStyle) },
                 text = {
                     Text(
-                        style = MaterialTheme.typography.bodyLarge,
+                        style = AppTheme.typography.bodyLarge,
                         text = stringResource(resource = presentationStyle.stringResource),
                     )
                 },

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/ProjectedConsumptionTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/ProjectedConsumptionTile.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -37,10 +36,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.consumption.Insights
 import com.rwmobi.kunigami.ui.previewsampledata.InsightsSamples
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.kwh
 import kunigami.composeapp.generated.resources.usage_kwh_month
@@ -53,12 +51,11 @@ internal fun ProjectedConsumptionTile(
     modifier: Modifier = Modifier,
     insights: Insights,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     Column(
         modifier = modifier
-            .clip(shape = MaterialTheme.shapes.large)
-            .background(MaterialTheme.colorScheme.surfaceContainer)
-            .padding(dimension.grid_2),
+            .clip(shape = AppTheme.shapes.large)
+            .background(AppTheme.colorScheme.surfaceContainer)
+            .padding(AppTheme.dimens.grid_2),
         verticalArrangement = Arrangement.Top,
     ) {
         UsageBlock(
@@ -68,7 +65,7 @@ internal fun ProjectedConsumptionTile(
 
         HorizontalDivider(
             modifier = Modifier
-                .padding(vertical = dimension.grid_1)
+                .padding(vertical = AppTheme.dimens.grid_1)
                 .alpha(0.5f),
         )
 
@@ -82,7 +79,7 @@ internal fun ProjectedConsumptionTile(
         Text(
             modifier = Modifier.fillMaxWidth(),
             text = stringResource(resource = Res.string.usage_projected_consumption),
-            style = MaterialTheme.typography.labelSmall,
+            style = AppTheme.typography.labelSmall,
             fontWeight = FontWeight.Normal,
         )
     }
@@ -93,30 +90,29 @@ private fun UsageBlock(
     usage: String,
     period: String,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(dimension.grid_1),
+        horizontalArrangement = Arrangement.spacedBy(AppTheme.dimens.grid_1),
     ) {
         Text(
             modifier = Modifier.wrapContentWidth(),
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface,
+            style = AppTheme.typography.titleMedium,
+            color = AppTheme.colorScheme.onSurface,
             text = usage,
         )
 
         Text(
             modifier = Modifier.wrapContentWidth(),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
+            style = AppTheme.typography.bodyMedium,
+            color = AppTheme.colorScheme.onSurface,
             text = stringResource(resource = Res.string.kwh),
         )
     }
 
     Text(
         modifier = Modifier.fillMaxWidth(),
-        style = MaterialTheme.typography.labelMedium,
-        color = MaterialTheme.colorScheme.onSurface.copy(
+        style = AppTheme.typography.labelMedium,
+        color = AppTheme.colorScheme.onSurface.copy(
             alpha = 0.5f,
         ),
         text = period,
@@ -126,10 +122,10 @@ private fun UsageBlock(
 @Preview
 @Composable
 private fun Preview() {
-    CommonPreviewSetup { dimension ->
+    CommonPreviewSetup {
         ProjectedConsumptionTile(
-            modifier = Modifier.height(dimension.widgetHeight)
-                .width(dimension.widgetWidthHalf),
+            modifier = Modifier.height(AppTheme.dimens.widgetHeight)
+                .width(AppTheme.dimens.widgetWidthHalf),
             insights = InsightsSamples.trueCost,
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/RateGroupTitle.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/RateGroupTitle.kt
@@ -17,7 +17,6 @@ package com.rwmobi.kunigami.ui.destinations.usage.components
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -25,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import com.rwmobi.kunigami.domain.extensions.roundToTwoDecimalPlaces
 import com.rwmobi.kunigami.ui.model.consumption.ConsumptionGroupWithPartitions
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.unit_kwh
 import org.jetbrains.compose.resources.stringResource
@@ -40,14 +40,14 @@ internal fun RateGroupTitle(
     ) {
         Text(
             modifier = Modifier.weight(1f),
-            style = MaterialTheme.typography.titleMedium,
+            style = AppTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
             text = consumptionGroupWithPartitions.title,
         )
 
         Text(
             modifier = Modifier.wrapContentSize(),
-            style = MaterialTheme.typography.titleMedium,
+            style = AppTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
             text = stringResource(
                 resource = Res.string.unit_kwh,

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TariffProjectionTilesAdaptive.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TariffProjectionTilesAdaptive.kt
@@ -33,11 +33,10 @@ import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.domain.model.product.Tariff
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
 import com.rwmobi.kunigami.ui.components.TariffSummaryTile
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.consumption.Insights
 import com.rwmobi.kunigami.ui.previewsampledata.InsightsSamples
 import com.rwmobi.kunigami.ui.previewsampledata.TariffSamples
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 
 @Composable
 internal fun TariffProjectionTilesAdaptive(
@@ -73,15 +72,14 @@ private fun TariffProjectionsTileFLinear(
     tariff: Tariff?,
     insights: Insights?,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     Column(
         modifier = modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(dimension.grid_1),
+        verticalArrangement = Arrangement.spacedBy(AppTheme.dimens.grid_1),
     ) {
         val fullWidthModifier = Modifier
             .fillMaxWidth()
-            .height(dimension.widgetHeight)
+            .height(AppTheme.dimens.widgetHeight)
 
         tariff?.let {
             TariffSummaryTile(
@@ -97,11 +95,11 @@ private fun TariffProjectionsTileFLinear(
             )
 
             Row(
-                horizontalArrangement = Arrangement.spacedBy(dimension.grid_1),
+                horizontalArrangement = Arrangement.spacedBy(AppTheme.dimens.grid_1),
             ) {
                 val halfWidthModifier = Modifier
                     .weight(1f)
-                    .height(dimension.widgetHeight)
+                    .height(AppTheme.dimens.widgetHeight)
 
                 if (insights.consumptionTimeSpan > 1) {
                     ConsumptionTile(
@@ -143,21 +141,20 @@ private fun TariffProjectionsTileFlowRow(
     tariff: Tariff?,
     insights: Insights?,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     val halfWidthModifier = Modifier
-        .width(dimension.widgetWidthHalf)
-        .height(dimension.widgetHeight)
-        .padding(horizontal = dimension.grid_0_5)
+        .width(AppTheme.dimens.widgetWidthHalf)
+        .height(AppTheme.dimens.widgetHeight)
+        .padding(horizontal = AppTheme.dimens.grid_0_5)
 
     val fullWidthModifier = Modifier
-        .width(dimension.widgetWidthFull)
-        .height(dimension.widgetHeight)
-        .padding(horizontal = dimension.grid_0_5)
+        .width(AppTheme.dimens.widgetWidthFull)
+        .height(AppTheme.dimens.widgetHeight)
+        .padding(horizontal = AppTheme.dimens.grid_0_5)
 
     FlowRow(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.Center,
-        verticalArrangement = Arrangement.spacedBy(dimension.grid_1),
+        verticalArrangement = Arrangement.spacedBy(AppTheme.dimens.grid_1),
     ) {
         tariff?.let {
             TariffSummaryTile(

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TitleNavigationBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/destinations/usage/components/TitleNavigationBar.kt
@@ -30,7 +30,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -43,9 +42,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.rwmobi.kunigami.ui.components.CommonPreviewSetup
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.model.consumption.ConsumptionPresentationStyle
-import com.rwmobi.kunigami.ui.theme.getDimension
+import com.rwmobi.kunigami.ui.theme.AppTheme
 import kunigami.composeapp.generated.resources.Res
 import kunigami.composeapp.generated.resources.chevron_left_circle
 import kunigami.composeapp.generated.resources.chevron_right_circle
@@ -64,7 +62,6 @@ internal fun TitleNavigationBar(
     onNavigateForward: () -> Unit,
     onSwitchPresentationStyle: (consumptionPresentationStyle: ConsumptionPresentationStyle) -> Unit,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     var presentationStyleDropdownMenuExpanded by remember { mutableStateOf(false) }
 
     Surface {
@@ -74,7 +71,7 @@ internal fun TitleNavigationBar(
         ) {
             Box(
                 modifier = Modifier
-                    .size(size = dimension.minTouchTarget)
+                    .size(size = AppTheme.dimens.minTouchTarget)
                     .clickable(
                         enabled = canNavigateBack,
                         onClick = onNavigateBack,
@@ -83,8 +80,8 @@ internal fun TitleNavigationBar(
             ) {
                 if (canNavigateBack) {
                     Icon(
-                        modifier = Modifier.padding(all = dimension.grid_1),
-                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.padding(all = AppTheme.dimens.grid_1),
+                        tint = AppTheme.colorScheme.onSecondaryContainer,
                         painter = painterResource(resource = Res.drawable.chevron_left_circle),
                         contentDescription = stringResource(resource = Res.string.content_description_previous_period),
                     )
@@ -93,13 +90,13 @@ internal fun TitleNavigationBar(
 
             BoxWithConstraints(
                 modifier = Modifier
-                    .padding(vertical = dimension.grid_1)
+                    .padding(vertical = AppTheme.dimens.grid_1)
                     .weight(weight = 1f),
             ) {
                 Button(
                     modifier = Modifier.fillMaxSize(),
                     colors = ButtonDefaults.buttonColors().copy(
-                        containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(
+                        containerColor = AppTheme.colorScheme.secondaryContainer.copy(
                             alpha = 0.32f,
                         ),
                     ),
@@ -108,8 +105,8 @@ internal fun TitleNavigationBar(
                     Text(
                         modifier = Modifier.fillMaxWidth(),
                         textAlign = TextAlign.Center,
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        style = AppTheme.typography.titleMedium,
+                        color = AppTheme.colorScheme.onSecondaryContainer,
                         text = title,
                     )
                 }
@@ -117,7 +114,7 @@ internal fun TitleNavigationBar(
                 PresentationStyleDropdownMenu(
                     modifier = Modifier
                         .width(width = maxWidth)
-                        .background(color = MaterialTheme.colorScheme.surface),
+                        .background(color = AppTheme.colorScheme.surface),
                     currentPresentationStyle = currentPresentationStyle,
                     expanded = presentationStyleDropdownMenuExpanded,
                     onDismiss = { presentationStyleDropdownMenuExpanded = false },
@@ -130,7 +127,7 @@ internal fun TitleNavigationBar(
 
             Box(
                 modifier = Modifier
-                    .size(size = dimension.minTouchTarget)
+                    .size(size = AppTheme.dimens.minTouchTarget)
                     .clickable(
                         enabled = canNavigateForward,
                         onClick = onNavigateForward,
@@ -139,8 +136,8 @@ internal fun TitleNavigationBar(
             ) {
                 if (canNavigateForward) {
                     Icon(
-                        modifier = Modifier.padding(all = dimension.grid_1),
-                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.padding(all = AppTheme.dimens.grid_1),
+                        tint = AppTheme.colorScheme.onSecondaryContainer,
                         painter = painterResource(resource = Res.drawable.chevron_right_circle),
                         contentDescription = stringResource(resource = Res.string.content_description_previous_period),
                     )
@@ -156,7 +153,7 @@ private fun Preview() {
     CommonPreviewSetup {
         TitleNavigationBar(
             modifier = Modifier
-                .background(color = MaterialTheme.colorScheme.secondary)
+                .background(color = AppTheme.colorScheme.secondary)
                 .fillMaxWidth()
                 .height(height = 64.dp),
             title = "Sample title",

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/Dimension.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/Dimension.kt
@@ -15,10 +15,8 @@
 
 package com.rwmobi.kunigami.ui.theme
 
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.rwmobi.kunigami.ui.model.ScreenSizeInfo
 
 /**
  * Source: https://proandroiddev.com/supporting-different-screen-sizes-on-android-with-jetpack-compose-f215c13081bd
@@ -87,6 +85,3 @@ val sw360Dimension = Dimension(
     grid_5_5 = 44.dp,
     grid_6 = 48.dp,
 )
-
-@Composable
-fun ScreenSizeInfo.getDimension(): Dimension = if (widthDp <= 360.dp) smallDimension else sw360Dimension

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/Theme.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/kunigami/ui/theme/Theme.kt
@@ -15,11 +15,18 @@
 
 package com.rwmobi.kunigami.ui.theme
 
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Shapes
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.dp
+import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.composehelper.shouldUseDarkTheme
 
 private val mediumContrastLightColorScheme = lightColorScheme(
@@ -106,14 +113,65 @@ fun AppTheme(
 ) {
     val shouldUseDarkTheme = useDarkTheme ?: shouldUseDarkTheme()
     val colorScheme = if (shouldUseDarkTheme) mediumContrastDarkColorScheme else mediumContrastLightColorScheme
+    val screenSizeInfo = getScreenSizeInfo()
+    val dimensions = if (screenSizeInfo.widthDp <= 360.dp) smallDimension else sw360Dimension
 
     androidStatusBarSideEffect?.let {
         it(colorScheme.secondary.toArgb(), shouldUseDarkTheme)
     }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = AppTypography(),
-        content = content,
-    )
+    ProvideDimens(dimensions = dimensions) {
+        ProvideColorScheme(colorScheme = colorScheme) {
+            MaterialTheme(
+                colorScheme = colorScheme,
+                typography = AppTypography(),
+                content = content,
+            )
+        }
+    }
+}
+
+private val LocalAppColorScheme = staticCompositionLocalOf {
+    mediumContrastLightColorScheme
+}
+
+@Composable
+fun ProvideColorScheme(
+    colorScheme: ColorScheme,
+    content: @Composable () -> Unit,
+) {
+    val colorPalette = remember { colorScheme }
+    CompositionLocalProvider(LocalAppColorScheme provides colorPalette, content = content)
+}
+
+private val LocalAppDimens = staticCompositionLocalOf {
+    smallDimension
+}
+
+@Composable
+fun ProvideDimens(
+    dimensions: Dimension,
+    content: @Composable () -> Unit,
+) {
+    val dimensionSet = remember { dimensions }
+    CompositionLocalProvider(LocalAppDimens provides dimensionSet, content = content)
+}
+
+object AppTheme {
+    val colorScheme: ColorScheme
+        @Composable
+        get() = LocalAppColorScheme.current
+
+    val dimens: Dimension
+        @Composable
+        get() = LocalAppDimens.current
+
+    val typography: androidx.compose.material3.Typography
+        @Composable
+        get() = AppTypography()
+
+    // We have not customised shapes yet, so we use the default
+    val shapes: Shapes
+        @Composable
+        get() = MaterialTheme.shapes
 }

--- a/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/components/ScrollbarMultiplatform.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/rwmobi/kunigami/ui/components/ScrollbarMultiplatform.desktop.kt
@@ -34,7 +34,6 @@ import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.foundation.v2.ScrollbarAdapter
 import androidx.compose.foundation.v2.maxScrollOffset
 import androidx.compose.material.Text
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -45,9 +44,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
-import com.rwmobi.kunigami.ui.composehelper.getScreenSizeInfo
 import com.rwmobi.kunigami.ui.theme.AppTheme
-import com.rwmobi.kunigami.ui.theme.getDimension
 import kotlinx.coroutines.delay
 
 @Composable
@@ -102,15 +99,15 @@ private fun ScrollbarMultiplatform(
     scrollbarAdapter: ScrollbarAdapter,
     content: @Composable (contentModifier: Modifier) -> Unit,
 ) {
-    val dimension = getScreenSizeInfo().getDimension()
     val density = LocalDensity.current
 
     var isScrollbarVisible by remember { mutableStateOf(false) }
 
     // Debounce mechanism to stabilize the scrollbar visibility state
+    val dimensGrid3 = AppTheme.dimens.grid_3
     LaunchedEffect(scrollbarAdapter.maxScrollOffset) {
         with(density) {
-            if (scrollbarAdapter.maxScrollOffset > dimension.grid_3.roundToPx()) {
+            if (scrollbarAdapter.maxScrollOffset > dimensGrid3.roundToPx()) {
                 isScrollbarVisible = true
             } else {
                 delay(1000) // Adjust the delay as needed
@@ -131,24 +128,24 @@ private fun ScrollbarMultiplatform(
                 VerticalDivider(
                     modifier = Modifier.fillMaxHeight(),
                     thickness = 1.dp,
-                    color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    color = AppTheme.colorScheme.surfaceContainerHighest,
                 )
 
                 VerticalScrollbar(
                     adapter = scrollbarAdapter,
                     style = LocalScrollbarStyle.current.copy(
-                        thickness = dimension.grid_1,
-                        unhoverColor = MaterialTheme.colorScheme.outlineVariant.copy(
+                        thickness = AppTheme.dimens.grid_1,
+                        unhoverColor = AppTheme.colorScheme.outlineVariant.copy(
                             alpha = 0.5f,
                         ),
-                        hoverColor = MaterialTheme.colorScheme.outline.copy(
+                        hoverColor = AppTheme.colorScheme.outline.copy(
                             alpha = 0.5f,
                         ),
                     ),
                     modifier = Modifier
                         .fillMaxHeight()
-                        .background(color = MaterialTheme.colorScheme.surface)
-                        .padding(horizontal = dimension.grid_0_5),
+                        .background(color = AppTheme.colorScheme.surface)
+                        .padding(horizontal = AppTheme.dimens.grid_0_5),
                 )
             }
         }


### PR DESCRIPTION
colorScheme and dimensions are set to be dynamic, while typography and shapes are static.

Now previews don't have to rely on dimension object 