### PR TITLE
[chore] Renovate: add material3/firebase package groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,6 +45,13 @@
       "matchPackageNames": [
         "/org.jetbrains.compose.*/"
       ]
+    },
+    {
+      "groupName": "material3",
+      "matchPackageNames": [
+        "androidx.compose.material3:material3",
+        "androidx.compose.material3:material3-adaptive-navigation-suite"
+      ]
     }
   ],
   "automerge": true,


### PR DESCRIPTION
## Summary

Follow-up to the recently merged Renovate serial-queue PR.

That PR correctly added `pinDigests` and `prConcurrentLimit` but the material3/firebase group detection checked `renovate.json` rather than the actual dependency files — so the groups were silently omitted.

- **`material3` group** *(where applicable)* — bundles `material3` + `material3-adaptive-navigation-suite`, which always release together.
- **`firebase` group** *(where applicable)* — bundles `firebase-bom` + `firebase-crashlytics` plugin, consistently 0–1 days apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)